### PR TITLE
Skew integer distribution to include extremes

### DIFF
--- a/runtime/libcn/include/cn-testing/dsl.h
+++ b/runtime/libcn/include/cn-testing/dsl.h
@@ -32,7 +32,7 @@
     goto cn_label_bennet_backtrack;                                                      \
   }
 
-#define CN_GEN_UNIFORM(ty) cn_gen_uniform_##ty(cn_gen_get_size())
+#define CN_GEN_UNIFORM(ty) cn_gen_uniform_##ty(0)
 
 #define CN_GEN_ALLOC(sz)                                                                 \
   ({                                                                                     \

--- a/runtime/libcn/include/cn-testing/rand.h
+++ b/runtime/libcn/include/cn-testing/rand.h
@@ -21,6 +21,16 @@ int16_t cn_gen_uniform_i16(uint16_t);
 int32_t cn_gen_uniform_i32(uint32_t);
 int64_t cn_gen_uniform_i64(uint64_t);
 
+uint8_t cn_gen_uniform_u8_sized(uint8_t);
+uint16_t cn_gen_uniform_u16_sized(uint16_t);
+uint32_t cn_gen_uniform_u32_sized(uint32_t);
+uint64_t cn_gen_uniform_u64_sized(uint64_t);
+
+int8_t cn_gen_uniform_i8_sized(uint8_t);
+int16_t cn_gen_uniform_i16_sized(uint16_t);
+int32_t cn_gen_uniform_i32_sized(uint32_t);
+int64_t cn_gen_uniform_i64_sized(uint64_t);
+
 uint8_t cn_gen_range_u8(uint8_t, uint8_t);
 uint16_t cn_gen_range_u16(uint16_t, uint16_t);
 uint32_t cn_gen_range_u32(uint32_t, uint32_t);

--- a/runtime/libcn/src/cn-testing/rand.c
+++ b/runtime/libcn/src/cn-testing/rand.c
@@ -153,17 +153,40 @@ SIGNED_GEN(64);
 #define SIZED_GEN(sm)                                                                    \
   uint##sm##_t cn_gen_uniform_u##sm##_sized(uint##sm##_t s) {                            \
     size_t sz = cn_gen_get_size();                                                       \
-    if (s > sz) {                                                                        \
-      s = sz;                                                                            \
+    if (s != 0 && s < sz) {                                                              \
+      sz = s;                                                                            \
     }                                                                                    \
-    return cn_gen_uniform_u##sm(s);                                                      \
+                                                                                         \
+    if (sz <= 8 * sizeof(size_t)) {                                                      \
+      size_t extremes_likelihood = 1 << (sz / 2 + 1);                                    \
+      if (!cn_gen_uniform_u64(extremes_likelihood)) {                                    \
+        return (s == 0) ? UINT##sm##_MAX : (s - 1);                                      \
+      }                                                                                  \
+    }                                                                                    \
+                                                                                         \
+    return cn_gen_uniform_u##sm(sz);                                                     \
   }                                                                                      \
   int##sm##_t cn_gen_uniform_i##sm##_sized(uint##sm##_t s) {                             \
     size_t sz = cn_gen_get_size();                                                       \
-    if (s > sz) {                                                                        \
-      s = sz;                                                                            \
+    if (s != 0 && s < sz) {                                                              \
+      sz = s;                                                                            \
     }                                                                                    \
-    return cn_gen_uniform_i##sm(s);                                                      \
+                                                                                         \
+    if (sz <= 8 * sizeof(size_t)) {                                                      \
+      size_t extremes_likelihood = 1 << (sz / 2 + 1);                                    \
+      if (!cn_gen_uniform_u64(extremes_likelihood)) {                                    \
+        switch (cn_gen_uniform_u8(2)) {                                                  \
+          case 0:                                                                        \
+            return (s == 0) ? INT##sm##_MIN : -(s - 1);                                  \
+          case 1:                                                                        \
+            return (s == 0) ? INT##sm##_MAX : (s - 1);                                   \
+          default:                                                                       \
+            assert(0);                                                                   \
+        }                                                                                \
+      }                                                                                  \
+    }                                                                                    \
+                                                                                         \
+    return cn_gen_uniform_i##sm(sz);                                                     \
   }
 
 SIZED_GEN(8);

--- a/runtime/libcn/src/cn-testing/rand.c
+++ b/runtime/libcn/src/cn-testing/rand.c
@@ -158,7 +158,7 @@ SIGNED_GEN(64);
     }                                                                                    \
     return cn_gen_uniform_u##sm(s);                                                      \
   }                                                                                      \
