### PR TITLE
resource inference formalisation and proofs

### DIFF
--- a/cn-coq.opam
+++ b/cn-coq.opam
@@ -15,7 +15,7 @@ homepage: "https://rems-project.github.io/cn-tutorial"
 bug-reports: "https://github.com/rems-project/cn/issues"
 depends: [
   "cn"
-  "coq" {>= "8.18.0"}
+  "coq" {>= "8.19.1"}
   "coq-ext-lib"
   "coq-struct-tact"
 ]

--- a/coq/Cerberus/Utils.v
+++ b/coq/Cerberus/Utils.v
@@ -4,7 +4,6 @@ Require Import Coq.Classes.DecidableClass.
 Require Import Coq.Floats.PrimFloat.
 Require Import Coq.Numbers.BinNums.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.Vectors.Vector.
 Require Import Coq.Strings.Ascii.
 
 Require Import StructTact.StructTactics.

--- a/coq/Cn/BaseTypes.v
+++ b/coq/Cn/BaseTypes.v
@@ -114,7 +114,7 @@ Proof.
     + constructor; auto.
   - (* TSet *)
     apply HTSet; apply IH.
-Qed.
+Defined.
 
 
 Definition member_types_gen (A:Type) := list (Id.t * t_gen A).
@@ -136,7 +136,7 @@ Definition t := t_gen unit.
 Fact sign_eq_dec (s1 s2 : sign) : {s1 = s2} + {s1 <> s2}.
 Proof.
   decide equality.
-Qed.
+Defined.
 
 (* TODO Check if needed *)
 Lemma prod_eq_dec {A B : Type}
@@ -145,7 +145,7 @@ Lemma prod_eq_dec {A B : Type}
       forall (p1 p2 : A * B), {p1 = p2} + {p1 <> p2}.
 Proof.
   decide equality.
-Qed.
+Defined.
 
 Lemma option_eq_dec {A : Type}
       (eqA : forall x y : A, {x = y} + {x <> y}) :
@@ -307,7 +307,7 @@ Module BasetTypes_t_as_MiniDecidableType <: MiniDecidableType.
         intros C.
         inversion C.
         congruence.
-  Qed.
+  Defined.
   
 End BasetTypes_t_as_MiniDecidableType.
 

--- a/coq/Cn/BaseTypes.v
+++ b/coq/Cn/BaseTypes.v
@@ -187,7 +187,6 @@ Module BasetTypes_t_as_MiniDecidableType <: MiniDecidableType.
       + left; reflexivity.
       + right. intros H. inversion H. congruence.
     -
-      (* TODO: this is not provavle with current induction principle! *)
       clear x.
       revert l0.
       induction X;intros.

--- a/coq/Cn/CN.v
+++ b/coq/Cn/CN.v
@@ -215,5 +215,5 @@ Inductive cn_error : Type :=
   | CNErr_duplicate_field : Symbol.identifier -> cn_error.
 
 (* Typing error *)
-Inductive cn_typing_error : Type :=
+Inductive cn_typing_error : Prop :=
   | CNErr_typing_TODO : cn_typing_error. 

--- a/coq/Cn/CNImpl.v
+++ b/coq/Cn/CNImpl.v
@@ -12,7 +12,8 @@ From Cerberus Require Import Implementation IntegerType Ctype Symbol.
 
 Local Open Scope nat_scope.
 
-Module CNImpl : Implementation.
+(* This is an instance of the Implementation module matching the implementation used in OCaml *)
+Module CNImpl <: Implementation.
 
   Definition is_signed_ity_impl ity :=
     match ity with
@@ -116,10 +117,10 @@ Module CNImpl : Implementation.
   Definition typeof_enum_impl (_:Symbol.sym)
              := Signed Int_.
 
-  Program Definition get :=
+  Definition get :=
     {|
       name            := "clang11_aarch64-unknown-freebsd13";
-      details         := "clang version 11.0.0\nTarget: Morello";
+      details         := "clang version 11.0.0";
       sizeof_pointer  := 8;
       alignof_pointer := 8;
       is_signed_ity   := is_signed_ity_impl;

--- a/coq/Cn/ErrorCommon.v
+++ b/coq/Cn/ErrorCommon.v
@@ -1,8 +1,9 @@
 Require Import Coq.Strings.String.
 
+From Cerberus Require Import Annot.
 Require Import Sym.
 
-Definition label_kind := unit. (* TODO: placeholder *)
+Definition label_kind := Annot.label_annot.
 
 (* Corresponds to OCaml type access *)
 Inductive access : Type :=

--- a/coq/Cn/False.v
+++ b/coq/Cn/False.v
@@ -1,7 +1,7 @@
 (* Define the False type *)
 
 (* TODO not sure if this is the good name. Maybe retname to TFalse later *)
-Inductive False_t : Type :=
+Inductive False_t : Prop :=
   | False. 
 
 Definition t := False_t.

--- a/coq/Cn/Locations.v
+++ b/coq/Cn/Locations.v
@@ -15,7 +15,7 @@ Module Locations_t_as_MiniDecidableType <: MiniDecidableType.
     intros x y.
     unfold eq.
     repeat decide equality.
-  Qed.
+  Defined.
 End Locations_t_as_MiniDecidableType.
 
 (* Define the info type *)

--- a/coq/Cn/LogicalConstraints.v
+++ b/coq/Cn/LogicalConstraints.v
@@ -30,7 +30,7 @@ Module LogicalConstraint_as_MiniDecidableType <: MiniDecidableType.
         apply BasetTypes_t_as_MiniDecidableType.eq_dec.
       +
         apply Sym_t_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End LogicalConstraint_as_MiniDecidableType.
 
 Module LogicalConstraints_as_DecidableType := Make_UDT LogicalConstraint_as_MiniDecidableType.

--- a/coq/Cn/Prooflog.v
+++ b/coq/Cn/Prooflog.v
@@ -17,15 +17,19 @@ Definition unfold_changed := list (Resource.t*unpack_result).
 Definition extract_changed := list Resource.t.
 Definition unfold_step := (unfold_changed*extract_changed)%type.
 
-Inductive resource_inference_type : Type :=
-  | PredicateRequest : ErrorCommon.situation ->
-                       Request.Predicate.t ->
-                       (Resource.predicate * list Z) ->
-                       resource_inference_type
-  | UnfoldResources: Location.t -> list unfold_step -> resource_inference_type.
-
 Inductive log_entry : Type :=
-  | ResourceInferenceStep : Context.t -> resource_inference_type -> Context.t -> log_entry.
+  | PredicateRequest : Context.t ->
+                       ErrorCommon.situation ->
+                       Request.Predicate.t ->
+                       Resource.predicate ->
+                       list log_entry ->
+                       Context.t ->
+                       log_entry
+  | UnfoldResources: Context.t ->
+                     Location.t ->
+                     list unfold_step ->
+                     Context.t ->
+                     log_entry.
 
 Definition log : Type := list log_entry.
 

--- a/coq/Cn/Prooflog.v
+++ b/coq/Cn/Prooflog.v
@@ -20,7 +20,6 @@ Definition unfold_step := (unfold_changed*extract_changed)%type.
 Inductive resource_inference_type : Type :=
   | PredicateRequest : ErrorCommon.situation ->
                        Request.Predicate.t ->
-                       option (Location.t * string) ->
                        (Resource.predicate * list Z) ->
                        resource_inference_type
   | UnfoldResources: Location.t -> list unfold_step -> resource_inference_type.

--- a/coq/Cn/Prooflog.v
+++ b/coq/Cn/Prooflog.v
@@ -9,13 +9,21 @@ Require Import Request.
 Require Import Resource.
 Require Import Context.
 
+Inductive unpack_result : Type :=
+  | UnpackLRT : LogicalReturnTypes.t -> unpack_result
+  | UnpackRES : list Resource.t -> unpack_result.
+
+Definition unfold_changed := list (Z*Resource.t*unpack_result).
+Definition extract_changed := list Resource.t.
+Definition unfold_step := (unfold_changed*extract_changed)%type.
+
 Inductive resource_inference_type : Type :=
   | PredicateRequest : ErrorCommon.situation ->
                        Request.Predicate.t ->
                        option (Location.t * string) ->
                        (Resource.predicate * list Z) ->
                        resource_inference_type
-  | UnfoldResources: Location.t -> resource_inference_type.
+  | UnfoldResources: Location.t -> list unfold_step -> resource_inference_type.
 
 Inductive log_entry : Type :=
   | ResourceInferenceStep : Context.t -> resource_inference_type -> Context.t -> log_entry.

--- a/coq/Cn/Prooflog.v
+++ b/coq/Cn/Prooflog.v
@@ -13,7 +13,7 @@ Inductive unpack_result : Type :=
   | UnpackLRT : LogicalReturnTypes.t -> unpack_result
   | UnpackRES : list Resource.t -> unpack_result.
 
-Definition unfold_changed := list (Z*Resource.t*unpack_result).
+Definition unfold_changed := list (Resource.t*unpack_result).
 Definition extract_changed := list Resource.t.
 Definition unfold_step := (unfold_changed*extract_changed)%type.
 

--- a/coq/Cn/Request.v
+++ b/coq/Cn/Request.v
@@ -102,7 +102,7 @@ Module QPredicate_as_MiniDecidableType <: MiniDecidableType.
     - apply List.list_eq_dec.
       apply IndexTerm_as_MiniDecidableType.eq_dec.
     - apply IndexTerm_as_MiniDecidableType.eq_dec.
-    - apply IndexTerm_as_MiniDecidableType.eq_dec.
+    - apply SCtypes_as_MiniDecidableType.eq_dec.
     - apply Locations_t_as_MiniDecidableType.eq_dec.
     - apply BaseTypes.prod_eq_dec.
       + apply Sym_t_as_MiniDecidableType.eq_dec.

--- a/coq/Cn/Request.v
+++ b/coq/Cn/Request.v
@@ -58,7 +58,7 @@ Module Init_as_MiniDecidableType <: MiniDecidableType.
   Proof.
     unfold eq.
     decide equality. 
-  Qed.
+  Defined.
 End Init_as_MiniDecidableType.
 
 Module Name_as_MiniDecidableType <: MiniDecidableType.
@@ -72,7 +72,7 @@ Module Name_as_MiniDecidableType <: MiniDecidableType.
     all: try apply SCtypes_as_MiniDecidableType.eq_dec.
     all: try apply Init_as_MiniDecidableType.eq_dec.
     all: try apply Sym_t_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End Name_as_MiniDecidableType.
 
 Module Predicate_as_MiniDecidableType <: MiniDecidableType.
@@ -87,7 +87,7 @@ Module Predicate_as_MiniDecidableType <: MiniDecidableType.
       apply IndexTerm_as_MiniDecidableType.eq_dec.
     - apply IndexTerm_as_MiniDecidableType.eq_dec.
     - apply Name_as_MiniDecidableType.eq_dec.
-  Qed. 
+  Defined. 
 End Predicate_as_MiniDecidableType.
 
 Module QPredicate_as_MiniDecidableType <: MiniDecidableType.
@@ -109,7 +109,7 @@ Module QPredicate_as_MiniDecidableType <: MiniDecidableType.
       + apply BasetTypes_t_as_MiniDecidableType.eq_dec.
     - apply IndexTerm_as_MiniDecidableType.eq_dec.
     - apply Name_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End QPredicate_as_MiniDecidableType.
 
 Module Request_as_MiniDecidableType <: MiniDecidableType.
@@ -122,5 +122,5 @@ Module Request_as_MiniDecidableType <: MiniDecidableType.
     all: decide equality.
     all: try apply Predicate_as_MiniDecidableType.eq_dec.
     all: try apply QPredicate_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End Request_as_MiniDecidableType.

--- a/coq/Cn/Resource.v
+++ b/coq/Cn/Resource.v
@@ -23,7 +23,7 @@ Module Output_as_MiniDecidableType <: MiniDecidableType.
     intros [o1] [o2].
     decide equality.
     apply IndexTerm_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End Output_as_MiniDecidableType.
 
 Module Resource_as_MiniDecidableType <: MiniDecidableType.
@@ -35,7 +35,7 @@ Module Resource_as_MiniDecidableType <: MiniDecidableType.
     apply BaseTypes.prod_eq_dec.
     - apply Request_as_MiniDecidableType.eq_dec.
     - apply Output_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End Resource_as_MiniDecidableType.
 
 Module Output_as_DecidableType := Make_UDT Output_as_MiniDecidableType.

--- a/coq/Cn/Resource.v
+++ b/coq/Cn/Resource.v
@@ -44,13 +44,10 @@ Module ResSet := FSetWeakList.Make Resource_as_DecidableType.
 Module ResSetDecide := FSetDecide.WDecide(ResSet).
 
 Definition set_from_list (l : list t) : ResSet.t :=
-  List.fold_left (fun s c => ResSet.add c s) l ResSet.empty.
-
-Definition set_from_list_r (l : list t) : ResSet.t :=
   List.fold_right (fun c s => ResSet.add c s) ResSet.empty l.
 
-Lemma ResSet_In_List_In_eq_r: forall r rs,
-  ResSet.In r (Resource.set_from_list_r rs) <-> List.In r rs.
+Lemma ResSet_In_List_In_eq: forall r rs,
+  ResSet.In r (Resource.set_from_list rs) <-> List.In r rs.
 Proof.
   intros r rs.
   induction rs.
@@ -65,29 +62,4 @@ Proof.
     destruct H as [H | H].
     + left; apply H.
     + right; apply IHrs, H.
-Qed.
-
-Lemma set_from_list_r_eq: forall l,
-  ResSet.Equal (set_from_list l) (set_from_list_r l).
-Proof.
-  intros l.
-  unfold set_from_list, set_from_list_r.
-  rewrite <- fold_left_rev_right.
-  unfold ResSet.Equal.
-  intros a; split; intros H.
-  - apply ResSet_In_List_In_eq_r in H.
-    apply ResSet_In_List_In_eq_r, in_rev, H.
-  - apply ResSet_In_List_In_eq_r, in_rev in H.
-    apply ResSet_In_List_In_eq_r, H.
-Qed.
-
-Lemma ResSet_In_List_In_eq: forall r rs,
-  ResSet.In r (Resource.set_from_list rs) <-> List.In r rs.
-Proof.
-  intros r rs.
-  split; intros H.
-  - apply set_from_list_r_eq in H.
-    apply ResSet_In_List_In_eq_r, H.
-  - apply set_from_list_r_eq.
-    apply ResSet_In_List_In_eq_r, H.
 Qed.

--- a/coq/Cn/Resource.v
+++ b/coq/Cn/Resource.v
@@ -45,3 +45,49 @@ Module ResSetDecide := FSetDecide.WDecide(ResSet).
 
 Definition set_from_list (l : list t) : ResSet.t :=
   List.fold_left (fun s c => ResSet.add c s) l ResSet.empty.
+
+Definition set_from_list_r (l : list t) : ResSet.t :=
+  List.fold_right (fun c s => ResSet.add c s) ResSet.empty l.
+
+Lemma ResSet_In_List_In_eq_r: forall r rs,
+  ResSet.In r (Resource.set_from_list_r rs) <-> List.In r rs.
+Proof.
+  intros r rs.
+  induction rs.
+  { split; intros H; inversion H. }
+  cbn.
+  split; intros H.
+  - apply ResSetDecide.F.add_iff in H.
+    destruct H as [H | H].
+    + left; apply H.
+    + right; apply IHrs, H.
+  - apply ResSetDecide.F.add_iff.
+    destruct H as [H | H].
+    + left; apply H.
+    + right; apply IHrs, H.
+Qed.
+
+Lemma set_from_list_r_eq: forall l,
+  ResSet.Equal (set_from_list l) (set_from_list_r l).
+Proof.
+  intros l.
+  unfold set_from_list, set_from_list_r.
+  rewrite <- fold_left_rev_right.
+  unfold ResSet.Equal.
+  intros a; split; intros H.
+  - apply ResSet_In_List_In_eq_r in H.
+    apply ResSet_In_List_In_eq_r, in_rev, H.
+  - apply ResSet_In_List_In_eq_r, in_rev in H.
+    apply ResSet_In_List_In_eq_r, H.
+Qed.
+
+Lemma ResSet_In_List_In_eq: forall r rs,
+  ResSet.In r (Resource.set_from_list rs) <-> List.In r rs.
+Proof.
+  intros r rs.
+  split; intros H.
+  - apply set_from_list_r_eq in H.
+    apply ResSet_In_List_In_eq_r, H.
+  - apply set_from_list_r_eq.
+    apply ResSet_In_List_In_eq_r, H.
+Qed.

--- a/coq/Cn/SCtypes.v
+++ b/coq/Cn/SCtypes.v
@@ -50,7 +50,7 @@ Proof.
       induction l as [| [c' b'] l IHl].
       * constructor.
       * constructor; auto.
-Qed.
+Defined.
 
 Definition t := ctype.
 
@@ -81,7 +81,7 @@ Module IntegerBaseType_as_MiniDecidableType <: MiniDecidableType.
     all: try (left; reflexivity).
     all: decide equality.
     all: apply Nat_as_DT.eq_dec.
-  Qed.
+  Defined.
 End IntegerBaseType_as_MiniDecidableType.
 
 Module IntegerType_as_MiniDecidableType <: MiniDecidableType.
@@ -97,7 +97,7 @@ Module IntegerType_as_MiniDecidableType <: MiniDecidableType.
     all: decide equality.
     all: try apply IntegerBaseType_as_MiniDecidableType.eq_dec.
     all: try apply Sym_t_as_MiniDecidableType.eq_dec.
-  Qed.
+  Defined.
 End IntegerType_as_MiniDecidableType.
 
 Module qualifiers_as_MiniDecidableType <: MiniDecidableType.
@@ -109,7 +109,7 @@ Module qualifiers_as_MiniDecidableType <: MiniDecidableType.
     intros x y.
     destruct x, y.
     do 2 decide equality.
-  Qed.
+  Defined.
 End qualifiers_as_MiniDecidableType.
 
 Module SCtypes_as_MiniDecidableType <: MiniDecidableType.
@@ -166,5 +166,5 @@ Module SCtypes_as_MiniDecidableType <: MiniDecidableType.
         destruct (IHl l') as [E | NE]; try (right; congruence).
         inversion E; subst.
         left; reflexivity.
-  Qed.
+  Defined.
 End SCtypes_as_MiniDecidableType.

--- a/coq/Cn/Sym.v
+++ b/coq/Cn/Sym.v
@@ -434,7 +434,7 @@ Module Symbol_identifier_as_MiniDecidableType <: MiniDecidableType.
   Proof.
     unfold eq.
     repeat decide equality.
-  Qed.
+  Defined.
 End Symbol_identifier_as_MiniDecidableType.
 
 Module Sym_t_as_MiniDecidableType <: MiniDecidableType.
@@ -444,7 +444,7 @@ Module Sym_t_as_MiniDecidableType <: MiniDecidableType.
   Proof.
     unfold eq.
     repeat decide equality.
-  Qed.
+  Defined.
 End Sym_t_as_MiniDecidableType.
 
 Module SymMap := FMapAVL.Make(Symbol_sym_as_OT).

--- a/coq/Cn/Terms.v
+++ b/coq/Cn/Terms.v
@@ -350,7 +350,7 @@ Proof.
   - clear - HCast HIT IH.
     destruct a.
     apply HCast; apply HIT, IH.
-Qed.
+Defined.
 
 Module Const_as_MiniDecidableType <: MiniDecidableType.
   Definition t := const.
@@ -387,7 +387,7 @@ Module Const_as_MiniDecidableType <: MiniDecidableType.
       inversion E; subst; left; reflexivity.
     - destruct (BasetTypes_t_as_MiniDecidableType.eq_dec t0 t1) as [E | NE]; try (right; congruence).
       inversion E; subst; left; reflexivity.
-  Qed.
+  Defined.
 End Const_as_MiniDecidableType.
 
 Module Unop_as_MiniDecidableType <: MiniDecidableType.
@@ -397,7 +397,7 @@ Module Unop_as_MiniDecidableType <: MiniDecidableType.
   Proof.
     unfold eq.
     decide equality.
-  Qed.
+  Defined.
 End Unop_as_MiniDecidableType.
 
 Module Binop_as_MiniDecidableType <: MiniDecidableType.
@@ -407,7 +407,7 @@ Module Binop_as_MiniDecidableType <: MiniDecidableType.
   Proof.
     unfold eq.
     decide equality.
-  Qed.
+  Defined.
 End Binop_as_MiniDecidableType.
 
 Module Pattern__as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableType) <: MiniDecidableType.
@@ -448,7 +448,7 @@ Module Pattern__as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableTyp
       destruct (Ty_as_MiniDecidableType.eq_dec tt t) as [E | ?]; try (right; congruence); subst.
       destruct (IHp p0); try (right; congruence); subst.
       left; reflexivity.
-  Qed.
+  Defined.
 
   Definition t := pattern_ ty.
   Definition eq := @eq t.
@@ -467,7 +467,7 @@ Module Pattern_as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableType
     destruct (Ty_as_MiniDecidableType.eq_dec tt1 tt2); try (right; congruence); subst.
     destruct (Locations_t_as_MiniDecidableType.eq_dec lc1 lc2) as [E | NE]; try (right; congruence).
     inversion E; subst; left; reflexivity.
-  Qed.
+  Defined.
 End Pattern_as_MiniDecidableType.
 
 Module Term_as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableType) <: MiniDecidableType.
