### PR TITLE
Fix #54, Ubuntu Docker build quirk

### DIFF
--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -14,8 +14,8 @@ module STermMap = Map.Make (IndexTerms.Surface)
 module StringMap = Map.Make (String)
 open Pp.Infix
 
-type function_sig =
-  { args : (Sym.t * BaseTypes.t) list; [@warning "-69" (* unused-record-field *)]
+type[@warning "-69" (* unused-record-field *)] function_sig =
+  { args : (Sym.t * BaseTypes.t) list;
       (* FIXME either delete this field, or explain why we don't need it *)
     return_bty : BaseTypes.t
   }

--- a/lib/fulminate/utils.ml
+++ b/lib/fulminate/utils.ml
@@ -89,10 +89,8 @@ let rec list_split_three = function
 
 type[@warning "-34" (* unused-type-declaration *)] cn_dependencies = CF.Symbol.sym list
 
-type[@warning "-34" (* unused-type-declaration *)] cn_dependency_graph =
-  { cn_functions_with_dependencies : (CF.Symbol.sym, C.ctype) Cn.cn_function list
-        [@warning "-69" (* unused-record-field *)]
-  }
+type[@warning "-34-69" (* unused-type-declaration, unused-record-field *)] cn_dependency_graph =
+  { cn_functions_with_dependencies : (CF.Symbol.sym, C.ctype) Cn.cn_function list }
 
 let[@warning "-32" (* unused-value-declaration *)] compute_cn_dependencies ail_prog =
   ail_prog


### PR DESCRIPTION
For some reason, the OCaml version 4.14.1-1ubuntu1 gives the following error when building CN in the Docker image:

```
File "lib/compile.ml", line 18, characters 4-81:
18 |   { args : (Sym.t * BaseTypes.t) list; [@warning "-69" (* unused-record-field *)]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error (warning 69 [unused-field]): record field args is never read.
(However, this field is used to build or mutate values.)
```

According to [this comment](https://github.com/rems-project/cn/issues/54#issuecomment-2795470964), the issue is mitigated by moving the attribute from the field to the type declaration itself, so this commit does that.