### PR TITLE
Added a switch to 'cn test' to produce output in Tyche format.

### DIFF
--- a/bin/test.ml
+++ b/bin/test.ml
@@ -426,11 +426,13 @@ module Flags = struct
     let doc = "Disable synthesizing C code to replicate bugs" in
     Arg.(value & flag & info [ "no-replicas" ] ~doc)
 
+
   let output_tyche =
     let doc = "Enable output in Tyche format" in
-    Arg.(value
-        & opt (some string) TestGeneration.default_cfg.output_tyche
-        & info [ "output-tyche" ] ~doc)
+    Arg.(
+      value
+      & opt (some string) TestGeneration.default_cfg.output_tyche
+      & info [ "output-tyche" ] ~doc)
 end
 
 let cmd =

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -52,6 +52,7 @@ let run_tests
       trap
       no_replays
       no_replicas
+      output_tyche
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
@@ -110,7 +111,8 @@ let run_tests
           disable_passes;
           trap;
           no_replays;
-          no_replicas
+          no_replicas;
+          output_tyche
         }
       in
       TestGeneration.set_config config;
@@ -423,6 +425,12 @@ module Flags = struct
   let no_replicas =
     let doc = "Disable synthesizing C code to replicate bugs" in
     Arg.(value & flag & info [ "no-replicas" ] ~doc)
+
+  let output_tyche =
+    let doc = "Enable output in Tyche format" in
+    Arg.(value
+        & opt (some string) TestGeneration.default_cfg.output_tyche
+        & info [ "output-tyche" ] ~doc)
 end
 
 let cmd =
@@ -474,6 +482,7 @@ let cmd =
     $ Flags.trap
     $ Flags.no_replays
     $ Flags.no_replicas
+    $ Flags.output_tyche
   in
   let doc =
     "Generates tests for all functions in [FILE] with CN specifications.\n\

--- a/lib/testGeneration/buildScript.ml
+++ b/lib/testGeneration/buildScript.ml
@@ -219,13 +219,14 @@ let run () =
           else
             [])
        @ (if Config.has_no_replicas () then
-         [ "--no-replicas" ]
-       else
-         [])
-       @ (match Config.get_output_tyche () with
+            [ "--no-replicas" ]
+          else
+            [])
+       @
+       match Config.get_output_tyche () with
        | Some file -> [ "--output-tyche"; file ]
-       | None -> []))
-    in
+       | None -> [])
+  in
   string "# Run"
   ^^ hardline
   ^^ (if Config.is_print_steps () then

--- a/lib/testGeneration/buildScript.ml
+++ b/lib/testGeneration/buildScript.ml
@@ -218,12 +218,14 @@ let run () =
             [ "--no-replays" ]
           else
             [])
-       @
-       if Config.has_no_replicas () then
+       @ (if Config.has_no_replicas () then
          [ "--no-replicas" ]
        else
          [])
-  in
+       @ (match Config.get_output_tyche () with
+       | Some file -> [ "--output-tyche"; file ]
+       | None -> []))
+    in
   string "# Run"
   ^^ hardline
   ^^ (if Config.is_print_steps () then

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -52,7 +52,7 @@ type t =
     trap : bool;
     no_replays : bool;
     no_replicas : bool;
-    output_tyche : string option;
+    output_tyche : string option
   }
 
 let default =
@@ -85,7 +85,7 @@ let default =
     trap = false;
     no_replays = false;
     no_replicas = false;
-    output_tyche = Option.None;
+    output_tyche = Option.None
   }
 
 
@@ -210,4 +210,4 @@ let has_no_replays () = !instance.no_replays
 
 let has_no_replicas () = !instance.no_replicas
 
-let get_output_tyche () = !instance.output_tyche 
+let get_output_tyche () = !instance.output_tyche

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -51,7 +51,8 @@ type t =
     disable_passes : string list;
     trap : bool;
     no_replays : bool;
-    no_replicas : bool
+    no_replicas : bool;
+    output_tyche : string option;
   }
 
 let default =
@@ -83,7 +84,8 @@ let default =
     disable_passes = [];
     trap = false;
     no_replays = false;
-    no_replicas = false
+    no_replicas = false;
+    output_tyche = Option.None;
   }
 
 
@@ -207,3 +209,5 @@ let is_trap () = !instance.trap
 let has_no_replays () = !instance.no_replays
 
 let has_no_replicas () = !instance.no_replicas
+
+let get_output_tyche () = !instance.output_tyche 

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -52,7 +52,7 @@ type t =
     trap : bool;
     no_replays : bool;
     no_replicas : bool;
-    output_tyche : string option;
+    output_tyche : string option
   }
 
 val default : t

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -51,7 +51,8 @@ type t =
     disable_passes : string list;
     trap : bool;
     no_replays : bool;
-    no_replicas : bool
+    no_replicas : bool;
+    output_tyche : string option;
   }
 
 val default : t
@@ -135,3 +136,5 @@ val is_trap : unit -> bool
 val has_no_replays : unit -> bool
 
 val has_no_replicas : unit -> bool