@@ -783,7 +783,7 @@ Module Term_as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableType) <
       inversion E; subst; clear E.
       destruct (IHt t0); try (right; congruence); subst.
       left; reflexivity.
-  Qed.
+  Defined.
 
   Definition t := term ty.
   Definition eq := @eq t.
@@ -802,5 +802,5 @@ Module Annot_as_MiniDecidableType (Ty_as_MiniDecidableType : MiniDecidableType) 
     destruct (Ty_as_MiniDecidableType.eq_dec tt1 tt2); try (right; congruence); subst.
     destruct (Locations_t_as_MiniDecidableType.eq_dec lc1 lc2) as [E | NE]; try (right; congruence).
     inversion E; subst; left; reflexivity.
-  Qed.
+  Defined.
 End Annot_as_MiniDecidableType.

--- a/coq/Reasoning/Ltac2Utils.v
+++ b/coq/Reasoning/Ltac2Utils.v
@@ -131,3 +131,22 @@ Ltac2 const_to_const_reference  (x:constr) :=
  | _ => Control.throw (Tactic_failure (Some (Message.of_string "Term is not a constant")))
  end.
 
+(* given list of `constr`s and decidable equlity pose equality proof for each pair *)
+Ltac2 rec pairwise_decidability (eq_dec : constr) (lst : constr list) : unit :=
+  let rec pairwise_decidability_aux (x : constr) (lst : constr list) : unit :=
+    match lst with
+    | [] => ()
+    | y :: ys =>
+      let h := Fresh.in_goal @H in
+      Std.remember false (Some h) (fun _ => constr:($eq_dec $x $y)) None { on_hyps := None; on_concl := AllOccurrences };
+      ltac1:(h |- destruct h as [h | h]; try inversion h) (Ltac1.of_ident h);
+      pairwise_decidability_aux x ys
+    end 
+  in
+  match lst with
+  | [] => ()
+  | x :: xs =>
+    pairwise_decidability_aux x xs;
+    pairwise_decidability eq_dec xs
+  end.
+

--- a/coq/Reasoning/Ltac2Utils.v
+++ b/coq/Reasoning/Ltac2Utils.v
@@ -105,29 +105,29 @@ end.
  @return A tuple (a, b) containing the first and second component of the pair.
  @raise An exception if parameter is not a fully applied pair
  *)
- Ltac2 destruct_pair (t : constr) :=
- match Constr.Unsafe.kind t with
- | Constr.Unsafe.App f args =>
-     let pair_constr := constr:(@pair) in
-     let pair_constr_name := get_constructor_name pair_constr in
-     let f_name := get_constructor_name f in
-     if Constr.equal f_name pair_constr_name then
-       if Int.equal (Array.length args) 4 then
-         let a := Array.get args 2 in
-         let b := Array.get args 3 in
-         (a, b)
-       else
-         Control.throw (Tactic_failure (Some (Message.of_string "Term is not a fully applied pair")))
-     else
-       Control.throw (Tactic_failure (Some (Message.of_string "Term is not a pair")))
- | _ =>
-     Control.throw (Tactic_failure (Some (Message.of_string "Term is not an application (and thus not a pair)")))
- end.
+Ltac2 destruct_pair (t : constr) :=
+  match Constr.Unsafe.kind t with
+  | Constr.Unsafe.App f args =>
+    let pair_constr := constr:(@pair) in
+    let pair_constr_name := get_constructor_name pair_constr in
+    let f_name := get_constructor_name f in
+    if Constr.equal f_name pair_constr_name then
+      if Int.equal (Array.length args) 4 then
+        let a := Array.get args 2 in
+        let b := Array.get args 3 in
+        (a, b)
+      else
+        Control.throw (Tactic_failure (Some (Message.of_string "Term is not a fully applied pair")))
+    else
+      Control.throw (Tactic_failure (Some (Message.of_string "Term is not a pair")))
+  | _ =>
+    Control.throw (Tactic_failure (Some (Message.of_string "Term is not an application (and thus not a pair)")))
+  end.
  
  (* Ident to constant reference *)
- Ltac2 const_to_const_reference  (x:constr) :=  
-  match Constr.Unsafe.kind x with
-  | Constr.Unsafe.Constant c _ => Std.ConstRef c
-  | _ => Control.throw (Tactic_failure (Some (Message.of_string "Term is not a constant")))
-  end.
+Ltac2 const_to_const_reference  (x:constr) :=  
+ match Constr.Unsafe.kind x with
+ | Constr.Unsafe.Constant c _ => Std.ConstRef c
+ | _ => Control.throw (Tactic_failure (Some (Message.of_string "Term is not a constant")))
+ end.
 

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -157,7 +157,7 @@ Ltac2 prove_unfold_step () :=
         Predicate.name := Request.Owned (SCtypes.Array _) _;
         Predicate.pointer := _; Predicate.iargs := _ 
       |}
