### PR TITLE
[CN-exec] Differentiate between for and while loops

### DIFF
--- a/cn.opam
+++ b/cn.opam
@@ -23,7 +23,7 @@ depends: [
   "zarith" {>= "1.13"}
 ]
 pin-depends: [
-  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#482e660"]
+  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#ef237b3"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/cStatements.ml
+++ b/lib/cStatements.ml
@@ -31,7 +31,7 @@ end
 
 module LocMap = Map.Make (LocCompare)
 
-let stmt_loc = function AnnotatedStatement (loc, _, _) -> loc
+let stmt_loc = function { loc; _ } -> loc
 
 let expr_loc = function AnnotatedExpression (_, _, loc, _) -> loc
 
@@ -88,7 +88,7 @@ let add_map_stmt (stmt : 'a statement) m =
   let rec f stmts m =
     match stmts with
     | [] -> m
-    | AnnotatedStatement (l, _, x) :: ss ->
+    | { loc = l; is_forloop; attrs; node = x } :: ss ->
       let m = map l m l in
       (match x with
        | AilSblock (_, ss2) -> f (ss2 @ ss) m

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -1306,9 +1306,12 @@ let rec cn_to_ail_expr_aux
                  let ail_case =
                    A.(AilScase (Nat_big_num.zero (* placeholder *), mk_stmt stat_block))
                  in
-                 A.(
-                   AnnotatedStatement
-                     (Cerb_location.unknown, CF.Annot.Attrs [ attribute ], ail_case))
+                 A.
+                   { loc = Cerb_location.unknown;
+                     is_forloop = false;
+                     attrs = CF.Annot.Attrs [ attribute ];
+                     node = ail_case
+                   }
                in
                let e1_transformed = transform_switch_expr e1 in
                let ail_case_stmts = List.map build_case dt.cn_dt_cases in
@@ -1681,7 +1684,12 @@ let generate_datatype_equality_function (cn_datatype : _ cn_datatype)
     let ail_case =
       A.(AilScase (Nat_big_num.zero, mk_stmt (AilSblock (bs, ss @ [ return_stat ]))))
     in
-    A.(AnnotatedStatement (Cerb_location.unknown, CF.Annot.Attrs [ attribute ], ail_case))
+    A.
+      { loc = Cerb_location.unknown;
+        is_forloop = false;
+        attrs = CF.Annot.Attrs [ attribute ];
+        node = ail_case
+      }
   in
   let switch_stmt =
     A.(
@@ -1784,9 +1792,12 @@ let generate_datatype_default_function (cn_datatype : _ cn_datatype) =
               (mk_expr (AilEmemberofptr (res_ident, Id.make here "tag")), enum_ident))))
   in
   let res_tag_assign_stat =
-    A.(
-      AnnotatedStatement
-        (Cerb_location.unknown, CF.Annot.Attrs [ attribute ], res_tag_assign))
+    A.
+      { loc = Cerb_location.unknown;
+        is_forloop = false;
+        attrs = CF.Annot.Attrs [ attribute ];
+        node = res_tag_assign
+      }
   in
   let lc_constr_sym = generate_sym_with_suffix ~suffix:"" ~lowercase:true constructor in
   let res_u = A.(AilEmemberofptr (res_ident, Id.make here "u")) in

--- a/lib/fulminate/executable_spec_utils.ml
+++ b/lib/fulminate/executable_spec_utils.ml
@@ -33,11 +33,18 @@ let mk_cn_expr cn_expr_ = Cn.CNExpr (Cerb_location.unknown, cn_expr_)
 
 let rm_cn_expr (Cn.CNExpr (_, cn_expr_)) = cn_expr_
 
-let mk_stmt stmt_ = A.AnnotatedStatement (Cerb_location.unknown, CF.Annot.Attrs [], stmt_)
+let mk_stmt stmt_ =
+  A.
+    { loc = Cerb_location.unknown;
+      is_forloop = false;
+      attrs = CF.Annot.Attrs [];
+      node = stmt_
+    }
+
 
 let rm_expr (A.AnnotatedExpression (_, _, _, expr_)) = expr_
 
-let rm_stmt (A.AnnotatedStatement (_, _, stmt_)) = stmt_
+let rm_stmt = function A.{ loc; is_forloop; attrs; node = stmt_ } -> stmt_
 
 let empty_ail_str = "empty_ail"
 

--- a/lib/fulminate/source_injection.ml
+++ b/lib/fulminate/source_injection.ml
@@ -328,7 +328,7 @@ let in_stmt_injs xs num_headers =
 (* (List.filter (fun (loc, _) -> Cerb_location.from_main_file loc) xs) *)
 
 (* build the injections for the pre/post conditions of a C function *)
-let pre_post_injs pre_post is_void is_main (A.AnnotatedStatement (loc, _, _)) =
+let pre_post_injs pre_post is_void is_main A.{ loc; _ } =
   let* pre_pos, post_pos =
     let* pre_pos, post_pos = Pos.of_location loc in
     let* pre_pos = Pos.offset_col ~off:1 pre_pos in


### PR DESCRIPTION
Use new information passed through Cerberus (commit [#ef237b3](https://github.com/rems-project/cerberus/commit/ef237b32cca2adac5762f9d9ad7b71c0361e4518) to differentiate between for and while loops. Fixes [`init_array.c`](https://github.com/rems-project/cn-tutorial/blob/main/src/examples/init_array.c) and related examples in CN tutorial.