+
+val get_output_tyche : unit -> string option

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -566,8 +566,8 @@ static inline void cn_load(void *ptr, size_t size) {
 static inline void cn_store(void *ptr, size_t size) {
   //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mSTORE\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
-static inline void cn_postfix(void *ptr, size_t size) {
-  //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
+static inline void cn_postfix(void *ptr, size_t size){
+    //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
 
 // use this macro to wrap an argument to another macro that contains commas

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -566,8 +566,8 @@ static inline void cn_load(void *ptr, size_t size) {
 static inline void cn_store(void *ptr, size_t size) {
   //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mSTORE\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
-static inline void cn_postfix(void *ptr, size_t size){
-    //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
+static inline void cn_postfix(void *ptr, size_t size) {
+  //   cn_printf(CN_LOGGING_INFO, "  \x1b[31mPOSTFIX\x1b[0m[%lu] - ptr: %p\n", size, ptr);
 }
 
 // use this macro to wrap an argument to another macro that contains commas

--- a/runtime/libcn/include/cn-replicate/lines.h
+++ b/runtime/libcn/include/cn-replicate/lines.h
@@ -8,6 +8,8 @@ extern "C" {
 void cn_replica_lines_append(char* line);
 void cn_replica_lines_reset();
 char* cn_replica_lines_to_str();
+char* cn_replica_lines_to_json_literal();
+void print_test_summary_tyche(FILE *out, char *test_suite, char *test_name, char *status, uint64_t suite_begin_time, char *representation, int64_t init_time, int64_t runtime);
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/cn-replicate/lines.h
+++ b/runtime/libcn/include/cn-replicate/lines.h
@@ -5,11 +5,25 @@
 extern "C" {
 #endif
 
-void cn_replica_lines_append(char* line);
+#include <inttypes.h>
+#include <stdio.h>
+
+void cn_replica_lines_append(char *line);
 void cn_replica_lines_reset();
-char* cn_replica_lines_to_str();
-char* cn_replica_lines_to_json_literal();
-void print_test_summary_tyche(FILE *out, char *test_suite, char *test_name, char *status, uint64_t suite_begin_time, char *representation, int64_t init_time, int64_t runtime);
+char *cn_replica_lines_to_str();
+char *cn_replica_lines_to_json_literal();
+
+struct tyche_line_info {
+  char *test_suite;
+  char *test_name;
+  char *status;
+  uint64_t suite_begin_time;
+  char *representation;
+  int64_t init_time;
+  int64_t runtime;
+};
+
+void print_test_summary_tyche(FILE *out, struct tyche_line_info *line_info);
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/cn-testing/size.h
+++ b/runtime/libcn/include/cn-testing/size.h
@@ -26,3 +26,6 @@ void cn_gen_set_input_timer(uint64_t time);
 uint64_t cn_gen_get_input_timer(void);
 
 uint64_t cn_gen_get_milliseconds(void);
+uint64_t cn_gen_get_microseconds(void);
+
+int64_t timediff_timeval(struct timeval *early, struct timeval *late);

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -3,6 +3,8 @@
 
 #include <setjmp.h>
 #include <stdbool.h>
+#include <time.h>
+#include <sys/time.h>
 
 #include <cn-executable/utils.h>
 #include <cn-testing/result.h>
@@ -22,11 +24,18 @@ enum cn_gen_sizing_strategy {
   CN_GEN_SIZE_QUICKCHECK = 2
 };
 
-typedef enum cn_test_result cn_test_case_fn(bool replay,
-    enum cn_test_gen_progress,
-    enum cn_gen_sizing_strategy,
-    bool trap,
-    bool replicas);
+struct cn_test_input {
+  bool replay;
+  enum cn_test_gen_progress progress_level;
+  enum cn_gen_sizing_strategy sizing_strategy;
+  bool trap;
+  bool replicas;
+  bool output_tyche;
+  FILE *tyche_output_stream;
+  uint64_t begin_time;
+};
+
+typedef enum cn_test_result cn_test_case_fn(struct cn_test_input test_input);
 
 void cn_register_test_case(const char* suite, const char* name, cn_test_case_fn* func);
 
@@ -51,11 +60,7 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
     longjmp(buf_##FuncName, 1);                                                          \
   }                                                                                      \
                                                                                          \
-  enum cn_test_result cn_test_const_##FuncName(bool replay,                              \
-      enum cn_test_gen_progress progress_level,                                          \
-      enum cn_gen_sizing_strategy sizing_strategy,                                       \
-      bool trap,                                                                         \
-      bool replicas) {                                                                   \
+  enum cn_test_result cn_test_const_##FuncName(struct cn_test_input) {                   \
     if (setjmp(buf_##FuncName)) {                                                        \
       return CN_TEST_FAIL;                                                               \
     }                                                                                    \
@@ -77,11 +82,8 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
     longjmp(buf_##Name, mode);                                                           \
   }                                                                                      \
                                                                                          \
-  enum cn_test_result cn_test_gen_##Name(bool replay,                                    \
-      enum cn_test_gen_progress progress_level,                                          \
-      enum cn_gen_sizing_strategy sizing_strategy,                                       \
-      bool trap,                                                                         \
-      bool replicas) {                                                                   \
+  enum cn_test_result cn_test_gen_##Name(struct cn_test_input test_input) {                                                                  \
+    struct timeval start_time_##FuncName, end_time_##FuncName;                           \
     cn_gen_rand_checkpoint checkpoint = cn_gen_rand_save();                              \
     int i = 0, d = 0, recentDiscards = 0;                                                \
     set_cn_failure_cb(&cn_test_gen_##Name##_fail);                                       \
@@ -89,11 +91,16 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
       case CN_FAILURE_ASSERT:                                                            \
       case CN_FAILURE_CHECK_OWNERSHIP:                                                   \
       case CN_FAILURE_OWNERSHIP_LEAK:                                                    \
-        if (progress_level == CN_TEST_GEN_PROGRESS_FINAL) {                              \
+        gettimeofday(&end_time_##FuncName, NULL);                                        \
+        if (test_input.progress_level == CN_TEST_GEN_PROGRESS_FINAL) {                   \
           print_test_info(#Suite, #Name, i, d);                                          \
         }                                                                                \
                                                                                          \
-        if (replicas) {                                                                  \
+        if(test_input.replicas && test_input.output_tyche) {                             \
+          int64_t runtime = timediff_timeval(&start_time_##FuncName, &end_time_##FuncName); \
+          print_test_summary_tyche(test_input.tyche_output_stream, #Suite, #Name, "failed", test_input.begin_time, cn_replica_lines_to_json_literal(), 0, runtime);            \
+        }                                                                                \
+        if (test_input.replicas) {                                                       \
           printf("********************** Failing input ***********************\n\n");    \
           printf("%s", cn_replica_lines_to_str());                                       \
           printf("\n************************************************************\n\n");  \
@@ -106,23 +113,23 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
         break;                                                                           \
     }                                                                                    \
     for (; i < Samples; i++) {                                                           \
-      if (progress_level == CN_TEST_GEN_PROGRESS_ALL) {                                  \
+      if (test_input.progress_level == CN_TEST_GEN_PROGRESS_ALL) {                       \
         printf("\r");                                                                    \
         print_test_info(#Suite, #Name, i, d);                                            \
       }                                                                                  \
       if (d == 10 * Samples) {                                                           \
-        if (progress_level == CN_TEST_GEN_PROGRESS_FINAL) {                              \
+        if (test_input.progress_level == CN_TEST_GEN_PROGRESS_FINAL) {                   \
           print_test_info(#Suite, #Name, i, d);                                          \
         }                                                                                \
         return CN_TEST_GEN_FAIL;                                                         \
       }                                                                                  \
-      if (!replay) {                                                                     \
+      if (!test_input.replay) {                                                          \
         cn_gen_set_size(cn_gen_compute_size(                                             \
-            sizing_strategy, Samples, cn_gen_get_max_size(), 10, i, recentDiscards));    \
+            test_input.sizing_strategy, Samples, cn_gen_get_max_size(), 10, i, recentDiscards));    \
         cn_gen_rand_replace(checkpoint);                                                 \
       }                                                                                  \
       CN_TEST_INIT();                                                                    \
-      if (!replay) {                                                                     \
+      if (!test_input.replay) {                                                          \
         cn_gen_set_input_timer(cn_gen_get_milliseconds());                               \
       } else {                                                                           \
         cn_gen_set_input_timeout(0);                                                     \
@@ -136,26 +143,32 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
       }                                                                                  \
       assume_##Name(__VA_ARGS__);                                                        \
       Init(res);                                                                         \
-      if (replicas) {                                                                    \
+      if (test_input.replicas || test_input.output_tyche) {                              \
         cn_replica_alloc_reset();                                                        \
         cn_replica_lines_reset();                                                        \
                                                                                          \
         cn_analyze_shape_##Name(__VA_ARGS__);                                            \
         cn_replicate_##Name(__VA_ARGS__);                                                \
       }                                                                                  \
-                                                                                         \
-      if (trap) {                                                                        \
+      \
+      if (test_input.trap) {                                                             \
         cn_trap();                                                                       \
       }                                                                                  \
+      gettimeofday(&start_time_##FuncName, NULL);                                        \
       (void)Name(__VA_ARGS__);                                                           \
-      if (replay) {                                                                      \
+      if (test_input.replay) {                                                           \
         return CN_TEST_PASS;                                                             \
       }                                                                                  \
       recentDiscards = 0;                                                                \
+      if(!test_input.replay && test_input.output_tyche) {                                                                   \
+        gettimeofday(&end_time_##FuncName, NULL);                                     \
+        int64_t runtime = timediff_timeval(&start_time_##FuncName, &end_time_##FuncName); \
+        print_test_summary_tyche(test_input.tyche_output_stream, #Suite, #Name, "passed", test_input.begin_time, cn_replica_lines_to_json_literal(), 0, runtime);            \
+      }                                                                                 \
     }                                                                                    \
                                                                                          \
-    if (progress_level != CN_TEST_GEN_PROGRESS_NONE) {                                   \
-      if (progress_level == CN_TEST_GEN_PROGRESS_ALL) {                                  \
+    if (test_input.progress_level != CN_TEST_GEN_PROGRESS_NONE) {                                   \
+      if (test_input.progress_level == CN_TEST_GEN_PROGRESS_ALL) {                                  \
         printf("\r");                                                                    \
       }                                                                                  \
       print_test_info(#Suite, #Name, i, d);                                              \

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -1,10 +1,11 @@
 #ifndef CN_TEST_H
 #define CN_TEST_H
 
+#include <sys/time.h>
+
 #include <setjmp.h>
 #include <stdbool.h>
 #include <time.h>
-#include <sys/time.h>
 
 #include <cn-executable/utils.h>
 #include <cn-testing/result.h>
@@ -31,7 +32,7 @@ struct cn_test_input {
   bool trap;
   bool replicas;
   bool output_tyche;
-  FILE *tyche_output_stream;
+  FILE* tyche_output_stream;
   uint64_t begin_time;
 };
 
@@ -82,7 +83,7 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
     longjmp(buf_##Name, mode);                                                           \
   }                                                                                      \
                                                                                          \
-  enum cn_test_result cn_test_gen_##Name(struct cn_test_input test_input) {                                                                  \
+  enum cn_test_result cn_test_gen_##Name(struct cn_test_input test_input) {              \
     struct timeval start_time_##FuncName, end_time_##FuncName;                           \
     cn_gen_rand_checkpoint checkpoint = cn_gen_rand_save();                              \
     int i = 0, d = 0, recentDiscards = 0;                                                \
@@ -96,9 +97,17 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
           print_test_info(#Suite, #Name, i, d);                                          \
         }                                                                                \
                                                                                          \
-        if(test_input.replicas && test_input.output_tyche) {                             \
-          int64_t runtime = timediff_timeval(&start_time_##FuncName, &end_time_##FuncName); \
-          print_test_summary_tyche(test_input.tyche_output_stream, #Suite, #Name, "failed", test_input.begin_time, cn_replica_lines_to_json_literal(), 0, runtime);            \
+        if (test_input.replicas && test_input.output_tyche) {                            \
+          int64_t runtime =                                                              \
+              timediff_timeval(&start_time_##FuncName, &end_time_##FuncName);            \
+          struct tyche_line_info line_info = {.test_suite = #Suite,                      \
+              .test_name = #Name,                                                        \
+              .status = "failed",                                                        \
+              .suite_begin_time = test_input.begin_time,                                 \
+              .representation = cn_replica_lines_to_json_literal(),                      \
+              .init_time = 0,                                                            \
+              .runtime = runtime};                                                       \
+          print_test_summary_tyche(test_input.tyche_output_stream, &line_info);          \
         }                                                                                \
         if (test_input.replicas) {                                                       \
           printf("********************** Failing input ***********************\n\n");    \
@@ -124,8 +133,12 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
         return CN_TEST_GEN_FAIL;                                                         \
       }                                                                                  \
       if (!test_input.replay) {                                                          \
-        cn_gen_set_size(cn_gen_compute_size(                                             \
-            test_input.sizing_strategy, Samples, cn_gen_get_max_size(), 10, i, recentDiscards));    \
+        cn_gen_set_size(cn_gen_compute_size(test_input.sizing_strategy,                  \
+            Samples,                                                                     \
+            cn_gen_get_max_size(),                                                       \
+            10,                                                                          \
+            i,                                                                           \
+            recentDiscards));                                                            \
         cn_gen_rand_replace(checkpoint);                                                 \
       }                                                                                  \
       CN_TEST_INIT();                                                                    \
@@ -150,7 +163,7 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
         cn_analyze_shape_##Name(__VA_ARGS__);                                            \
         cn_replicate_##Name(__VA_ARGS__);                                                \
       }                                                                                  \
-      \
+                                                                                         \
       if (test_input.trap) {                                                             \
         cn_trap();                                                                       \
       }                                                                                  \
@@ -160,15 +173,23 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
         return CN_TEST_PASS;                                                             \
       }                                                                                  \
       recentDiscards = 0;                                                                \
-      if(!test_input.replay && test_input.output_tyche) {                                                                   \
-        gettimeofday(&end_time_##FuncName, NULL);                                     \
-        int64_t runtime = timediff_timeval(&start_time_##FuncName, &end_time_##FuncName); \
-        print_test_summary_tyche(test_input.tyche_output_stream, #Suite, #Name, "passed", test_input.begin_time, cn_replica_lines_to_json_literal(), 0, runtime);            \
-      }                                                                                 \
+      if (!test_input.replay && test_input.output_tyche) {                               \
+        gettimeofday(&end_time_##FuncName, NULL);                                        \
+        int64_t runtime =                                                                \
+            timediff_timeval(&start_time_##FuncName, &end_time_##FuncName);              \
+        struct tyche_line_info line_info = {.test_suite = #Suite,                        \
+            .test_name = #Name,                                                          \
+            .status = "passed",                                                          \
+            .suite_begin_time = test_input.begin_time,                                   \
+            .representation = cn_replica_lines_to_json_literal(),                        \
+            .init_time = 0,                                                              \
+            .runtime = runtime};                                                         \
+        print_test_summary_tyche(test_input.tyche_output_stream, &line_info);            \
+      }                                                                                  \
     }                                                                                    \
                                                                                          \
-    if (test_input.progress_level != CN_TEST_GEN_PROGRESS_NONE) {                                   \
-      if (test_input.progress_level == CN_TEST_GEN_PROGRESS_ALL) {                                  \
+    if (test_input.progress_level != CN_TEST_GEN_PROGRESS_NONE) {                        \
+      if (test_input.progress_level == CN_TEST_GEN_PROGRESS_ALL) {                       \
         printf("\r");                                                                    \
       }                                                                                  \
       print_test_info(#Suite, #Name, i, d);                                              \

--- a/runtime/libcn/src/cn-replicate/lines.c
+++ b/runtime/libcn/src/cn-replicate/lines.c
@@ -1,3 +1,5 @@
+#include <ctype.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,4 +46,70 @@ char* cn_replica_lines_to_str() {
   }
 
   return res;
+}
+
+char *cn_replica_lines_to_json_literal() {
+  size_t sz = 0;
+  for (int i = 0; i < size; i++) {
+    sz += strlen(lines[i]) + 2;  // +2 for newline
+    for(int j = 0; j < strlen(lines[i]); j++) {
+      char k = lines[i][j];
+      if(k == '\"' || k == '\\' || k == '\b' || k == '\f' || k == '\r' || k == '\t') {
+        sz++;
+      } else if(!isprint(k)) {
+        sz += 5;
+      }
+    }
+  }
+
+  char* res = malloc(sz + 1);
+  for (int i = 0; i < size; i++) {
+    for(int j = 0; j < strlen(lines[i]); j++) {
+      char k = lines[i][j];
+      if(k == '\"') {
+        strlcat(res, "\\\"", sz+1);
+      } else if(k == '\\') {
+        strlcat(res, "\\\\", sz+1);
+      } else if(k == '\b') {
+        strlcat(res, "\\b", sz+1);
+      } else if(k == '\f') {
+        strlcat(res, "\\f", sz+1);
+      } else if(k == '\r') {
+        strlcat(res, "\\r", sz+1);
+      } else if(k == '\t') {
+        strlcat(res, "\\t", sz+1);
+      } else if(!isprint(k)) {
+        snprintf(&res[strlen(res)], 7, "\\u%4x", (int) k);
+      } else {
+        snprintf(&res[strlen(res)], 2, "%c", k);
+      }
+    }
+    strlcat(res, "\\n", sz+1);
+  }
+
+  return res;
+}
+
+// 'djb' string hashing function
+// Source: http://www.cse.yorku.ca/~oz/hash.html
+unsigned long hash(unsigned char *str) {
+  unsigned long hash = 5381;
+  int c;
+
+  while (c = *str++)
+      hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+
+  return hash;
+}
+
+void print_test_summary_tyche(FILE *out, 
+                              char *test_suite,
+                              char *test_name,
+                              char *status,
+                              uint64_t suite_begin_time,
+                              char *representation,
+                              int64_t init_time,
+                              int64_t runtime) {
+  fprintf(out, "\n{ \"type\": \"test_case\", \"property\": \"%s-%s\", \"arguments\": { \"n\": \"%lx\" }, \"run_start\": %.6lf, \"status\": \"%s\", \"status_reason\": \"\", \"representation\": \"%s\", \"features\": {}, \"timing\": { \"execute:test\": %.6lf, \"overall:gc\": 0.0, \"generate:n\": %.6lf }, \"coverage\": {} }\n",
+       test_suite, test_name, hash(representation), suite_begin_time / 1000000.0, status, representation, runtime / 1000000.0, init_time / 1000000.0);  
 }

--- a/runtime/libcn/src/cn-replicate/lines.c
+++ b/runtime/libcn/src/cn-replicate/lines.c
@@ -69,24 +69,24 @@ char *cn_replica_lines_to_json_literal() {
     for (int j = 0; j < strlen(lines[i]); j++) {
       char k = lines[i][j];
       if (k == '\"') {
-        strlcat(res, "\\\"", sz + 1);
+        strncat(res, "\\\"", 3);
       } else if (k == '\\') {
-        strlcat(res, "\\\\", sz + 1);
+        strncat(res, "\\\\", 3);
       } else if (k == '\b') {
-        strlcat(res, "\\b", sz + 1);
+        strncat(res, "\\b", 3);
       } else if (k == '\f') {
-        strlcat(res, "\\f", sz + 1);
+        strncat(res, "\\f", 3);
       } else if (k == '\r') {
-        strlcat(res, "\\r", sz + 1);
+        strncat(res, "\\r", 3);
       } else if (k == '\t') {
-        strlcat(res, "\\t", sz + 1);
+        strncat(res, "\\t", 3);
       } else if (!isprint(k)) {
         snprintf(&res[strlen(res)], 7, "\\u%4x", (int)k);
       } else {
         snprintf(&res[strlen(res)], 2, "%c", k);
       }
     }
-    strlcat(res, "\\n", sz + 1);
+    strncat(res, "\\n", 3);
   }
 
   return res;

--- a/runtime/libcn/src/cn-replicate/lines.c
+++ b/runtime/libcn/src/cn-replicate/lines.c
@@ -1,3 +1,5 @@
+#include "cn-replicate/lines.h"
+
 #include <ctype.h>
 #include <inttypes.h>
 #include <stddef.h>
@@ -7,12 +9,12 @@
 
 static size_t size = 0;
 static size_t capacity = 0;
-static char** lines = NULL;
+static char **lines = NULL;
 
-void cn_replica_lines_append(char* line) {
+void cn_replica_lines_append(char *line) {
   if (size == capacity) {
     capacity = (capacity == 0) ? 8 : 2 * capacity;
-    lines = realloc(lines, capacity * sizeof(char*));
+    lines = realloc(lines, capacity * sizeof(char *));
     if (lines == NULL) {
       fprintf(stderr, "Failed to expand reproduction array\n");
       abort();
@@ -33,13 +35,13 @@ void cn_replica_lines_reset() {
   capacity = 0;
 }
 
-char* cn_replica_lines_to_str() {
+char *cn_replica_lines_to_str() {
   size_t sz = 0;
   for (int i = 0; i < size; i++) {
     sz += strlen(lines[i]) + 1;  // +1 for newline
   }
 
-  char* res = malloc(sz + 1);
+  char *res = malloc(sz + 1);
   for (int i = 0; i < size; i++) {
     strcat(res, lines[i]);
     strcat(res, "\n");
@@ -52,39 +54,39 @@ char *cn_replica_lines_to_json_literal() {
   size_t sz = 0;
   for (int i = 0; i < size; i++) {
     sz += strlen(lines[i]) + 2;  // +2 for newline
-    for(int j = 0; j < strlen(lines[i]); j++) {
+    for (int j = 0; j < strlen(lines[i]); j++) {
       char k = lines[i][j];
-      if(k == '\"' || k == '\\' || k == '\b' || k == '\f' || k == '\r' || k == '\t') {
+      if (k == '\"' || k == '\\' || k == '\b' || k == '\f' || k == '\r' || k == '\t') {
         sz++;
-      } else if(!isprint(k)) {
+      } else if (!isprint(k)) {
         sz += 5;
       }
     }
   }
 
-  char* res = malloc(sz + 1);
+  char *res = malloc(sz + 1);
   for (int i = 0; i < size; i++) {
-    for(int j = 0; j < strlen(lines[i]); j++) {
+    for (int j = 0; j < strlen(lines[i]); j++) {
       char k = lines[i][j];
-      if(k == '\"') {
-        strlcat(res, "\\\"", sz+1);
-      } else if(k == '\\') {
-        strlcat(res, "\\\\", sz+1);
-      } else if(k == '\b') {
-        strlcat(res, "\\b", sz+1);
-      } else if(k == '\f') {
-        strlcat(res, "\\f", sz+1);
-      } else if(k == '\r') {
-        strlcat(res, "\\r", sz+1);
-      } else if(k == '\t') {
-        strlcat(res, "\\t", sz+1);
-      } else if(!isprint(k)) {
-        snprintf(&res[strlen(res)], 7, "\\u%4x", (int) k);
+      if (k == '\"') {
+        strlcat(res, "\\\"", sz + 1);
+      } else if (k == '\\') {
+        strlcat(res, "\\\\", sz + 1);
+      } else if (k == '\b') {
+        strlcat(res, "\\b", sz + 1);
+      } else if (k == '\f') {
+        strlcat(res, "\\f", sz + 1);
+      } else if (k == '\r') {
+        strlcat(res, "\\r", sz + 1);
+      } else if (k == '\t') {
+        strlcat(res, "\\t", sz + 1);
+      } else if (!isprint(k)) {
+        snprintf(&res[strlen(res)], 7, "\\u%4x", (int)k);
       } else {
         snprintf(&res[strlen(res)], 2, "%c", k);
       }
     }
-    strlcat(res, "\\n", sz+1);
+    strlcat(res, "\\n", sz + 1);
   }
 
   return res;
@@ -97,19 +99,23 @@ unsigned long hash(unsigned char *str) {
   int c;
 
   while (c = *str++)
-      hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+    hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
 
   return hash;
 }
 
-void print_test_summary_tyche(FILE *out, 
-                              char *test_suite,
-                              char *test_name,
-                              char *status,
-                              uint64_t suite_begin_time,
-                              char *representation,
-                              int64_t init_time,
-                              int64_t runtime) {
-  fprintf(out, "\n{ \"type\": \"test_case\", \"property\": \"%s-%s\", \"arguments\": { \"n\": \"%lx\" }, \"run_start\": %.6lf, \"status\": \"%s\", \"status_reason\": \"\", \"representation\": \"%s\", \"features\": {}, \"timing\": { \"execute:test\": %.6lf, \"overall:gc\": 0.0, \"generate:n\": %.6lf }, \"coverage\": {} }\n",
-       test_suite, test_name, hash(representation), suite_begin_time / 1000000.0, status, representation, runtime / 1000000.0, init_time / 1000000.0);  
+void print_test_summary_tyche(FILE *out, struct tyche_line_info *line_info) {
+  fprintf(out,
+      "\n{ \"type\": \"test_case\", \"property\": \"%s-%s\", \"arguments\": { \"n\": "
+      "\"%lx\" }, \"run_start\": %.6lf, \"status\": \"%s\", \"status_reason\": \"\", "
+      "\"representation\": \"%s\", \"features\": {}, \"timing\": { \"execute:test\": "
+      "%.6lf, \"overall:gc\": 0.0, \"generate:n\": %.6lf }, \"coverage\": {} }\n",
+      line_info->test_suite,
+      line_info->test_name,
+      hash(line_info->representation),
+      line_info->suite_begin_time / 1000000.0,
+      line_info->status,
+      line_info->representation,
+      line_info->runtime / 1000000.0,
+      line_info->init_time / 1000000.0);
 }

--- a/runtime/libcn/src/cn-testing/size.c
+++ b/runtime/libcn/src/cn-testing/size.c
@@ -89,7 +89,7 @@ uint64_t cn_gen_get_input_timer(void) {
   #include <Windows.h>
 
 /// Taken from https://stackoverflow.com/questions/10905892/equivalent-of-gettimeofday-for-windows
-int gettimeofday(struct timeval* tp, struct timezone* tzp) {
+int gettimeofday(struct timeval *tp, struct timezone *tzp) {
   // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
   // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
   // until 00:00:00 January 1, 1970
@@ -125,5 +125,5 @@ uint64_t cn_gen_get_microseconds(void) {
 }
 
 int64_t timediff_timeval(struct timeval *early, struct timeval *late) {
-  return (late->tv_sec - early->tv_sec)*1000000 + (late->tv_usec - early->tv_usec);
+  return (late->tv_sec - early->tv_sec) * 1000000 + (late->tv_usec - early->tv_usec);
 }

--- a/runtime/libcn/src/cn-testing/size.c
+++ b/runtime/libcn/src/cn-testing/size.c
@@ -116,3 +116,14 @@ uint64_t cn_gen_get_milliseconds(void) {
   gettimeofday(&tv, NULL);
   return (((uint64_t)tv.tv_sec) * 1000) + (tv.tv_usec / 1000);
 }
+
+uint64_t cn_gen_get_microseconds(void) {
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+  return (((uint64_t)tv.tv_sec) * 1000000) + tv.tv_usec;
+}
+
+int64_t timediff_timeval(struct timeval *early, struct timeval *late) {
+  return (late->tv_sec - early->tv_sec)*1000000 + (late->tv_usec - early->tv_usec);
+}

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -352,8 +352,7 @@ int cn_test_main(int argc, char* argv[]) {
           .output_tyche = output_tyche,
           .tyche_output_stream = tyche_output_stream,
           .begin_time = begin_time};
-      enum cn_test_result result =
-          test_case->func(test_input);  //(false, progress_level, sizing_strategy, 0, 0);
+      enum cn_test_result result = test_case->func(test_input);
       if (!(results[i] == CN_TEST_PASS && result == CN_TEST_GEN_FAIL)) {
         results[i] = result;
       }

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -208,7 +208,7 @@ int cn_test_main(int argc, char* argv[]) {
   int replicas = 1;
   int print_seed = 0;
   bool output_tyche = false;
-  FILE *tyche_output_stream = NULL;
+  FILE* tyche_output_stream = NULL;
 
   for (int i = 0; i < argc; i++) {
     char* arg = argv[i];
@@ -307,9 +307,9 @@ int cn_test_main(int argc, char* argv[]) {
     } else if (strcmp("--print-seed", arg) == 0) {
       print_seed = 1;
     } else if (strcmp("--output-tyche", arg) == 0) {
-      char *next = argv[i + 1];
+      char* next = argv[i + 1];
       tyche_output_stream = fopen(next, "w");
-      if(tyche_output_stream != NULL) {
+      if (tyche_output_stream != NULL) {
         output_tyche = true;
       }
     }
@@ -344,17 +344,16 @@ int cn_test_main(int argc, char* argv[]) {
       }
       repros[i].checkpoint = cn_gen_rand_save();
       cn_gen_set_input_timeout(input_timeout);
-      struct cn_test_input test_input = { .replay = false,
-        .progress_level = progress_level,
-        .sizing_strategy = sizing_strategy,
-        .trap = 0,
-        .replicas = 0,
-        .output_tyche = output_tyche,
-        .tyche_output_stream = tyche_output_stream,
-        .begin_time = begin_time
-      };
+      struct cn_test_input test_input = {.replay = false,
+          .progress_level = progress_level,
+          .sizing_strategy = sizing_strategy,
+          .trap = 0,
+          .replicas = 0,
+          .output_tyche = output_tyche,
+          .tyche_output_stream = tyche_output_stream,
+          .begin_time = begin_time};
       enum cn_test_result result =
-          test_case->func(test_input); //(false, progress_level, sizing_strategy, 0, 0);
+          test_case->func(test_input);  //(false, progress_level, sizing_strategy, 0, 0);
       if (!(results[i] == CN_TEST_PASS && result == CN_TEST_GEN_FAIL)) {
         results[i] = result;
       }
@@ -376,18 +375,15 @@ int cn_test_main(int argc, char* argv[]) {
             cn_printf(CN_LOGGING_ERROR, "\n");
 
             cn_test_reproduce(&repros[i]);
-            struct cn_test_input test_input = { .replay = true,
-              .progress_level = CN_TEST_GEN_PROGRESS_NONE,
-              .sizing_strategy = sizing_strategy,
-              .trap = trap,
-              .replicas = replicas,
-              .output_tyche = output_tyche,
-              .tyche_output_stream = tyche_output_stream,
-              .begin_time = begin_time
-            };
-            enum cn_test_result replay_result = test_case->func(
-              test_input);
-                // true, CN_TEST_GEN_PROGRESS_NONE, sizing_strategy, trap, replicas);
+            struct cn_test_input test_input = {.replay = true,
+                .progress_level = CN_TEST_GEN_PROGRESS_NONE,
+                .sizing_strategy = sizing_strategy,
+                .trap = trap,
+                .replicas = replicas,
+                .output_tyche = output_tyche,
+                .tyche_output_stream = tyche_output_stream,
+                .begin_time = begin_time};
+            enum cn_test_result replay_result = test_case->func(test_input);
 
             if (replay_result != CN_TEST_FAIL) {
               fprintf(stderr,
@@ -422,7 +418,7 @@ int cn_test_main(int argc, char* argv[]) {
   } while (timediff < timeout);
 
 outside_loop:;
-  if(tyche_output_stream != NULL) {
+  if (tyche_output_stream != NULL) {
     fclose(tyche_output_stream);
   }
 

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -192,7 +192,7 @@ void cn_test_reproduce(struct cn_test_reproduction* repro) {
 }
 
 int cn_test_main(int argc, char* argv[]) {
-  int begin_time = cn_gen_get_milliseconds();
+  uint64_t begin_time = cn_gen_get_microseconds();
   set_cn_logging_level(CN_LOGGING_NONE);
 
   cn_gen_srand(cn_gen_get_milliseconds());
@@ -207,6 +207,9 @@ int cn_test_main(int argc, char* argv[]) {
   int replay = 1;
   int replicas = 1;
   int print_seed = 0;
+  bool output_tyche = false;
+  FILE *tyche_output_stream = NULL;
+
   for (int i = 0; i < argc; i++) {
     char* arg = argv[i];
 
@@ -303,6 +306,12 @@ int cn_test_main(int argc, char* argv[]) {
       replicas = 0;
     } else if (strcmp("--print-seed", arg) == 0) {
       print_seed = 1;
+    } else if (strcmp("--output-tyche", arg) == 0) {
+      char *next = argv[i + 1];
+      tyche_output_stream = fopen(next, "w");
+      if(tyche_output_stream != NULL) {
+        output_tyche = true;
+      }
     }
   }
 
@@ -313,6 +322,7 @@ int cn_test_main(int argc, char* argv[]) {
   if (print_seed) {
     printf("Using seed: %016" PRIx64 "\n", seed);
   }
+
   cn_gen_srand(seed);
   cn_gen_rand();  // Junk to get something to make a checkpoint from
 
@@ -334,8 +344,17 @@ int cn_test_main(int argc, char* argv[]) {
       }
       repros[i].checkpoint = cn_gen_rand_save();
       cn_gen_set_input_timeout(input_timeout);
+      struct cn_test_input test_input = { .replay = false,
+        .progress_level = progress_level,
+        .sizing_strategy = sizing_strategy,
+        .trap = 0,
+        .replicas = 0,
+        .output_tyche = output_tyche,
+        .tyche_output_stream = tyche_output_stream,
+        .begin_time = begin_time
+      };
       enum cn_test_result result =
-          test_case->func(false, progress_level, sizing_strategy, 0, 0);
+          test_case->func(test_input); //(false, progress_level, sizing_strategy, 0, 0);
       if (!(results[i] == CN_TEST_PASS && result == CN_TEST_GEN_FAIL)) {
         results[i] = result;
       }
@@ -357,8 +376,18 @@ int cn_test_main(int argc, char* argv[]) {
             cn_printf(CN_LOGGING_ERROR, "\n");
 
             cn_test_reproduce(&repros[i]);
+            struct cn_test_input test_input = { .replay = true,
+              .progress_level = CN_TEST_GEN_PROGRESS_NONE,
+              .sizing_strategy = sizing_strategy,
+              .trap = trap,
+              .replicas = replicas,
+              .output_tyche = output_tyche,
+              .tyche_output_stream = tyche_output_stream,
+              .begin_time = begin_time
+            };
             enum cn_test_result replay_result = test_case->func(
-                true, CN_TEST_GEN_PROGRESS_NONE, sizing_strategy, trap, replicas);
+              test_input);
+                // true, CN_TEST_GEN_PROGRESS_NONE, sizing_strategy, trap, replicas);
 
             if (replay_result != CN_TEST_FAIL) {
               fprintf(stderr,
@@ -384,7 +413,7 @@ int cn_test_main(int argc, char* argv[]) {
       }
 
       if (timeout != 0) {
-        timediff = cn_gen_get_milliseconds() / 1000 - begin_time;
+        timediff = (cn_gen_get_microseconds() - begin_time) / 1000000;
       }
     }
     if (timediff < timeout) {
@@ -393,6 +422,10 @@ int cn_test_main(int argc, char* argv[]) {
   } while (timediff < timeout);
 
 outside_loop:;
+  if(tyche_output_stream != NULL) {
+    fclose(tyche_output_stream);
+  }
+
   int passed = 0;
   int failed = 0;
   int errored = 0;


### PR DESCRIPTION
This is a first whack at Tyche support in `cn test`. Adding the `--output-tyche` flag to the `cn test command, *e.g.*:

`cn test --output-tyche results.jsonl ...`

will output a file `results.jsonl` that can be loaded into Tyche. The "replica" text is used as the representation for each test case, and a hash thereof is used as the identifier. I believe the (wall clock) runtime of the tests is being measured accurately; no coverage data or test setup time is included.