-      _ _) _) ] =>
+      _) _) ] =>
         Message.print (msg (Message.of_string "Arrays are not supported yet"));
         Std.constructor_n false 2 NoBindings (* apply array_resource_inference_step *)
   | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ 
@@ -165,7 +165,7 @@ Ltac2 prove_unfold_step () :=
         Predicate.name := Request.Owned (SCtypes.Struct ?isym) _;
         Predicate.pointer := _; Predicate.iargs := _ 
       |}
-      _ _) _) ] =>
+      _) _) ] =>
        (* PredicateRequest case *)
        verbose_msg (smsg "Checking PredicateRequest for Struct");
        verbose_print_constr "    Predicate symbol name: " isym;
@@ -192,7 +192,7 @@ Ltac2 prove_unfold_step () :=
           } clause ;
           prove_struct_resource_inference_step ()
        )
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ ?p _ _) _) ] =>
+  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ ?p _) _) ] =>
        (* PredicateRequest case *)
        verbose_msg (smsg "Checking PredicateRequest for non-struct");
        verbose_print_constr "    Predicate: " p;

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -91,6 +91,7 @@ Qed.
    | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_simple_resource_inference_step: match failed")))
    end.
 
+
 (* [struct_resource_inference_step constructor] proof *)
  Ltac2 prove_struct_resource_inference_step () :=
  match! goal with
@@ -124,10 +125,11 @@ Qed.
       let global_map :=List.fold_left (fun m (k, v) => FMap.add k v m) empty_map lic_pairs in
       *)
       Control.shelve ()
-     );  (* unfold predicte *)
-     Control.focus 1 1 (Control.shelve);  (* TODO: prove pointer address and arguments equality (via provable) *)
-     verbose_print "TODO: verify the rest of of `struct_resource_inference_step` premises";
-     Control.shelve ()
+     );  (* unfold predicate *)
+     Control.focus 1 1 (fun () =>
+      pairwise_decidability (constr:(Resource_as_MiniDecidableType.eq_dec)) in_res_list ;
+      ltac1:(cbn;ResSetDecide.fsetdec)
+     )
  | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_struct_resource_inference_step: match failed")))
 end.
 

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -152,20 +152,20 @@ Ltac2 prove_unfold_step () :=
  let smsg s := Message.concat (Message.concat (Message.of_string "Step #") (Message.of_int n)) (Message.concat (Message.of_string ": ") (Message.of_string s)) in
  let msg m := Message.concat (Message.concat (Message.of_string "Step #") (Message.of_int n)) (Message.concat (Message.of_string ": ") m) in
  match! goal with
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ 
+  | [ |- log_entry_valid (PredicateRequest _ _ 
       {| 
         Predicate.name := Request.Owned (SCtypes.Array _) _;
         Predicate.pointer := _; Predicate.iargs := _ 
       |}
-      _) _) ] =>
+      _ _ _) ] =>
         Message.print (msg (Message.of_string "Arrays are not supported yet"));
         Std.constructor_n false 2 NoBindings (* apply array_resource_inference_step *)
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest ?s
+  | [ |- log_entry_valid (PredicateRequest _ ?s
       {| 
         Predicate.name := Request.Owned (SCtypes.Struct ?isym) _;
         Predicate.pointer := _; Predicate.iargs := _ 
       |}
-      _) _) ] =>
+      _ _ _) ] =>
        (* PredicateRequest case *)
        verbose_msg (smsg "Checking PredicateRequest for Struct");
        verbose_print_constr "    Situation: " s;
@@ -193,9 +193,9 @@ Ltac2 prove_unfold_step () :=
           } clause ;
           prove_struct_resource_inference_step ()
        )
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest ?s ?p _) _) ] =>
+  | [ |- log_entry_valid (PredicateRequest _ ?s ?p _ _ _)] =>
        (* PredicateRequest case *)
-       verbose_msg (smsg "Checking PredicateRequest for non-struct");
+       verbose_msg (smsg "Checking PredicateRequest for non-Struct");
        verbose_print_constr "    Situation: " s;
        verbose_print_constr "    Predicate: " p;
        Std.constructor false; (* apply simple_resource_inference_step*)
@@ -221,7 +221,7 @@ Ltac2 prove_unfold_step () :=
            } clause ;
            prove_simple_resource_inference_step ()
        )
-  | [ |- log_entry_valid (ResourceInferenceStep _ (UnfoldResources _ _) _) ] =>
+  | [ |- log_entry_valid (UnfoldResources _ _ _ _) ] =>
       (* UnfoldResources case *)
       verbose_msg (smsg "Checking UnfoldResources");
       Std.constructor false;

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -96,7 +96,7 @@ Qed.
  Ltac2 prove_struct_resource_inference_step () :=
  match! goal with
  | [ |- exists field_res,
-        resource_unfold _ _ field_res /\
+        resource_unfold_full _ _ field_res /\
         ResSet.Equal (set_from_list ?out_res) (ResSet.diff (set_from_list ?in_res) field_res) ] =>
 
    (* now try to compute field_res from in_res and out_res *)
@@ -173,7 +173,7 @@ Ltac2 prove_unfold_step () :=
        verbose_print_constr "    Situation: " s;
        verbose_print_constr "    Predicate symbol name: " isym;
        let lhints := destruct_list (constr:(log_entry)) hints in
-       verbose_msg (Message.concat (Message.of_string "    Humber of hits: ") (Message.of_int (List.length lhints)));
+       verbose_msg (Message.concat (Message.of_string "    Number of hits: ") (Message.of_int (List.length lhints)));
        Std.constructor_n false 3 NoBindings; (* apply struct_resource_inference_step *)
        Control.focus 1 1 (fun () => Std.reflexivity ());
        Control.focus 1 1 (fun () => Std.reflexivity ());

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -122,7 +122,7 @@ Qed.
  | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_struct_resource_inference_step: match failed")))
 end.
 
-Ltac2 prove_unfold_step _hints :=
+Ltac2 prove_unfold_step (hints:constr) :=
   match! goal with
   | [ |- unfold_step _ _ ] =>
       Std.constructor false;
@@ -131,9 +131,12 @@ Ltac2 prove_unfold_step _hints :=
       Control.focus 1 1 (fun () => Std.reflexivity ());
       Control.focus 1 1 (fun () => Std.reflexivity ());
 
-      Message.print (Message.of_string "TODO: Shelving unfold step pre-condition.");
       (* Proof using computational reflection: *)
-      Control.shelve ()
+      ltac1:(hints |- apply unfold_all_explicit_eq with (unfold_changed := (unfold_step_flatten hints))) 
+        (Ltac1.of_constr hints);
+      ltac1:(apply unfold_all_explicit_fun_eq);
+      ltac1:(vm_compute);
+      ltac1:(reflexivity)
   | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_unfold_step: match failed")))
   end.
 

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -113,12 +113,15 @@ Qed.
    if List.is_empty diff then
     Control.throw (Tactic_failure (Some (Message.of_string "No resource change between the input and output")))
    else
-     match Ident.of_string "diff" with
+     match Ident.of_string "rdiff" with
      | Some diffident =>
       let diffname := Fresh.in_goal diffident in
       Std.remember false (Some diffname) (fun () => 
         recons_list (constr:(Resource.t)) diff
       ) None clause;
+      let diff_set := constr:(set_from_list &rdiff) in
+      verbose_print_constr "    diff_set: " diff_set;
+      exists $diff_set;
       verbose_print "TODO: verify the rest of of `struct_resource_inference_step` premises";
       Control.shelve ()
    | None =>

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -66,7 +66,7 @@ Qed.
      match diff with
      | [res] =>
          (* single resource [res] matched, extract request as [req] *)
-         let (req,out') := destruct_pair res in
+         let (req,_) := destruct_pair res in
          let p := predicate_of_request req in
          exists $p;
          Std.split false NoBindings;
@@ -96,7 +96,7 @@ Qed.
  Ltac2 prove_struct_resource_inference_step () :=
  match! goal with
  | [ |- exists field_res,
-        resource_unfold ?iglobal ?res field_res /\
+        resource_unfold _ _ field_res /\
         ResSet.Equal (set_from_list ?out_res) (ResSet.diff (set_from_list ?in_res) field_res) ] =>
 
    (* now try to compute field_res from in_res and out_res *)
@@ -136,7 +136,7 @@ end.
 
 Ltac2 prove_unfold_step () :=
   match! goal with
-  | [ |- unfold_step ?c ?c' ] =>
+  | [ |- unfold_step _ _ ] =>
       Std.constructor false;
       Control.focus 1 1 (fun () => Std.reflexivity ());
       Control.focus 1 1 (fun () => Std.reflexivity ());
@@ -154,16 +154,16 @@ Ltac2 prove_unfold_step () :=
  match! goal with
   | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ 
       {| 
-        Predicate.name := Request.Owned (SCtypes.Array ?p) ?iinit;
-        Predicate.pointer := ?ipointer; Predicate.iargs := ?iargs 
+        Predicate.name := Request.Owned (SCtypes.Array _) _;
+        Predicate.pointer := _; Predicate.iargs := _ 
       |}
       _ _) _) ] =>
         Message.print (msg (Message.of_string "Arrays are not supported yet"));
         Std.constructor_n false 2 NoBindings (* apply array_resource_inference_step *)
   | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ 
       {| 
-        Predicate.name := Request.Owned (SCtypes.Struct ?isym) ?iinit;
-        Predicate.pointer := ?ipointer; Predicate.iargs := ?iargs 
+        Predicate.name := Request.Owned (SCtypes.Struct ?isym) _;
+        Predicate.pointer := _; Predicate.iargs := _ 
       |}
       _ _) _) ] =>
        (* PredicateRequest case *)
@@ -244,7 +244,7 @@ Ltac2 prove_unfold_step () :=
                Std.constructor false
              else if Constr.equal f_name cons_name then
                (* cons case *)
-               let head := Array.get args 1 in
+               (* let head := Array.get args 1 in *)
                let tail := Array.get args 2 in
                Std.constructor false;
                Control.focus 1 1 (fun () => prove_log_entry_valid n);

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -96,7 +96,7 @@ Qed.
  Ltac2 prove_struct_resource_inference_step () :=
  match! goal with
  | [ |- exists field_res,
-        resource_unfold_full _ _ field_res /\
+        unfold_all _ _ field_res /\
         ResSet.Equal (set_from_list ?out_res) (ResSet.diff (set_from_list ?in_res) field_res) ] =>
 
    (* now try to compute field_res from in_res and out_res *)

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -1,4 +1,4 @@
-From Ltac2 Require Import Ltac1 Ltac2 Notations Std Constr Env Ident.
+From Ltac2 Require Import Ltac1 Ltac2 Notations Std Constr Env Ident FSet FMap.
  
 From Cn Require Import Prooflog Request Resource Context.
 Require Import Ltac2Utils ResourceInference.
@@ -111,7 +111,18 @@ Qed.
      exists $field_res_set;
      Std.split false NoBindings;
      Control.focus 1 1 (fun () =>
+      (* WIP:
       let s_decls := constr:($iglobal.(Global.struct_decls)) in
+      let empty_map:((int, constr) FMap.t) := FMap.empty (Tags.int_tag) in
+      let lc := destruct_list (constr:(Sym.t * Memory.struct_decls)) s_decls in
+      let lcc_pairs := List.map destruct_pair lc in 
+      *)
+      (* Now lc_pars have elements of constr:(Sym.t) * constr:Memory.struct_decls) type,
+         For stroring in FMap, we need to convert first element to int.
+       *)
+      (*
+      let global_map :=List.fold_left (fun m (k, v) => FMap.add k v m) empty_map lic_pairs in
+      *)
       Control.shelve ()
      );  (* unfold predicte *)
      Control.focus 1 1 (Control.shelve);  (* TODO: prove pointer address and arguments equality (via provable) *)
@@ -119,6 +130,7 @@ Qed.
      Control.shelve ()
  | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_struct_resource_inference_step: match failed")))
 end.
+
 
 Ltac2 prove_unfold_step () :=
   match! goal with
@@ -174,7 +186,7 @@ Ltac2 prove_unfold_step () :=
             rCofix := true;
             rZeta := true;
             rDelta := true;
-            rConst := [const_to_const_reference  constr:(@set_from_list)]
+            rConst := [const_to_const_reference constr:(@set_from_list); const_to_const_reference constr:(@Sym.map_from_list)]
           } clause ;
           prove_struct_resource_inference_step ()
        )

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -133,8 +133,7 @@ Qed.
  | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "prove_struct_resource_inference_step: match failed")))
 end.
 
-
-Ltac2 prove_unfold_step () :=
+Ltac2 prove_unfold_step _hints :=
   match! goal with
   | [ |- unfold_step _ _ ] =>
       Std.constructor false;
@@ -173,7 +172,7 @@ Ltac2 prove_unfold_step () :=
        verbose_print_constr "    Situation: " s;
        verbose_print_constr "    Predicate symbol name: " isym;
        let lhints := destruct_list (constr:(log_entry)) hints in
