### PR TITLE
Fix warnings when testing

### DIFF
--- a/lib/testGeneration/buildScript.ml
+++ b/lib/testGeneration/buildScript.ml
@@ -46,7 +46,7 @@ let attempt cmd success failure =
 
 
 let cc_flags () =
-  [ "-g"; "\"-I${RUNTIME_PREFIX}/include/\"" ]
+  [ "-g"; "\"-I${RUNTIME_PREFIX}/include/\""; "${CFLAGS}"; "${CPPFLAGS}" ]
   @ (let sanitize, no_sanitize = Config.has_sanitizers () in
      (match sanitize with Some sanitize -> [ "-fsanitize=" ^ sanitize ] | None -> [])
      @

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -504,7 +504,7 @@ CN_GEN_PTR_CASTS_UNSIGNED(uint32_t, cn_bits_u32)
 CN_GEN_PTR_CASTS_UNSIGNED(uint64_t, cn_bits_u64)
 CN_GEN_PTR_CASTS_SIGNED(signed long, cn_integer)
 
-cn_pointer *convert_to_cn_pointer(void *ptr);
+cn_pointer *convert_to_cn_pointer(const void *ptr);
 void *convert_from_cn_pointer(cn_pointer *cn_ptr);
 cn_pointer *cn_pointer_add(cn_pointer *ptr, cn_integer *i);
 cn_pointer *cast_cn_pointer_to_cn_pointer(cn_pointer *p);

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -147,7 +147,7 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
       if (trap) {                                                                        \
         cn_trap();                                                                       \
       }                                                                                  \
-      Name(__VA_ARGS__);                                                                 \
+      (void)Name(__VA_ARGS__);                                                           \
       if (replay) {                                                                      \
         return CN_TEST_PASS;                                                             \
       }                                                                                  \

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -498,9 +498,9 @@ cn_bool* cn_map_equality(
       cn_map_subset(m2, m1, value_equality_fun));
 }
 
-cn_pointer* convert_to_cn_pointer(void* ptr) {
+cn_pointer* convert_to_cn_pointer(const void* ptr) {
   cn_pointer* res = (cn_pointer*)cn_bump_malloc(sizeof(cn_pointer));
-  res->ptr = ptr;  // Carries around an address
+  res->ptr = (void*)ptr;  // Carries around an address
   return res;
 }
 

--- a/tests/cn-test-gen/run-single-test.sh
+++ b/tests/cn-test-gen/run-single-test.sh
@@ -14,6 +14,9 @@ else
 fi
 rm -rf $DIR
 
+# For stricter CI
+export CPPFLAGS="${CPPFLAGS} -Werror"
+
 # For UBSan
 export UBSAN_OPTIONS=halt_on_error=1
 

--- a/tests/cn-test-gen/src/mkm.pass.c
+++ b/tests/cn-test-gen/src/mkm.pass.c
@@ -550,7 +550,6 @@ ensures take Client_out = OptionClientNew(return, fd, CS_RECV_KEY_ID);
 {
   struct client *c = cn_malloc(sizeof(struct client));
   if (c == ((void *)0)) {
-    0;
     return ((void *)0);
   }
   /*@ from_bytes Block<struct client>(c); @*/
@@ -570,13 +569,11 @@ requires take Client_in = ClientObject(c);
 {
   int ret = 0;
   if (ret != 0) {
-    0;
     // Keep going.  Even if TCP shutdown fails, we still need to close the
     // file descriptor.
   }
   ret = 0;
   if (ret != 0) {
-    0;
     // Keep going.  On Linux, `close` always closes the file descriptor,
     // but may report I/O errors afterward.
   }
@@ -724,7 +721,6 @@ ensures
   /*@ apply UnViewShift_Owned_u8(buf, buf + pos, pos, buf_size - pos ); @*/
   /*@ apply UnSplitAt_Owned_u8(buf, buf_size, pos, buf_size - pos ); @*/
   if (ret < 0) {
-    0;
     return RES_ERROR;
   } else if (ret == 0) {
     return RES_EOF;
@@ -763,7 +759,6 @@ ensures
   /*@ apply UnViewShift_Owned_u8(buf, buf + pos, pos, buf_size - pos ); @*/
   /*@ apply UnSplitAt_Owned_u8(buf, buf_size, pos, buf_size - pos ); @*/
   if (ret < 0) {
-    0;
     return RES_ERROR;
   } else if (ret == 0) {
     return RES_EOF;


### PR DESCRIPTION
1. Accept `const void*` to `convert_to_cn_pointer`. This eliminates most of the remaining warnings and I don't see a way around it.
2. Discard unused returns, which avoids a warning when testing pure functions. This is fine, as Fulminate tests the return value before the functions return.
3. Use `CPPFLAGS` to set `-Werror` for CI