-  int##sm##_t cn_gen_uniform_i##sm##_sized(int##sm##_t s) {                              \
+  int##sm##_t cn_gen_uniform_i##sm##_sized(uint##sm##_t s) {                             \
     size_t sz = cn_gen_get_size();                                                       \
     if (s > sz) {                                                                        \
       s = sz;                                                                            \

--- a/runtime/libcn/src/cn-testing/uniform.c
+++ b/runtime/libcn/src/cn-testing/uniform.c
@@ -6,11 +6,11 @@
 
 #define BITS_GEN(sm)                                                                     \
   cn_bits_u##sm* cn_gen_uniform_cn_bits_u##sm(uint64_t sz) {                             \
-    return convert_to_cn_bits_u##sm(cn_gen_uniform_u##sm(sz));                           \
+    return convert_to_cn_bits_u##sm(cn_gen_uniform_u##sm##_sized(sz));                   \
   }                                                                                      \
                                                                                          \
   cn_bits_i##sm* cn_gen_uniform_cn_bits_i##sm(uint64_t sz) {                             \
-    return convert_to_cn_bits_i##sm(cn_gen_uniform_i##sm(sz));                           \
+    return convert_to_cn_bits_i##sm(cn_gen_uniform_i##sm##_sized(sz));                   \
   }
 
 BITS_GEN(8);