-       verbose_msg (Message.concat (Message.of_string "    Number of hits: ") (Message.of_int (List.length lhints)));
+       verbose_msg (Message.concat (Message.of_string "    Number of hints: ") (Message.of_int (List.length lhints)));
        Std.constructor_n false 3 NoBindings; (* apply struct_resource_inference_step *)
        Control.focus 1 1 (fun () => Std.reflexivity ());
        Control.focus 1 1 (fun () => Std.reflexivity ());
@@ -226,11 +225,13 @@ Ltac2 prove_unfold_step () :=
            } clause ;
            prove_simple_resource_inference_step ()
        )
-  | [ |- log_entry_valid (UnfoldResources _ _ _ _) ] =>
+  | [ |- log_entry_valid (UnfoldResources _ _ ?hints _) ] =>
       (* UnfoldResources case *)
       verbose_msg (smsg "Checking UnfoldResources");
+      let lhints := destruct_list (constr:(log_entry)) hints in
+      verbose_msg (Message.concat (Message.of_string "    Number of hints: ") (Message.of_int (List.length lhints)));
       Std.constructor false;
-      prove_unfold_step ()
+      prove_unfold_step hints
   | [ |- _ ] => 
       Control.throw (Tactic_failure (Some (msg (Message.of_string "prove_log_entry_valid: match failed"))))
   end.

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -219,7 +219,7 @@ Ltac2 prove_unfold_step () :=
            } clause ;
            prove_simple_resource_inference_step ()
        )
-  | [ |- log_entry_valid (ResourceInferenceStep _ (UnfoldResources _) _) ] =>
+  | [ |- log_entry_valid (ResourceInferenceStep _ (UnfoldResources _ _) _) ] =>
       (* UnfoldResources case *)
       verbose_msg (smsg "Checking UnfoldResources");
       Std.constructor false;

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -113,20 +113,11 @@ Qed.
    if List.is_empty diff then
     Control.throw (Tactic_failure (Some (Message.of_string "No resource change between the input and output")))
    else
-     match Ident.of_string "rdiff" with
-     | Some diffident =>
-      let diffname := Fresh.in_goal diffident in
-      Std.remember false (Some diffname) (fun () => 
-        recons_list (constr:(Resource.t)) diff
-      ) None clause;
-      let diff_set := constr:(set_from_list &rdiff) in
-      verbose_print_constr "    diff_set: " diff_set;
-      exists $diff_set;
-      verbose_print "TODO: verify the rest of of `struct_resource_inference_step` premises";
-      Control.shelve ()
-   | None =>
-    Control.throw (Tactic_failure (Some (Message.of_string "res_set_remove_many_steps: identifier generation failed")))
-   end
+     let cdiff := recons_list (constr:(Resource.t)) diff in
+     let diff_set := constr:(set_from_list $cdiff) in
+     exists $diff_set;
+     verbose_print "TODO: verify the rest of of `struct_resource_inference_step` premises";
+     Control.shelve ()
  | [ |- _ ] => Control.throw (Tactic_failure (Some (Message.of_string "res_set_remove_many_steps: match failed")))
 end.
 

--- a/coq/Reasoning/ProofAutomation.v
+++ b/coq/Reasoning/ProofAutomation.v
@@ -160,7 +160,7 @@ Ltac2 prove_unfold_step () :=
       _) _) ] =>
         Message.print (msg (Message.of_string "Arrays are not supported yet"));
         Std.constructor_n false 2 NoBindings (* apply array_resource_inference_step *)
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ 
+  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest ?s
       {| 
         Predicate.name := Request.Owned (SCtypes.Struct ?isym) _;
         Predicate.pointer := _; Predicate.iargs := _ 
@@ -168,6 +168,7 @@ Ltac2 prove_unfold_step () :=
       _) _) ] =>
        (* PredicateRequest case *)
        verbose_msg (smsg "Checking PredicateRequest for Struct");
+       verbose_print_constr "    Situation: " s;
        verbose_print_constr "    Predicate symbol name: " isym;
        Std.constructor_n false 3 NoBindings; (* apply struct_resource_inference_step *)
        Control.focus 1 1 (fun () => Std.reflexivity ());
@@ -192,9 +193,10 @@ Ltac2 prove_unfold_step () :=
           } clause ;
           prove_struct_resource_inference_step ()
        )
-  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest _ ?p _) _) ] =>
+  | [ |- log_entry_valid (ResourceInferenceStep _ (PredicateRequest ?s ?p _) _) ] =>
        (* PredicateRequest case *)
        verbose_msg (smsg "Checking PredicateRequest for non-struct");
+       verbose_print_constr "    Situation: " s;
        verbose_print_constr "    Predicate: " p;
        Std.constructor false; (* apply simple_resource_inference_step*)
        Control.focus 1 1 (fun () => Std.reflexivity ());

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -86,6 +86,66 @@ Fixpoint bt_of_sct_fun (sct : SCtypes.t) (bt : BaseTypes.t): bool :=
   | _ => false
   end.
 
