### PR TITLE
Add README details for opam installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ and its dependencies.
    opam init --yes --compiler=5.2.0
    ````
 
+   Make sure you follow the instructions provided at the end of the output of `opam init` to complete the initialisation. Typically, on Unix, this is:
+
+   ```
+   eval $(opam env)
+   ```
+
 4. Clone the CN repo:
    ```
    git clone https://github.com/rems-project/cn.git


### PR DESCRIPTION
For OCaml noobs like me that didn't see / follow the instructions provided at the end of the output of 'opam init'.

I spent a good 15 minutes trying to figure out why I couldn't get `make install` to recognize `dune`. I'm hoping this saves someone else that time.