--- a/tests/cn-test-gen/src/list_seg.pass.c
+++ b/tests/cn-test-gen/src/list_seg.pass.c
@@ -1,13 +1,12 @@
-struct List
-{
-    int value;
-    struct List* next;
+struct List {
+  unsigned int value;
+  struct List *next;
 };
 
 /*@
 datatype IntList {
   Nil {},
-  Cons { i32 head, IntList tail }
+  Cons { u32 head, IntList tail }
 }
 
 predicate IntList ListSegment(pointer from, pointer to) {
@@ -21,7 +20,7 @@ predicate IntList ListSegment(pointer from, pointer to) {
 }
 @*/
 
-int sum(struct List* xs)
+unsigned int sum(struct List *xs)
 /*@
   requires
     take l1 = ListSegment(xs,NULL);
@@ -30,10 +29,10 @@ int sum(struct List* xs)
     l1 == l2;
 @*/
 {
-    int result = 0;
-    while (xs) {
-        result += xs->value;
-        xs = xs->next;
-    }
-    return result;
+  unsigned int result = 0;
+  while (xs) {
+    result += xs->value;
+    xs = xs->next;
+  }
+  return result;
 }

--- a/tests/cn-test-gen/src/sorted_list.sum.pass.c
+++ b/tests/cn-test-gen/src/sorted_list.sum.pass.c
@@ -1,18 +1,17 @@
 // Sorted list
 
-struct List
-{
-  int value;
-  struct List* next;
+struct List {
+  unsigned int value;
+  struct List *next;
 };
 
 /*@
 datatype IntList {
   Nil {},
-  Cons { i32 head, IntList tail }
+  Cons { u32 head, IntList tail }
 }
 
-function (boolean) validCons(i32 head, IntList tail) {
+function (boolean) validCons(u32 head, IntList tail) {
   match tail {
     Nil {} => { true }
     Cons { head: next, tail: _ } => { head <= next }
@@ -31,9 +30,9 @@ predicate IntList ListSegment(pointer from, pointer to) {
 }
 @*/
 
-
-// This is a valid spec, even though to verify with CN we'd need a loop invariant.
-int sum(struct List* xs)
+// This is a valid spec, even though to verify with CN we'd need a loop
+// invariant.
+unsigned int sum(struct List *xs)
 /*@
   requires
     take l1 = ListSegment(xs,NULL);
@@ -43,8 +42,8 @@ int sum(struct List* xs)
     true;
 @*/
 {
-  int result = 0;
-  while(xs) {
+  unsigned int result = 0;
+  while (xs) {
     result += xs->value;
     xs = xs->next;
   }

--- a/tests/cn-test-gen/src/sorted_list_alt2.pass.c
+++ b/tests/cn-test-gen/src/sorted_list_alt2.pass.c
@@ -1,15 +1,15 @@
 struct List {
-  int value;
+  unsigned int value;
   struct List *next;
 };
 
 /*@
 datatype IntList {
   Nil {},
-  Cons { i32 head, IntList tail }
+  Cons { u32 head, IntList tail }
 }
 
-function (boolean) validCons(i32 head, IntList tail) {
+function (boolean) validCons(u32 head, IntList tail) {
   match tail {
     Nil {} => { true }
     Cons { head: next, tail: _ } => { head <= next }
@@ -17,14 +17,14 @@ function (boolean) validCons(i32 head, IntList tail) {
 }
 
 datatype I32Option {
-  SomeI32 { i32 data },
+  SomeI32 { u32 data },
   NoneI32 {}
 }
 
-function (i32) getSome(datatype I32Option opt) {
+function (u32) getSome(datatype I32Option opt) {
   match (opt) {
     SomeI32 { data: data } => { data }
-    NoneI32 {} => { default<i32> }
+    NoneI32 {} => { default<u32> }
   }
 }
 
@@ -52,7 +52,7 @@ predicate IntList ListSegment(pointer from, pointer to) {
 }
 @*/
 
-int sum(struct List *xs)
+unsigned int sum(struct List *xs)
 /*@
   requires
     take l1 = ListSegment(xs,NULL);
@@ -62,7 +62,7 @@ int sum(struct List *xs)
     true;
 @*/
 {
-  int result = 0;
+  unsigned int result = 0;
   while (xs) {
     result += xs->value;
     xs = xs->next;
@@ -74,7 +74,7 @@ void *cn_malloc(unsigned long size);
 void cn_free_sized(void *p, unsigned long size);
 
 /*@
-function [rec] (IntList) insertList(boolean dups, i32 x, IntList xs) {
+function [rec] (IntList) insertList(boolean dups, u32 x, IntList xs) {
   match xs {
     Nil {} => { Cons { head: x, tail: Nil {} } }
     Cons { head: head, tail: tail } => {
@@ -92,7 +92,7 @@ function [rec] (IntList) insertList(boolean dups, i32 x, IntList xs) {
 }
 @*/
 
-void insert(int x, struct List **xs)
+void insert(unsigned int x, struct List **xs)
 /*@
   requires
     take list_ptr = Owned<struct List*>(xs);

--- a/tests/cn-test-gen/src/sorted_list_alt3.pass.c
+++ b/tests/cn-test-gen/src/sorted_list_alt3.pass.c
@@ -1,23 +1,22 @@
-struct List
-{
-  int value;
-  struct List* next;
+struct List {
+  unsigned int value;
+  struct List *next;
 };
 
 /*@
 datatype IntList {
   Nil {},
-  Cons { i32 head, IntList tail }
+  Cons { u32 head, IntList tail }
 }
 
-function (boolean) validCons(i32 head, IntList tail) {
+function (boolean) validCons(u32 head, IntList tail) {
   match tail {
     Nil {} => { true }
     Cons { head: next, tail: _ } => { head <= next }
   }
 }
 
-predicate IntList ListSegmentAux(pointer from, pointer to, i32 prev) {
+predicate IntList ListSegmentAux(pointer from, pointer to, u32 prev) {
   if (ptr_eq(from,to)) {
     return Nil {};
   } else {
@@ -39,7 +38,7 @@ predicate IntList ListSegment(pointer from, pointer to) {
 }
 @*/
 
-int sum(struct List* xs)
+unsigned int sum(struct List *xs)
 /*@
   requires
     take l1 = ListSegment(xs,NULL);
@@ -49,8 +48,8 @@ int sum(struct List* xs)
     true;
 @*/
 {
-  int result = 0;
-  while(xs) {
+  unsigned int result = 0;
+  while (xs) {
     result += xs->value;
     xs = xs->next;
   }
@@ -60,7 +59,7 @@ int sum(struct List* xs)
 void *cn_malloc(unsigned long size);
 
 /*@
-function [rec] (IntList) insertList(boolean dups, i32 x, IntList xs) {
+function [rec] (IntList) insertList(boolean dups, u32 x, IntList xs) {
   match xs {
     Nil {} => { Cons { head: x, tail: Nil {} } }
     Cons { head: head, tail: tail } => {
@@ -78,7 +77,7 @@ function [rec] (IntList) insertList(boolean dups, i32 x, IntList xs) {
 }
 @*/
 
-void insert(int x, struct List **xs)
+void insert(unsigned int x, struct List **xs)
 /*@
   requires
     take list_ptr = Owned<struct List*>(xs);
@@ -89,11 +88,11 @@ void insert(int x, struct List **xs)
     new_list == insertList(true,x,list);
 @*/
 {
-  struct List *node = (struct List*) cn_malloc(sizeof(struct List));
+  struct List *node = (struct List *)cn_malloc(sizeof(struct List));
   node->value = x;
 
-  struct List* prev = 0;
-  struct List* cur = *xs;
+  struct List *prev = 0;
+  struct List *cur = *xs;
   while (cur && cur->value < x) {
     prev = cur;
     cur = cur->next;


### PR DESCRIPTION
It still isn't that reliable at catching bugs, though.

Could either fiddle with the distribution a bit more, or consider a more principled approach for extreme/boundary values.