+Lemma eq_dec_refl_l {A : Type} (x : A) (eq_dec : forall x y : A, {x = y} + {x <> y}) :
+  bool_of_sum (eq_dec x x) = true.
+Proof.
+  destruct (eq_dec x x) as [H | H]; auto.
+Qed.
+
+Lemma eq_dec_refl_r {A : Type} (x y : A) (eq_dec : forall x y : A, {x = y} + {x <> y}) :
+  bool_of_sum (eq_dec x y) = true -> x = y.
+Proof.
+  destruct (eq_dec x y) as [H | H]; auto.
+  intros ?; discriminate.
+Qed.
+
+Lemma bt_of_sct_rel_fun_eq: forall sct bt,
+  bt_of_sct_rel sct bt <-> bt_of_sct_fun sct bt = true.
+Proof.
+  intros sct bt.
+  split; intros H.
+  - induction H; try reflexivity.
+    + unfold bt_of_sct_fun.
+      apply eq_dec_refl_l.
+    + simpl.
+      rewrite IHbt_of_sct_rel.
+      reflexivity.
+    + simpl.
+      apply eq_dec_refl_l.
+  - revert bt H.
+    apply SCtypes.ctype_ind_set with (P := fun sct => forall bt : BaseTypes.t, bt_of_sct_fun sct bt = true -> bt_of_sct_rel sct bt).
+    + intros bt H.
+      destruct bt; try discriminate.
+      constructor.
+    + intros i bt H.
+      destruct bt; try discriminate.
+      unfold bt_of_sct_fun in H.
+      destruct BasetTypes_t_as_MiniDecidableType.eq_dec as [E | ?]; try discriminate.
+      rewrite E.
+      constructor.
+    + intros [sct' o] IH bt H.
+      destruct o; try discriminate.
+      destruct bt; try discriminate.
+      simpl in IH, H.
+      destruct (bt_of_sct_fun sct' bt2) eqn:H'; try discriminate.
+      destruct BasetTypes_t_as_MiniDecidableType.eq_dec as [E | ?]; try discriminate.
+      clear H.
+      rewrite E.
+      constructor.
+      apply IH, H'.
+    + intros sct' IH bt H.
+      destruct bt; try discriminate.
+      destruct u.
+      constructor.
+    + intros s bt H.
+      destruct bt; try discriminate.
+      simpl in H.
+      destruct Sym_t_as_MiniDecidableType.eq_dec as [E | ?]; try discriminate.
+      rewrite E.
+      constructor.
+    + intros ? ? ? ? H.
+      inversion H.
+Qed.
 
 (* Defines when a term represents a cast of another term to a specific type *)
 Inductive cast_ (loc: Locations.t) : BaseTypes.t -> IndexTerms.t -> IndexTerms.t -> Prop :=

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -139,12 +139,13 @@ Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
 
 Inductive resource_unfold_full (globals:Global.t): ResSet.t -> ResSet.t -> Prop :=
 | resource_unfold_full_step:
-    forall input output r unfolded_r,
+    forall input input' output r unfolded_r,
     (* Find a resource that can be unfolded *)
     ResSet.In r input ->
     resource_unfold globals r unfolded_r ->
     (* Continue unfolding with the resource replaced by its unfolded components *)
-    resource_unfold_full globals (ResSet.union (ResSet.remove r input) unfolded_r) output ->
+    ResSet.Equal input' (ResSet.union (ResSet.remove r input) unfolded_r) ->
+    resource_unfold_full globals input' output ->
     (* This is the result of unfolding the input *)
     resource_unfold_full globals input output
 | resource_unfold_full_fixpoint:

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -175,11 +175,9 @@ Inductive struct_piece_to_resource
   (loc: Location.t)
   : output -> Resource.t -> Prop :=
 | struct_piece_to_resource_struct:
-  forall pid pty field_bt fields field_it struct_loc,
+  forall pid pty fields field_it struct_loc,
   Memory.piece_member_or_padding piece = Some (pid, pty) ->
   let field_pointer := Terms.IT _ (Terms.MemberShift _ ipointer tag pid) (BaseTypes.Loc _ tt) loc in
-  (* The field's type maps to its base type *)
-  bt_of_sct_rel pty field_bt ->
   (* field_out is the IT corresponding to pid in iout's field list *)
   List.In (pid, field_it) fields
 

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -333,6 +333,23 @@ Proof.
       all: assumption.
 Qed.
 
+
+Definition subsumed_fun (p1 p2 : Request.name) : bool :=
+  orb
+    (bool_of_sum (Name_as_MiniDecidableType.eq_dec p1 p2))
+    (match p1, p2 with
+    | Request.Owned ct Uninit, Request.Owned ct' Init
+        => bool_of_sum (SCtypes_as_MiniDecidableType.eq_dec ct ct')
+    | _, _ => false
+    end).
+
+Lemma subsumed_fun_eq:
+  forall p1 p2,
+  subsumed p1 p2 <-> subsumed_fun p1 p2 = true.
+Proof.
+  
+Admitted. 
+
 Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
 | resource_unfold_struct:
   forall out_res ipointer iargs iout iinit iinit' isym sdecl loc,

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -526,8 +526,8 @@ Fixpoint resource_unfold_full_explicit_fun
 
 Lemma resource_unfold_full_explicit_fun_eq:
   forall globals input output unfold_changed,
-  resource_unfold_full_explicit globals unfold_changed (Resource.set_from_list input) (Resource.set_from_list output) ->
-  resource_unfold_full_explicit_fun globals unfold_changed input output = true.
+  resource_unfold_full_explicit_fun globals unfold_changed input output = true ->
+  resource_unfold_full_explicit globals unfold_changed (Resource.set_from_list input) (Resource.set_from_list output).
 Proof.
   admit.
 Admitted.

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -108,8 +108,6 @@ Inductive struct_piece_to_resource
            loc))).
 
 Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
-(* Removed resource_unfold_nonstruct constructor *)
-
 | resource_unfold_struct:
   forall out_res ipointer iargs iout iinit iinit' isym sdecl loc,
 

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -651,6 +651,15 @@ Proof.
   - eapply unfold_all_fixpoint; eassumption.
 Qed.
 
+Definition resource_is_struct (r : Resource.t): bool :=
+  match r with
+  | (Request.P {| Predicate.name := Request.Owned (SCtypes.Struct _) _;
+                  Predicate.pointer := _;
+                  Predicate.iargs := _ |}, _) =>
+    true
+  | _ => false
+  end.
+
 (* Computable version of unfold_all_explicit predicate *)
 Fixpoint unfold_all_explicit_fun
   (globals:Global.t)
@@ -662,7 +671,9 @@ Fixpoint unfold_all_explicit_fun
     List.existsb (fun r' => bool_of_sum (Resource_as_DecidableType.eq_dec r r')) input &&
     unfold_one_fun globals r unfolded_r_list &&
     unfold_all_explicit_fun globals unfold_changed input' output
-  | [] => ResSet.equal (Resource.set_from_list input) (Resource.set_from_list output)
+  | [] =>
+    negb (List.existsb resource_is_struct input) && (* this should be updated later to support arrays *)
+    ResSet.equal (Resource.set_from_list input) (Resource.set_from_list output)
   | _ => false
   end.
 

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -546,8 +546,55 @@ Lemma unfold_one_fun_eq:
   unfold_one_fun globals r out_res = true ->
   unfold_one globals r (Resource.set_from_list out_res).
 Proof.
-  admit.
-Admitted.
+  intros globals r out_res H.
+  unfold unfold_one_fun in H.
+  destruct r as [req out].
+  destruct req as [P | Q]; try discriminate; subst.
+  destruct P as [name pointer args].
+  destruct name; try discriminate.
+  destruct t; try discriminate.
+  destruct SymMap.find eqn:Hf; try discriminate.
+  apply andb_prop in H; destruct H as [HlEQ H].
+  apply Nat.eqb_eq in HlEQ.
+  apply SymMap.find_2 in Hf.
+  assert (piece_def : Memory.struct_piece) by (repeat constructor).
+  assert (res_def : Resource.t) by (repeat constructor).
+  eapply unfold_one_struct with (iinit' := i).
+  { apply Subsumed_equal.
+    reflexivity. }
+  { apply Hf. }
+  intros r; split.
+  - intros Hr.
+    apply ResSet_In_List_In_eq in Hr.
+    eapply In_nth with (d := res_def) in Hr as [n [Hl_out_res Hnth]].
+    eapply forallb_forall in H; revgoals.
+    { apply nth_In with (n := n).
+      rewrite length_combine, HlEQ, Nat.min_id.
+      apply Hl_out_res. }
+    rewrite combine_nth with (x := piece_def) (y := res_def) in H by (apply HlEQ).
+    rewrite <- Hnth.
+    exists (nth n s0 piece_def); split.
+    + apply nth_In.
+      rewrite HlEQ.
+      apply Hl_out_res.
+    + apply struct_piece_to_resource_fun_eq, H.
+  - intros [piece [Hp H1]].
+    apply ResSet_In_List_In_eq.
+    eapply In_nth with (d := piece_def) in Hp as [n [Hl_s0 Hnth]].
+    eapply forallb_forall in H; revgoals.
+    { apply nth_In with (n := n).
+      rewrite length_combine, <- HlEQ, Nat.min_id.
+      apply Hl_s0. }
+    rewrite combine_nth with (x := piece_def) (y := res_def) in H by (apply HlEQ).
+    rewrite Hnth in H.
+    apply struct_piece_to_resource_fun_eq in H.
+    erewrite struct_piece_to_resource_functional with (res1 := r) (res2 := nth n out_res res_def).
+    + apply nth_In.
+      rewrite <- HlEQ.
+      apply Hl_s0.
+    + apply H1.
+    + apply H.
+Qed.
 
 Inductive unfold_all (globals:Global.t): ResSet.t -> ResSet.t -> Prop :=
 | unfold_all_step:

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -297,10 +297,11 @@ Inductive log_entry_valid : log_entry -> Prop :=
   (* Find the struct resource and its fields *)
   (exists (field_res: ResSet.t),
       (* The struct unfolds to field resources *)
-      resource_unfold iglobal
-        (Request.P {| Predicate.name := iname;
-                     Predicate.pointer := ipointer;
-                     Predicate.iargs := iargs |}, out)
+      resource_unfold_full iglobal
+        (ResSet.singleton
+          (Request.P {| Predicate.name := iname;
+                       Predicate.pointer := ipointer;
+                       Predicate.iargs := iargs |}, out))
         field_res /\
       (* Output context is input context minus all field resources *)
       ResSet.Equal out_res (ResSet.diff in_res field_res)

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -234,7 +234,7 @@ Inductive log_entry_valid : log_entry -> Prop :=
 | array_resource_inference_step:
   forall ity isize iinit ipointer iargs
     oname opointer oargs
-    err out lines oloc
+    err out lines
     icomputational ilogical iresources iconstraints iglobal
     ocomputational ological oresources oconstraints oglobal,
 
@@ -256,7 +256,6 @@ Inductive log_entry_valid : log_entry -> Prop :=
           {| Predicate.name := Request.Owned (SCtypes.Array (SCtypes.Integer ity, isize)) iinit;
             Predicate.pointer := ipointer;
             Predicate.iargs := iargs |}
-          oloc (* unused *)
           ((
               (* output predicate *)
               {| Predicate.name:=oname; Predicate.pointer:=opointer; Predicate.iargs:=oargs |},
@@ -279,7 +278,7 @@ Inductive log_entry_valid : log_entry -> Prop :=
 | struct_resource_inference_step:
   forall isym iinit ipointer iargs
     oname opointer oargs
-    err out lines oloc
+    err out lines
     icomputational ilogical iresources iconstraints iglobal
     ocomputational ological oresources oconstraints oglobal,
 
@@ -328,7 +327,6 @@ Inductive log_entry_valid : log_entry -> Prop :=
           {| Predicate.name := Request.Owned (SCtypes.Struct isym) iinit;
             Predicate.pointer := ipointer;
             Predicate.iargs := iargs |}
-          oloc (* unused *)
           ((
               (* output predicate *)
               {| Predicate.name:=oname; Predicate.pointer:=opointer; Predicate.iargs:=oargs |},
@@ -351,7 +349,7 @@ Inductive log_entry_valid : log_entry -> Prop :=
 | simple_resource_inference_step:
   forall iname  ipointer  iargs
     oname  opointer  oargs
-    err out lines oloc
+    err out lines
     icomputational ilogical iresources iconstraints iglobal
     ocomputational ological oresources oconstraints oglobal,
 
@@ -397,7 +395,6 @@ Inductive log_entry_valid : log_entry -> Prop :=
             err (* unused *)
             (* input predicate *)
             {| Predicate.name:=iname; Predicate.pointer:=ipointer; Predicate.iargs:=iargs |}
-            oloc (* unused *)
             ((
                 (* output predicate *)
                 {| Predicate.name:=oname; Predicate.pointer:=opointer; Predicate.iargs:=oargs |},

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -540,6 +540,9 @@ Proof.
   admit.
 Admitted.
 
+Definition unfold_step_flatten (l : list unfold_step): unfold_changed :=
+  List.concat (List.map fst l).
+
 (** Inductive predicate which defines correctness of resource unfolding step *)
 Inductive unfold_step : Context.t -> Context.t -> Prop :=
 | simple_unfold_step:

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -338,17 +338,37 @@ Definition subsumed_fun (p1 p2 : Request.name) : bool :=
   orb
     (bool_of_sum (Name_as_MiniDecidableType.eq_dec p1 p2))
     (match p1, p2 with
-    | Request.Owned ct Uninit, Request.Owned ct' Init
-        => bool_of_sum (SCtypes_as_MiniDecidableType.eq_dec ct ct')
-    | _, _ => false
-    end).
+     | Request.Owned ct Uninit, Request.Owned ct' Init
+         => bool_of_sum (SCtypes_as_MiniDecidableType.eq_dec ct ct')
+     | _, _ => false
+     end).
 
 Lemma subsumed_fun_eq:
   forall p1 p2,
   subsumed p1 p2 <-> subsumed_fun p1 p2 = true.
 Proof.
-  
-Admitted. 
+  intros p1 p2.
+  split.
+  - intros H.
+    unfold subsumed_fun.
+    apply orb_true_intro.
+    inversion H; subst.
+    + left.
+      apply eq_dec_refl_l.
+    + right.
+      apply eq_dec_refl_l.
+  - intros H.
+    unfold subsumed_fun in H.
+    apply orb_prop in H; destruct H as [H | H].
+    + apply Subsumed_equal.
+      eapply eq_dec_refl_r, H.
+    + destruct p1; try discriminate.
+      destruct i; try discriminate.
+      destruct p2; try discriminate.
+      destruct i; try discriminate.
+      apply Subsumed_owned.
+      eapply eq_dec_refl_r, H.
+Qed.
 
 Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
 | resource_unfold_struct:

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -227,9 +227,9 @@ Local Definition ptr_addr_and_args_eq (g: Global.t) (c: LCSet.t) (p p': IndexTer
 (** Inductive predicate which defines correctess of log inference step *)
 Inductive log_entry_valid : log_entry -> Prop :=
 | unfold_resources_step:
-  forall loc c c',
+  forall loc c c' steps,
   unfold_step c c' ->
-  log_entry_valid (ResourceInferenceStep c (UnfoldResources loc) c')
+  log_entry_valid (ResourceInferenceStep c (UnfoldResources loc steps) c')
 
 | array_resource_inference_step:
   forall ity isize iinit ipointer iargs

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -114,8 +114,13 @@ Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
     )
 
 | resource_unfold_struct:
-  forall out_res ipointer iargs iout iinit isym sdecl loc,
+  forall out_res ipointer iargs iout iinit iinit' isym sdecl loc,
 
+  let iname := Request.Owned (SCtypes.Struct isym) iinit in
+  let iname' := Request.Owned (SCtypes.Struct isym) iinit' in
+
+  subsumed iname iname' ->
+  
   (* lookup struct declaration in global environment *)
   SymMap.MapsTo isym sdecl globals.(Global.struct_decls) ->
 
@@ -123,14 +128,14 @@ Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
   (forall r,
      ResSet.In r out_res <->
        exists piece, List.In piece sdecl /\
-                struct_piece_to_resource piece iinit ipointer iargs isym loc iout r)
+                struct_piece_to_resource piece iinit' ipointer iargs isym loc iout r)
 
   ->
 
     resource_unfold globals
       (Request.P
          {|
-           Predicate.name := Request.Owned (SCtypes.Struct isym) iinit;
+           Predicate.name := iname;
            Predicate.pointer := ipointer;
            Predicate.iargs := iargs
          |},

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -608,12 +608,13 @@ Inductive unfold_all (globals:Global.t): ResSet.t -> ResSet.t -> Prop :=
     (* This is the result of unfolding the input *)
     unfold_all globals input output
 | unfold_all_fixpoint:
-    forall input,
+    forall input output,
     (* A fixpoint is reached when no resource can be unfolded further *)
     ~ ResSet.Exists
         (fun r => exists unfolded_r, unfold_one globals r unfolded_r)
         input ->
-    unfold_all globals input input.
+    ResSet.Equal input output ->
+    unfold_all globals input output.
 
 (* A version of `unfold_all`, using hints *)
 Inductive unfold_all_explicit (globals:Global.t):
@@ -630,12 +631,13 @@ Inductive unfold_all_explicit (globals:Global.t):
     (* This is the result of unfolding the input *)
     unfold_all_explicit globals ((r, UnpackRES unfolded_r_list) :: unfold_changed) input output
 | unfold_all_explicit_fixpoint:
-    forall input,
+    forall input output,
     (* A fixpoint is reached when no resource can be unfolded further *)
     ~ ResSet.Exists
         (fun r => exists unfolded_r, unfold_one globals r unfolded_r)
         input ->
-    unfold_all_explicit globals [] input input.
+    ResSet.Equal input output ->
+    unfold_all_explicit globals [] input output.
 
 (* Proof that unfold_all_explicit is equivalent to unfold_all *)    
 Lemma unfold_all_explicit_eq:
@@ -645,8 +647,8 @@ Lemma unfold_all_explicit_eq:
 Proof.
   intros globals input output unfold_changed H.
   induction H.
-  - econstructor; eassumption.
-  - econstructor; eassumption.
+  - eapply unfold_all_step; eassumption.
+  - eapply unfold_all_fixpoint; eassumption.
 Qed.
 
 (* Computable version of unfold_all_explicit predicate *)

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -42,12 +42,11 @@ Inductive bt_of_sct_rel : SCtypes.t -> BaseTypes.t -> Prop :=
 
 (* Defines when a term represents a cast of another term to a specific type *)
 Inductive cast_ (loc: Locations.t) : BaseTypes.t -> IndexTerms.t -> IndexTerms.t -> Prop :=
-| cast_same: forall bt t' bt' l',
-  bt = bt' ->
-  cast_ loc bt (Terms.IT _ t' bt' l') (Terms.IT _ t' bt' l')
+| cast_same: forall bt t' l',
+  cast_ loc bt (Terms.IT _ t' bt l') (Terms.IT _ t' bt l')
 | cast_diff: forall bt t' bt' l',
   bt <> bt' ->
-  cast_ loc bt (Terms.IT _ t' bt' l') (Terms.IT _ (Terms.Cast _ bt (Terms.IT _ t' bt' l')) bt loc).
+  cast_ loc bt (Terms.IT _ t' bt l') (Terms.IT _ (Terms.Cast _ bt (Terms.IT _ t' bt' l')) bt loc).
 
 Inductive allocId_ (loc: Locations.t) : IndexTerms.t -> IndexTerms.t -> Prop :=
 | allocId_intro: forall t' bt' l' result,

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -380,6 +380,17 @@ Inductive resource_unfold (globals:Global.t): Resource.t -> ResSet.t -> Prop :=
          iout)
       out_res.
 
+Definition resource_unfold_fun (globals:Global.t) (r : Resource.t) (out_res: list Resource.t) : bool.
+  admit.
+Admitted.
+
+Lemma resource_unfold_fun_eq:
+  forall globals r out_res,
+  resource_unfold globals r (Resource.set_from_list out_res) <-> resource_unfold_fun globals r out_res = true.
+Proof.
+  admit.
+Admitted.
+
 Inductive resource_unfold_full (globals:Global.t): ResSet.t -> ResSet.t -> Prop :=
 | resource_unfold_full_step:
     forall input input' output r unfolded_r,
@@ -430,6 +441,21 @@ Proof.
   - econstructor; eassumption.
   - econstructor; eassumption.
 Qed.
+
+Definition resource_unfold_full_explicit_fun
+  (globals:Global.t)
+  (unfold_changed : list (Resource.t * unpack_result))
+  (input output: list Resource.t): bool.
+  admit.
+Admitted.
+
+Lemma resource_unfold_full_explicit_fun_eq:
+  forall globals input output unfold_changed,
+  resource_unfold_full_explicit globals unfold_changed (Resource.set_from_list input) (Resource.set_from_list output) ->
+  resource_unfold_full_explicit_fun globals unfold_changed input output = true.
+Proof.
+  admit.
+Admitted.
 
 (** Inductive predicate which defines correctness of resource unfolding step *)
 Inductive unfold_step : Context.t -> Context.t -> Prop :=

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -543,7 +543,8 @@ Definition unfold_one_fun (globals:Global.t) (r : Resource.t) (out_res: list Res
 (* Equivalence between unfold_one and unfold_one_fun *)
 Lemma unfold_one_fun_eq:
   forall globals r out_res,
-  unfold_one globals r (Resource.set_from_list out_res) <-> unfold_one_fun globals r out_res = true.
+  unfold_one_fun globals r out_res = true ->
+  unfold_one globals r (Resource.set_from_list out_res).
 Proof.
   admit.
 Admitted.

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -21,6 +21,10 @@ Definition ctx_resources_set (l:((list (Resource.t * Z)) * Z)) : ResSet.t
   :=
   Resource.set_from_list (List.map fst (fst l)).
 
+Inductive term_is_struct: Terms.term BaseTypes.t -> Prop :=
+| term_is_struct_intro: forall tag fields,
+  term_is_struct (Terms.Struct _ tag fields).
+
 (* Relation between Sctypes.t and BaseTypes.t *)
 Inductive bt_of_sct_rel : SCtypes.t -> BaseTypes.t -> Prop :=
 | bt_of_sct_void : bt_of_sct_rel SCtypes.Void (BaseTypes.Unit unit)
@@ -91,8 +95,10 @@ Inductive struct_piece_to_resource
   let field_pointer := Terms.IT _ (Terms.MemberShift _ ipointer tag pid) (BaseTypes.Loc _ tt) loc in
   (* The field's type maps to its base type *)
   bt_of_sct_rel pty field_bt ->
-
   let struct_type := (BaseTypes.Struct _ tag) in
+  ~ term_is_struct struct_term
+
+  ->
 
     struct_piece_to_resource piece iinit ipointer iargs tag loc
       (Resource.O (Terms.IT _ struct_term struct_type struct_loc))

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -510,12 +510,19 @@ Proof.
   - econstructor; eassumption.
 Qed.
 
-Definition resource_unfold_full_explicit_fun
+Fixpoint resource_unfold_full_explicit_fun
   (globals:Global.t)
   (unfold_changed : list (Resource.t * unpack_result))
-  (input output: list Resource.t): bool.
-  admit.
-Admitted.
+  (input output: list Resource.t): bool :=
+  match unfold_changed with
+  | ((r, UnpackRES unfolded_r_list) :: unfold_changed) =>
+    let input' := List.app (List.remove Resource_as_DecidableType.eq_dec r input) unfolded_r_list in
+    List.existsb (fun r' => bool_of_sum (Resource_as_DecidableType.eq_dec r r')) input &&
+    resource_unfold_fun globals r output &&
+    resource_unfold_full_explicit_fun globals unfold_changed input' output
+  | [] => bool_of_sum (List.list_eq_dec Resource_as_DecidableType.eq_dec input output)
+  | _ => false
+  end.
 
 Lemma resource_unfold_full_explicit_fun_eq:
   forall globals input output unfold_changed,

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -525,9 +525,9 @@ Fixpoint unfold_all_explicit_fun
   | ((r, UnpackRES unfolded_r_list) :: unfold_changed) =>
     let input' := List.app (List.remove Resource_as_DecidableType.eq_dec r input) unfolded_r_list in
     List.existsb (fun r' => bool_of_sum (Resource_as_DecidableType.eq_dec r r')) input &&
-    unfold_one_fun globals r output &&
+    unfold_one_fun globals r unfolded_r_list &&
     unfold_all_explicit_fun globals unfold_changed input' output
-  | [] => bool_of_sum (List.list_eq_dec Resource_as_DecidableType.eq_dec input output)
+  | [] => ResSet.equal (Resource.set_from_list input) (Resource.set_from_list output)
   | _ => false
   end.
 

--- a/doc/CN-COQ.md
+++ b/doc/CN-COQ.md
@@ -2,8 +2,8 @@
 
 ## Installation
 
-You need Opam >= 2.0.0 OCaml >= 4.12.0 Coq >= 8.18.0.
-(>= 4.12.0). The developers are currently using OCaml 5.2.0 and Coq 8.19.2.
+You need Opam >= 2.0.0 OCaml >= 4.12.0 Coq >= 8.19.2.
+(>= 4.12.0). The developers are currently using OCaml 5.2.0 and Coq 8.20.1
 
 It is recommended to create a new switch for CN-Coq:
 

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2197,7 +2197,7 @@ let pp_unfold_step (s : Prooflog.unfold_step) =
 
 
 let rec pp_log_entry = function
-  | Prooflog.PredicateRequest (c, s, p, r, h,c') ->
+  | Prooflog.PredicateRequest (c, s, p, r, h, c') ->
     pp_constructor
       "PredicateRequest"
       [ pp_context c;
@@ -2210,11 +2210,8 @@ let rec pp_log_entry = function
   | Prooflog.UnfoldResources (c, loc, steps, c') ->
     pp_constructor
       "UnfoldResources"
-      [ pp_context c;
-        pp_location loc;
-        pp_list pp_unfold_step steps;
-        pp_context c'
-      ]
+      [ pp_context c; pp_location loc; pp_list pp_unfold_step steps; pp_context c' ]
+
 
 let coq_steps_var_name = "ResourceInferenceSteps"
 

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2193,10 +2193,7 @@ let pp_unpack_result (r : Prooflog.unpack_result) =
 
 
 let pp_unfold_step (s : Prooflog.unfold_step) =
-  pp_pair
-    (pp_list (pp_triple pp_int pp_resource pp_unpack_result))
-    (pp_list pp_resource)
-    s
+  pp_pair (pp_list (pp_pair pp_resource pp_unpack_result)) (pp_list pp_resource) s
 
 
 let pp_resource_inference_type = function
@@ -2252,7 +2249,7 @@ let pp_proof_log (steps : Prooflog.log) (generate_proof : bool) =
   ^^ coq_def
        (coq_steps_var_name ^ ":Prooflog.log")
        P.empty
-       (pp_list pp_resource_inference_step steps)
+       (pp_list pp_resource_inference_step (List.rev steps))
   ^^ P.hardline
   ^^
   if generate_proof then

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2197,12 +2197,11 @@ let pp_unfold_step (s : Prooflog.unfold_step) =
 
 
 let pp_resource_inference_type = function
-  | Prooflog.PredicateRequest (s, p, o, ri) ->
+  | Prooflog.PredicateRequest (s, p, ri) ->
     pp_constructor
       "PredicateRequest"
       [ pp_situation s;
         pp_predicate p;
-        pp_option (pp_pair pp_location pp_string) o;
         pp_pair pp_resource_predicate (pp_list pp_int) ri
       ]
   | Prooflog.UnfoldResources (loc, steps) ->

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2186,6 +2186,19 @@ let pp_context (c : Context.t) =
     ]
 
 
+let pp_unpack_result (r : Prooflog.unpack_result) =
+  match r with
+  | Prooflog.UnpackLRT lrt -> pp_constructor "UnpackLRT" [ pp_logical_return_type lrt ]
+  | Prooflog.UnpackRES res -> pp_constructor "UnpackRES" [ pp_list pp_resource res ]
+
+
+let pp_unfold_step (s : Prooflog.unfold_step) =
+  pp_pair
+    (pp_list (pp_triple pp_int pp_resource pp_unpack_result))
+    (pp_list pp_resource)
+    s
+
+
 let pp_resource_inference_type = function
   | Prooflog.PredicateRequest (s, p, o, ri) ->
     pp_constructor
@@ -2195,7 +2208,8 @@ let pp_resource_inference_type = function
         pp_option (pp_pair pp_location pp_string) o;
         pp_pair pp_resource_predicate (pp_list pp_int) ri
       ]
-  | Prooflog.UnfoldResources loc -> pp_constructor "UnfoldResources" [ pp_location loc ]
+  | Prooflog.UnfoldResources (loc, steps) ->
+    pp_constructor "UnfoldResources" [ pp_location loc; pp_list pp_unfold_step steps ]
 
 
 (* Add this definition before its use in `pp_unit_file_with_resource_inference` *)

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2196,25 +2196,25 @@ let pp_unfold_step (s : Prooflog.unfold_step) =
   pp_pair (pp_list (pp_pair pp_resource pp_unpack_result)) (pp_list pp_resource) s
 
 
-let pp_resource_inference_type = function
-  | Prooflog.PredicateRequest (s, p, ri) ->
+let rec pp_log_entry = function
+  | Prooflog.PredicateRequest (c, s, p, r, h,c') ->
     pp_constructor
       "PredicateRequest"
-      [ pp_situation s;
+      [ pp_context c;
+        pp_situation s;
         pp_predicate p;
-        pp_pair pp_resource_predicate (pp_list pp_int) ri
+        pp_resource_predicate r;
+        pp_list pp_log_entry h;
+        pp_context c'
       ]
-  | Prooflog.UnfoldResources (loc, steps) ->
-    pp_constructor "UnfoldResources" [ pp_location loc; pp_list pp_unfold_step steps ]
-
-
-(* Add this definition before its use in `pp_unit_file_with_resource_inference` *)
-let pp_resource_inference_step = function
-  | Prooflog.ResourceInferenceStep (c1, ri, c2) ->
+  | Prooflog.UnfoldResources (c, loc, steps, c') ->
     pp_constructor
-      "ResourceInferenceStep"
-      [ pp_context c1; pp_resource_inference_type ri; pp_context c2 ]
-
+      "UnfoldResources"
+      [ pp_context c;
+        pp_location loc;
+        pp_list pp_unfold_step steps;
+        pp_context c'
+      ]
 
 let coq_steps_var_name = "ResourceInferenceSteps"
 
@@ -2248,7 +2248,7 @@ let pp_proof_log (steps : Prooflog.log) (generate_proof : bool) =
   ^^ coq_def
        (coq_steps_var_name ^ ":Prooflog.log")
        P.empty
-       (pp_list pp_resource_inference_step (List.rev steps))
+       (pp_list pp_log_entry (List.rev steps))
   ^^ P.hardline
   ^^
   if generate_proof then

--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -4,6 +4,9 @@ let proof_log_enabled = ref false
 (* Function to set the proof log enabled flag *)
 let set_enabled flag = proof_log_enabled := flag
 
+(* Function to check if proof logging is enabled *)
+let is_enabled () = !proof_log_enabled
+
 type unpack_result =
   | UnpackLRT of LogicalReturnTypes.t
   | UnpackRES of Resource.t list

--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -8,7 +8,7 @@ type unpack_result =
   | UnpackLRT of LogicalReturnTypes.t
   | UnpackRES of Resource.t list
 
-type unfold_changed = (int * Resource.t * unpack_result) list
+type unfold_changed = (Resource.t * unpack_result) list
 
 type extract_changed = Resource.t list
 

--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -14,14 +14,15 @@ type extract_changed = Resource.t list
 
 type unfold_step = unfold_changed * extract_changed
 
-type resource_inference_type =
-  | PredicateRequest of
-      Error_common.situation * Request.Predicate.t * (Resource.predicate * int list)
-  | UnfoldResources of Cerb_location.t * unfold_step list
-
-(** Info about what happened *)
 type log_entry =
-  | ResourceInferenceStep of (Context.t * resource_inference_type * Context.t)
+  | PredicateRequest of
+      Context.t
+      * Error_common.situation
+      * Request.Predicate.t
+      * Resource.predicate
+      * log_entry list
+      * Context.t
+  | UnfoldResources of Context.t * Cerb_location.t * unfold_step list * Context.t
 
 type log = log_entry list (* most recent first *)
 
@@ -37,10 +38,4 @@ let add_log_entry entry =
 
 let get_proof_log () = !proof_log
 
-let record_resource_inference_step
-      (c : Context.t)
-      (c' : Context.t)
-      (ri : resource_inference_type)
-  : unit
-  =
-  add_log_entry (ResourceInferenceStep (c, ri, c'))
+let record_resource_inference_step entry = add_log_entry entry

--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -16,10 +16,7 @@ type unfold_step = unfold_changed * extract_changed
 
 type resource_inference_type =
   | PredicateRequest of
-      Error_common.situation
-      * Request.Predicate.t
-      * (Locations.t * string) option
-      * (Resource.predicate * int list)
+      Error_common.situation * Request.Predicate.t * (Resource.predicate * int list)
   | UnfoldResources of Cerb_location.t * unfold_step list
 
 (** Info about what happened *)

--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -4,13 +4,23 @@ let proof_log_enabled = ref false
 (* Function to set the proof log enabled flag *)
 let set_enabled flag = proof_log_enabled := flag
 
+type unpack_result =
+  | UnpackLRT of LogicalReturnTypes.t
+  | UnpackRES of Resource.t list
+
+type unfold_changed = (int * Resource.t * unpack_result) list
+
+type extract_changed = Resource.t list
+
+type unfold_step = unfold_changed * extract_changed
+
 type resource_inference_type =
   | PredicateRequest of
       Error_common.situation
       * Request.Predicate.t
       * (Locations.t * string) option
       * (Resource.predicate * int list)
-  | UnfoldResources of Cerb_location.t
+  | UnfoldResources of Cerb_location.t * unfold_step list
 
 (** Info about what happened *)
 type log_entry =

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -22,6 +22,8 @@ type log = log_entry list
 
 val set_enabled : bool -> unit
 
+val is_enabled : unit -> bool
+
 val add_log_entry : log_entry -> unit
 
 val get_proof_log : unit -> log_entry list

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -10,10 +10,7 @@ type unfold_step = unfold_changed * extract_changed
 
 type resource_inference_type =
   | PredicateRequest of
-      Error_common.situation
-      * Request.Predicate.t
-      * (Locations.t * string) option
-      * (Resource.predicate * int list)
+      Error_common.situation * Request.Predicate.t * (Resource.predicate * int list)
   | UnfoldResources of Cerb_location.t * unfold_step list
 
 type log_entry =

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -8,13 +8,15 @@ type extract_changed = Resource.t list
 
 type unfold_step = unfold_changed * extract_changed
 
-type resource_inference_type =
-  | PredicateRequest of
-      Error_common.situation * Request.Predicate.t * (Resource.predicate * int list)
-  | UnfoldResources of Cerb_location.t * unfold_step list
-
 type log_entry =
-  | ResourceInferenceStep of (Context.t * resource_inference_type * Context.t)
+  | PredicateRequest of
+      Context.t
+      * Error_common.situation
+      * Request.Predicate.t
+      * Resource.predicate
+      * log_entry list
+      * Context.t
+  | UnfoldResources of Context.t * Cerb_location.t * unfold_step list * Context.t
 
 type log = log_entry list
 
@@ -24,8 +26,4 @@ val add_log_entry : log_entry -> unit
 
 val get_proof_log : unit -> log_entry list
 
-val record_resource_inference_step
-  :  Context.t ->
-  Context.t ->
-  resource_inference_type ->
-  unit
+val record_resource_inference_step : log_entry -> unit

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -1,10 +1,20 @@
+type unpack_result =
+  | UnpackLRT of LogicalReturnTypes.t
+  | UnpackRES of Resource.t list
+
+type unfold_changed = (int * Resource.t * unpack_result) list
+
+type extract_changed = Resource.t list
+
+type unfold_step = unfold_changed * extract_changed
+
 type resource_inference_type =
   | PredicateRequest of
       Error_common.situation
       * Request.Predicate.t
-      * (Cerb_location.t * string) option
+      * (Locations.t * string) option
       * (Resource.predicate * int list)
-  | UnfoldResources of Cerb_location.t
+  | UnfoldResources of Cerb_location.t * unfold_step list
 
 type log_entry =
   | ResourceInferenceStep of (Context.t * resource_inference_type * Context.t)

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -2,7 +2,7 @@ type unpack_result =
   | UnpackLRT of LogicalReturnTypes.t
   | UnpackRES of Resource.t list
 
-type unfold_changed = (int * Resource.t * unpack_result) list
+type unfold_changed = (Resource.t * unpack_result) list
 
 type extract_changed = Resource.t list
 

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -248,9 +248,7 @@ module General = struct
     | Some r ->
       let@ c' = get_typing_context () in
       Prooflog.record_resource_inference_step
-        c
-        c'
-        (PredicateRequest (fst uiinfo, requested, r));
+        (Prooflog.PredicateRequest (c, fst uiinfo, requested, (fst r), [], c'));
       return (Some r)
     | None -> return None
 

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -325,20 +325,17 @@ module General = struct
              match provable (LC.T needed_at_index) with
              | `False -> continue
              | `True ->
-              let@ c = get_typing_context () in
-              let pointer = IT.(arrayShift_ ~base:requested.pointer ~index requested.step here) in
-              let sub_req : Req.Predicate.t =
-                { name = requested.name;
-                  pointer;
-                  iargs = List.map (IT.subst su) requested.iargs
-                }
-              in               
-            let@ o_re_index =
-                predicate_request
-                   loc
-                   uiinfo
-                   sub_req
-              in
+               let@ c = get_typing_context () in
+               let pointer =
+                 IT.(arrayShift_ ~base:requested.pointer ~index requested.step here)
+               in
+               let sub_req : Req.Predicate.t =
+                 { name = requested.name;
+                   pointer;
+                   iargs = List.map (IT.subst su) requested.iargs
+                 }
+               in
+               let@ o_re_index = predicate_request loc uiinfo sub_req in
                (match o_re_index with
                 | None -> continue
                 | Some (((_p', O p'_oarg) as rr), _, l') ->

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -123,21 +123,21 @@ module General = struct
                { requests = request_chain; situation; model; ctxt }
            in
            { loc; msg })
-       | Some ((re, Resource.O oargs), changed_or_deleted') ->
+       | Some ((re, Resource.O oargs), changed_or_deleted', l) ->
          assert (Request.equal re resource);
          let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
          let changed_or_deleted = changed_or_deleted @ changed_or_deleted' in
          return
-           (LAT.subst rt_subst (IT.make_subst [ (s, oargs) ]) ftyp, changed_or_deleted))
+           (LAT.subst rt_subst (IT.make_subst [ (s, oargs) ]) ftyp, changed_or_deleted, l))
     | Define ((s, it), _info, ftyp) ->
       let it = Simplify.IndexTerms.simp simp_ctxt it in
-      return (LAT.subst rt_subst (IT.make_subst [ (s, it) ]) ftyp, changed_or_deleted)
+      return (LAT.subst rt_subst (IT.make_subst [ (s, it) ]) ftyp, changed_or_deleted, [])
     | Constraint (c, info, ftyp) ->
       let@ provable = provable loc in
       Pp.(debug 9 (lazy (item "checking constraint" (LC.pp c))));
       let res = provable c in
       (match res with
-       | `True -> return (ftyp, changed_or_deleted)
+       | `True -> return (ftyp, changed_or_deleted, [])
        | `False ->
          let@ model = model () in
          let@ all_cs = get_cs () in
@@ -151,14 +151,13 @@ module General = struct
                TypeErrors.Unproven_constraint
                  { constr = c; info; requests = snd uiinfo; ctxt; model }
            }))
-    | I _rt -> return (ftyp, changed_or_deleted)
+    | I _rt -> return (ftyp, changed_or_deleted, [])
 
 
   (* TODO: check that oargs are in the same order? *)
   let rec predicate_request loc (uiinfo : uiinfo) (requested : Req.Predicate.t)
-    : (Resource.predicate * int list) option m
+    : (Resource.predicate * int list * Prooflog.log) option m
     =
-    let@ c = get_typing_context () in
     Pp.(debug 7 (lazy (item __LOC__ (Req.pp (P requested)))));
     let start_timing = Pp.time_log_start __LOC__ "" in
     let@ oarg_bt = WellTyped.oarg_bt_of_pred loc requested.name in
@@ -226,7 +225,7 @@ module General = struct
     Pp.(debug 9 (Lazy.map (fun x -> !^"resource was" ^^ x ^^ !^"found") not_str));
     let@ res =
       match needed with
-      | false -> return (Some ((requested, oarg), changed_or_deleted))
+      | false -> return (Some ((requested, oarg), changed_or_deleted, []))
       | true ->
         (match Pack.packing_ft here global provable (P requested) with
          | Some packing_ft ->
@@ -234,23 +233,17 @@ module General = struct
              lazy (LogicalArgumentTypes.pp (fun _ -> Pp.string "resource") packing_ft)
            in
            Pp.debug 9 (Lazy.map (Pp.item "attempting to pack compound resource") ft_pp);
-           let@ o, changed_or_deleted =
+           let@ o, changed_or_deleted, log =
              ftyp_args_request_for_pack loc uiinfo packing_ft
            in
-           return (Some ((requested, Resource.O o), changed_or_deleted))
+           return (Some ((requested, Resource.O o), changed_or_deleted, log))
          | None ->
            let req_pp = lazy (Req.pp (P requested)) in
            Pp.debug 9 (Lazy.map (Pp.item "no pack rule for resource, failing") req_pp);
            return None)
     in
     Pp.time_log_end start_timing;
-    match res with
-    | Some r ->
-      let@ c' = get_typing_context () in
-      Prooflog.record_resource_inference_step
-        (Prooflog.PredicateRequest (c, fst uiinfo, requested, (fst r), [], c'));
-      return (Some r)
-    | None -> return None
+    return res
 
 
   and qpredicate_request_aux loc uiinfo (requested : Req.QPredicate.t) =
@@ -316,12 +309,12 @@ module General = struct
         (needed, C [])
     in
     let here = Locations.other __LOC__ in
-    let@ needed, oarg =
+    let@ needed, oarg, l =
       let@ movable_indices = get_movable_indices () in
       let module Eff = Effectful.Make (Typing) in
       Eff.ListM.fold_rightM
-        (fun (predicate_name, index) (needed, oarg) ->
-           let continue = return (needed, oarg) in
+        (fun (predicate_name, index) (needed, oarg, l) ->
+           let continue = return (needed, oarg, l) in
            if
              (not (IT.is_false needed))
              && Req.subsumed requested.name predicate_name
@@ -332,37 +325,43 @@ module General = struct
              match provable (LC.T needed_at_index) with
              | `False -> continue
              | `True ->
-               let@ o_re_index =
-                 let pointer =
-                   IT.(arrayShift_ ~base:requested.pointer ~index requested.step here)
-                 in
-                 predicate_request
+              let@ c = get_typing_context () in
+              let pointer = IT.(arrayShift_ ~base:requested.pointer ~index requested.step here) in
+              let sub_req : Req.Predicate.t =
+                { name = requested.name;
+                  pointer;
+                  iargs = List.map (IT.subst su) requested.iargs
+                }
+              in               
+            let@ o_re_index =
+                predicate_request
                    loc
                    uiinfo
-                   { name = requested.name;
-                     pointer;
-                     iargs = List.map (IT.subst su) requested.iargs
-                   }
-               in
+                   sub_req
+              in
                (match o_re_index with
                 | None -> continue
-                | Some ((_p', O p'_oarg), _) ->
+                | Some (((_p', O p'_oarg) as rr), _, l') ->
                   let oarg = add_case (One { one_index = index; value = p'_oarg }) oarg in
                   let sym, bt' = requested.q in
                   let needed' =
                     IT.(and_ [ needed; ne__ (sym_ (sym, bt', here)) index here ] here)
                   in
-                  return (needed', oarg)))
+                  let@ c' = get_typing_context () in
+                  let log_entry =
+                    Prooflog.PredicateRequest (c, fst uiinfo, sub_req, rr, l', c')
+                  in
+                  return (needed', oarg, log_entry :: l)))
            else
              continue)
         movable_indices
-        (needed, oarg)
+        (needed, oarg, [])
     in
     let nothing_more_needed = LC.forall_ requested.q (IT.not_ needed here) in
     Pp.debug 9 (lazy (Pp.item "checking resource remainder" (LC.pp nothing_more_needed)));
     let holds = provable nothing_more_needed in
     match holds with
-    | `True -> return (Some (oarg, rw_time))
+    | `True -> return (Some (oarg, rw_time, l))
     | `False ->
       let@ model = model () in
       debug_constraint_failure_diagnostics 9 model simp_ctxt nothing_more_needed;
@@ -374,7 +373,7 @@ module General = struct
     let@ oarg_item_bt = WellTyped.oarg_bt_of_pred loc requested.name in
     match o_oarg with
     | None -> return None
-    | Some (oarg, rw_time) ->
+    | Some (oarg, rw_time, l) ->
       let@ oarg = cases_to_map loc uiinfo (snd requested.q) oarg_item_bt oarg in
       let r =
         Req.QPredicate.
@@ -387,18 +386,18 @@ module General = struct
             iargs = requested.iargs
           }
       in
-      return (Some ((r, Resource.O oarg), rw_time))
+      return (Some ((r, Resource.O oarg), rw_time, l))
 
 
   and ftyp_args_request_for_pack loc uiinfo ftyp =
     (* record the resources now, so errors are raised with all the resources present,
        rather than those that remain after some arguments are claimed *)
     let@ original_resources = all_resources_tagged loc in
-    let rec loop ftyp rw_time =
+    let rec loop ftyp rw_time l =
       match ftyp with
-      | LogicalArgumentTypes.I rt -> return (rt, rw_time)
+      | LogicalArgumentTypes.I rt -> return (rt, rw_time, l)
       | _ ->
-        let@ ftyp, rw_time =
+        let@ ftyp, rw_time, _l =
           parametric_ftyp_args_request_step
             resource_request
             IT.subst
@@ -408,30 +407,36 @@ module General = struct
             ftyp
             rw_time
         in
-        loop ftyp rw_time
+        loop ftyp rw_time (l @ _l)
     in
-    loop ftyp []
+    loop ftyp [] []
 
 
-  and resource_request loc uiinfo (request : Req.t) : (Resource.t * int list) option m =
+  and resource_request loc uiinfo (request : Req.t)
+    : (Resource.t * int list * Prooflog.log) option m
+    =
     match request with
     | P request ->
       let@ result = predicate_request loc uiinfo request in
       return
         (Option.map
-           (fun ((p, o), changed_or_deleted) -> ((Req.P p, o), changed_or_deleted))
+           (fun ((p, o), changed_or_deleted, l) -> ((Req.P p, o), changed_or_deleted, l))
            result)
     | Q request ->
       let@ result = qpredicate_request loc uiinfo request in
       return
         (Option.map
-           (fun ((q, o), changed_or_deleted) -> ((Req.Q q, o), changed_or_deleted))
+           (fun ((q, o), changed_or_deleted, l) -> ((Req.Q q, o), changed_or_deleted, l))
            result)
 
 
   (* I don't know if we need the rw_time in check.ml? *)
+  (*
+     This is called directly from check.ml. Maybe it should be in Special, as
+     predicate_request?
+  *)
   let ftyp_args_request_step rt_subst loc situation original_resources ftyp =
-    let@ rt, _rw_time =
+    let@ rt, _rw_time, _l =
       parametric_ftyp_args_request_step
         resource_request
         rt_subst
@@ -441,6 +446,10 @@ module General = struct
         ftyp
         []
     in
+    (* We started with top-level call of ftyp_args_request_step, so we need to
+       record the resource inference steps for the inner calls. They not nested
+       under anything, so we need to record them separately. *)
+    List.iter Prooflog.record_resource_inference_step _l;
     return rt
 end
 
@@ -464,8 +473,15 @@ module Special = struct
       ]
     in
     let uiinfo = (situation, requests) in
+    let@ c = get_typing_context () in
     let@ result = General.predicate_request loc uiinfo request in
-    match result with Some r -> return r | None -> fail_missing_resource loc uiinfo
+    match result with
+    | Some (r, rw_time, log) ->
+      let@ c' = get_typing_context () in
+      Prooflog.record_resource_inference_step
+        (Prooflog.PredicateRequest (c, fst uiinfo, request, r, log, c'));
+      return (r, rw_time)
+    | None -> fail_missing_resource loc uiinfo
 
 
   let has_predicate loc situation (request, oinfo) =
@@ -542,5 +558,12 @@ module Special = struct
     in
     let uiinfo = (situation, requests) in
     let@ result = General.qpredicate_request loc uiinfo request in
-    match result with Some r -> return r | None -> fail_missing_resource loc uiinfo
+    match result with
+    | Some (r, rw_time, log) ->
+      (* We started with top-level call of qpredicate_request, so we need to
+         record the resource inference steps for the inner calls. They not
+         nested under anything, so we need to record them separately. *)
+      List.iter Prooflog.record_resource_inference_step log;
+      return (r, rw_time)
+    | None -> fail_missing_resource loc uiinfo
 end

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -417,10 +417,16 @@ module General = struct
     =
     match request with
     | P request ->
+      let@ c = get_typing_context () in
       let@ result = predicate_request loc uiinfo request in
+      let@ c' = get_typing_context () in
       return
         (Option.map
-           (fun ((p, o), changed_or_deleted, l) -> ((Req.P p, o), changed_or_deleted, l))
+           (fun ((p, o), changed_or_deleted, l) ->
+              let log_entry =
+                Prooflog.PredicateRequest (c, fst uiinfo, request, (p, o), l, c')
+              in
+              ((Req.P p, o), changed_or_deleted, [ log_entry ]))
            result)
     | Q request ->
       let@ result = qpredicate_request loc uiinfo request in

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -397,7 +397,7 @@ module General = struct
       match ftyp with
       | LogicalArgumentTypes.I rt -> return (rt, rw_time, l)
       | _ ->
-        let@ ftyp, rw_time, _l =
+        let@ ftyp, rw_time, l' =
           parametric_ftyp_args_request_step
             resource_request
             IT.subst
@@ -407,7 +407,7 @@ module General = struct
             ftyp
             rw_time
         in
-        loop ftyp rw_time (l @ _l)
+        loop ftyp rw_time (l @ l')
     in
     loop ftyp [] []
 
@@ -445,7 +445,7 @@ module General = struct
      predicate_request?
   *)
   let ftyp_args_request_step rt_subst loc situation original_resources ftyp =
-    let@ rt, _rw_time, _l =
+    let@ rt, _rw_time, l =
       parametric_ftyp_args_request_step
         resource_request
         rt_subst
@@ -459,7 +459,7 @@ module General = struct
        record the resource inference steps for the inner calls. They not nested
        under anything, so we need to record them separately. *)
     if Prooflog.is_enabled () then
-      List.iter Prooflog.record_resource_inference_step _l
+      List.iter Prooflog.record_resource_inference_step l
     else
       ();
     return rt

--- a/lib/sym.ml
+++ b/lib/sym.ml
@@ -19,11 +19,6 @@ module Map = Map.Make (Ord)
 
 let description = S.symbol_description
 
-let pp_string_no_nums sym =
-  let print_nums = false in
-  Cerb_frontend.Pp_symbol.to_string_pretty_cn ~print_nums sym
-
-
 let pp_string sym =
   if !executable_spec_enabled then
     Cerb_frontend.Pp_symbol.to_string_pretty sym

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -726,9 +726,7 @@ let do_unfold_resources loc =
     let@ c' = get_typing_context () in
     return
       (Prooflog.record_resource_inference_step
-         c
-         c'
-         (UnfoldResources (loc, List.rev changed)))
+         (Prooflog.UnfoldResources (c, loc, List.rev changed, c')))
 
 
 let sync_unfold_resources loc =

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -709,7 +709,7 @@ let do_unfold_resources loc =
        | _ ->
          let converted_unpack =
            List.map
-             (fun (i, re, unpackable) ->
+             (fun (_, re, unpackable) ->
                 match unpackable with
                 | `LRT lrt -> (re, UnpackLRT lrt)
                 | `RES res -> (re, UnpackRES res))

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -714,10 +714,14 @@ let do_unfold_resources loc =
                 match unpackable with
                 | `LRT lrt -> (re, UnpackLRT lrt)
                 | `RES res ->
-                  let res_simp = List.map (fun (r, Res.O oargs) ->
-                    let r = Simplify.Request.simp simp_ctxt r in
-                    let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
-                    (r, Res.O oargs)) res in
+                  let res_simp =
+                    List.map
+                      (fun (r, Res.O oargs) ->
+                         let r = Simplify.Request.simp simp_ctxt r in
+                         let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
+                         (r, Res.O oargs))
+                      res
+                  in
                   (re, UnpackRES res_simp))
              unpack
          in

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -740,9 +740,9 @@ let do_unfold_resources loc =
   | [] -> return ()
   | _ ->
     let@ c' = get_typing_context () in
-    return
-      (Prooflog.record_resource_inference_step
-         (Prooflog.UnfoldResources (c, loc, List.rev changed, c')))
+    Prooflog.record_resource_inference_step
+      (Prooflog.UnfoldResources (c, loc, List.rev changed, c'));
+    return ()
 
 
 let sync_unfold_resources loc =

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -711,8 +711,8 @@ let do_unfold_resources loc =
            List.map
              (fun (i, re, unpackable) ->
                 match unpackable with
-                | `LRT lrt -> (i, re, UnpackLRT lrt)
-                | `RES res -> (i, re, UnpackRES res))
+                | `LRT lrt -> (re, UnpackLRT lrt)
+                | `RES res -> (re, UnpackRES res))
              unpack
          in
          aux ((converted_unpack, extract) :: changed))

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -650,6 +650,7 @@ let map_and_fold_resources_internal loc (f : Res.t -> 'acc -> changed * 'acc) (a
 (* the main inference loop *)
 let do_unfold_resources loc =
   let rec aux changed =
+    let open Prooflog in
     let@ s = get_typing_context () in
     let@ movable_indices = get_movable_indices () in
     let@ _provable_f = provable_internal (Locations.other __LOC__) in
@@ -666,9 +667,7 @@ let do_unfold_resources loc =
         List.fold_right
           (fun (re, i) (keep, unpack, extract) ->
              match Pack.unpack loc s.global provable_f2 re with
-             | Some unpackable ->
-               let pname = Req.get_name (fst re) in
-               (keep, (i, pname, unpackable) :: unpack, extract)
+             | Some unpackable -> (keep, (i, re, unpackable) :: unpack, extract)
              | None ->
                let re_reduced, extracted =
                  Pack.extractable_multiple provable_m movable_indices re
@@ -687,7 +686,8 @@ let do_unfold_resources loc =
       in
       let@ () = set_typing_context { s with resources = (keep, orig_ix) } in
       let do_unpack = function
-        | _i, pname, `LRT lrt ->
+        | _i, re, `LRT lrt ->
+          let pname = Req.get_name (fst re) in
           let@ _, members =
             make_return_record
               loc
@@ -697,22 +697,38 @@ let do_unfold_resources loc =
               (LogicalReturnTypes.binders lrt)
           in
           bind_logical_return_internal loc members lrt
-        | _i, pname, `RES res ->
+        | _i, re, `RES res ->
+          let pname = Req.get_name (fst re) in
           let is_owned = match pname with Owned _ -> true | _ -> false in
           iterM (add_r_internal ~derive_constraints:(not is_owned) loc) res
       in
       let@ () = iterM do_unpack unpack in
       let@ () = iterM (add_r_internal loc) extract in
-      (match (unpack, extract) with [], [] -> return changed | _ -> aux true)
+      (match (unpack, extract) with
+       | [], [] -> return changed
+       | _ ->
+         let converted_unpack =
+           List.map
+             (fun (i, re, unpackable) ->
+                match unpackable with
+                | `LRT lrt -> (i, re, UnpackLRT lrt)
+                | `RES res -> (i, re, UnpackRES res))
+             unpack
+         in
+         aux ((converted_unpack, extract) :: changed))
   in
   let@ c = get_typing_context () in
-  let@ changed = aux false in
+  let@ changed = aux [] in
   let@ () = modify (fun s -> { s with unfold_resources_required = false }) in
-  if changed then
+  match changed with
+  | [] -> return ()
+  | _ ->
     let@ c' = get_typing_context () in
-    return (Prooflog.record_resource_inference_step c c' (UnfoldResources loc))
-  else
-    return ()
+    return
+      (Prooflog.record_resource_inference_step
+         c
+         c'
+         (UnfoldResources (loc, List.rev changed)))
 
 
 let sync_unfold_resources loc =

--- a/tests/cn/reverse.error.c.verify
+++ b/tests/cn/reverse.error.c.verify
@@ -13,5 +13,5 @@ tests/cn/reverse.error.c:124:3: error: Missing resource for de-allocating
   ^~~~~~~~~ 
 Resource needed: W<struct node>(&n3)
   which requires: W<signed int>(&&n3->head)
-      other location (File "lib/resourceInference.ml", line 220, characters 31-38)  (arg head)
+      other location (File "lib/resourceInference.ml", line 221, characters 31-38)  (arg head)
 State file: file:///tmp/state__reverse.error.c__main.html

--- a/tests/cn/reverse.error.c.verify
+++ b/tests/cn/reverse.error.c.verify
@@ -13,5 +13,5 @@ tests/cn/reverse.error.c:124:3: error: Missing resource for de-allocating
   ^~~~~~~~~ 
 Resource needed: W<struct node>(&n3)
   which requires: W<signed int>(&&n3->head)
-      other location (File "lib/resourceInference.ml", line 221, characters 31-38)  (arg head)
+      other location (File "lib/resourceInference.ml", line 220, characters 31-38)  (arg head)
 State file: file:///tmp/state__reverse.error.c__main.html

--- a/tests/run-cn-coq.sh
+++ b/tests/run-cn-coq.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # CI test for CN Coq extraction.
-# OPAM package `cn-coq` must be installed.
+# If running without -d flag, OPAM package `cn-coq` must be installed.
+# If running with -d flag, it must be run from the root of the Cn repository.
 
 set -uo pipefail
-
 
 # List of blacklisted files that are known to run out of memory in Coq.
 # Paths must be relative to the 'tests/cn' directory.
@@ -85,9 +85,9 @@ PASSED_COUNT=0
 FAILED_COUNT=0
 
 if [ ${USE_DUNE} -eq 1 ]; then
-    CN=(${WITH_CN:=dune exec cn --})
+    CN=(${WITH_CN:=dune exec -p cn,cn-coq cn --})
     unset CERB_INSTALL_PREFIX
-    COQ_CN_THEORIES_DIR="$(realpath "../_build/default/coq")"
+    COQ_CN_THEORIES_DIR="$(realpath "_build/default/coq")"
     COQ_MAKEFILE_FLAGS="-R . Top -R ${COQ_CN_THEORIES_DIR}/Cerberus/ Cerberus -R ${COQ_CN_THEORIES_DIR}/Cn/ Cn -R ${COQ_CN_THEORIES_DIR}/Reasoning/ Reasoning"
 else
     CN=(cn)

--- a/tests/run-cn-coq.sh
+++ b/tests/run-cn-coq.sh
@@ -16,6 +16,7 @@ BLACKLISTED_FILES=(
     mergesort.c
     mergesort_alt.c
     mutual_rec/mutual_rec2.c
+    mutual_rec/mutual_rec3.c    
 )
 
 # Parse command line options


### PR DESCRIPTION
Further work on resource inference proofs.

1. Added hints logging to unfolding and predicted request calls
2. Adjusted correctness predicates formulation
3. Proof automation
4. Proved previously admitted decidable equality for all types

(this is a milestone, not the final result)

