### PR TITLE
Remove module aliases from Fuliminate mli files

### DIFF
--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -1,9 +1,6 @@
-module CF = Cerb_frontend
-module A = CF.AilSyntax
-module C = CF.Ctype
-module BT = BaseTypes
+open Cerb_frontend
 
-val ownership_ctypes : C.ctype list ref
+val ownership_ctypes : Ctype.ctype list ref
 
 type spec_mode =
   | Pre
@@ -12,7 +9,7 @@ type spec_mode =
   | Statement
 
 module MembersKey : sig
-  type t = (Id.t * BT.t) list
+  type t = (Id.t * BaseTypes.t) list
 
   val compare : t -> t -> int
 end
@@ -21,36 +18,30 @@ module RecordMap : module type of Map.Make (MembersKey)
 
 val records : Sym.t RecordMap.t ref
 
-val augment_record_map : ?cn_sym:Sym.t -> BT.t -> unit
+val augment_record_map : ?cn_sym:Sym.t -> BaseTypes.t -> unit
 
-val lookup_records_map_opt : BT.t -> Sym.t option
+val lookup_records_map_opt : BaseTypes.t -> Sym.t option
 
-val bt_to_cn_base_type : BT.t -> Sym.t CF.Cn.cn_base_type
-
-val bt_to_ail_ctype : ?pred_sym:Sym.t option -> BT.t -> C.ctype
-
-val get_conversion_to_fn_str : BT.t -> string option
-
-val get_conversion_from_fn_str : BT.t -> string option
+val bt_to_ail_ctype : ?pred_sym:Sym.t option -> BaseTypes.t -> Ctype.ctype
 
 val wrap_with_convert_from
   :  ?sct:Sctypes.t ->
-  CF.GenTypes.genTypeCategory A.expression_ ->
-  BT.t ->
-  CF.GenTypes.genTypeCategory A.expression_
+  GenTypes.genTypeCategory AilSyntax.expression_ ->
+  BaseTypes.t ->
+  GenTypes.genTypeCategory AilSyntax.expression_
 
 val wrap_with_convert_to
   :  ?sct:Sctypes.t ->
-  CF.GenTypes.genTypeCategory A.expression_ ->
-  BT.t ->
-  CF.GenTypes.genTypeCategory A.expression_
+  GenTypes.genTypeCategory AilSyntax.expression_ ->
+  BaseTypes.t ->
+  GenTypes.genTypeCategory AilSyntax.expression_
 
 val wrap_with_convert_from_cn_bool
-  :  CF.GenTypes.genTypeCategory A.expression ->
-  CF.GenTypes.genTypeCategory A.expression
+  :  GenTypes.genTypeCategory AilSyntax.expression ->
+  GenTypes.genTypeCategory AilSyntax.expression
 
 type ail_bindings_and_statements =
-  A.bindings * CF.GenTypes.genTypeCategory A.statement_ list
+  AilSyntax.bindings * GenTypes.genTypeCategory AilSyntax.statement_ list
 
 type ail_executable_spec =
   { pre : ail_bindings_and_statements;
@@ -64,135 +55,164 @@ type ail_executable_spec =
 
 val generate_get_or_put_ownership_function
   :  without_ownership_checking:bool ->
-  C.ctype ->
-  A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
+  Ctype.ctype ->
+  AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition
 
 val generate_assume_ownership_function
   :  without_ownership_checking:bool ->
-  C.ctype ->
-  A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
+  Ctype.ctype ->
+  AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition
 
 val generate_datatype_equality_function
-  :  A.sigma_cn_datatype ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  :  AilSyntax.sigma_cn_datatype ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_datatype_map_get
   :  Cerb_frontend.Symbol.sym Cerb_frontend.Cn.cn_datatype ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_datatype_default_function
   :  Cerb_frontend.Symbol.sym Cerb_frontend.Cn.cn_datatype ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_struct_conversion_to_function
-  :  A.sigma_tag_definition ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  :  AilSyntax.sigma_tag_definition ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_struct_conversion_from_function
-  :  A.sigma_tag_definition ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  :  AilSyntax.sigma_tag_definition ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_struct_equality_function
   :  ?is_record:bool ->
-  A.sigma_tag_definition ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  AilSyntax.sigma_tag_definition ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_struct_map_get
-  :  A.sigma_tag_definition ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  :  AilSyntax.sigma_tag_definition ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_struct_default_function
   :  ?is_record:bool ->
-  A.sigma_tag_definition ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  AilSyntax.sigma_tag_definition ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
-val generate_record_tag : Sym.t -> BT.t -> Sym.t option
+val generate_record_tag : Sym.t -> BaseTypes.t -> Sym.t option
 
-val generate_record_opt : Sym.t -> BT.t -> A.sigma_tag_definition option
+val generate_record_opt : Sym.t -> BaseTypes.t -> AilSyntax.sigma_tag_definition option
 
 val generate_record_equality_function
-  :  Sym.t * BT.member_types ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  :  Sym.t * BaseTypes.member_types ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_record_default_function
   :  'a ->
-  Sym.t * BT.member_types ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  Sym.t * BaseTypes.member_types ->
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val generate_record_map_get
   :  Sym.t * 'a ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val cn_to_ail_expr_toplevel
-  :  A.sigma_cn_datatype list ->
-  (C.union_tag * C.ctype) list ->
+  :  AilSyntax.sigma_cn_datatype list ->
+  (Ctype.union_tag * Ctype.ctype) list ->
   Sym.t option ->
   spec_mode option ->
   IndexTerms.t ->
-  A.bindings
-  * CF.GenTypes.genTypeCategory A.statement_ list
-  * CF.GenTypes.genTypeCategory A.expression
+  AilSyntax.bindings
+  * GenTypes.genTypeCategory AilSyntax.statement_ list
+  * GenTypes.genTypeCategory AilSyntax.expression
 
 val cn_to_ail_logical_constraint
-  :  A.sigma_cn_datatype list ->
-  (C.union_tag * C.ctype) list ->
+  :  AilSyntax.sigma_cn_datatype list ->
+  (Ctype.union_tag * Ctype.ctype) list ->
   spec_mode option ->
   LogicalConstraints.t ->
-  A.bindings
-  * CF.GenTypes.genTypeCategory A.statement_ list
-  * CF.GenTypes.genTypeCategory A.expression
+  AilSyntax.bindings
+  * GenTypes.genTypeCategory AilSyntax.statement_ list
+  * GenTypes.genTypeCategory AilSyntax.expression
 
-val cn_to_ail_struct : A.sigma_tag_definition -> A.sigma_tag_definition list
+val cn_to_ail_struct
+  :  AilSyntax.sigma_tag_definition ->
+  AilSyntax.sigma_tag_definition list
 
 val cn_to_ail_datatype
   :  ?first:bool ->
-  A.sigma_cn_datatype ->
-  Locations.t * A.sigma_tag_definition list
+  AilSyntax.sigma_cn_datatype ->
+  Locations.t * AilSyntax.sigma_tag_definition list
 
 val cn_to_ail_records
-  :  (MembersKey.t * A.ail_identifier) list ->
-  A.sigma_tag_definition list
+  :  (MembersKey.t * AilSyntax.ail_identifier) list ->
+  AilSyntax.sigma_tag_definition list
 
 val cn_to_ail_function
   :  Sym.t * Definition.Function.t ->
-  A.sigma_cn_datatype list ->
-  A.sigma_cn_function list ->
-  ((Locations.t * A.sigma_declaration)
-  * CF.GenTypes.genTypeCategory A.sigma_function_definition option)
-  * A.sigma_tag_definition option
+  AilSyntax.sigma_cn_datatype list ->
+  AilSyntax.sigma_cn_function list ->
+  ((Locations.t * AilSyntax.sigma_declaration)
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition option)
+  * AilSyntax.sigma_tag_definition option
 
 val cn_to_ail_predicates
   :  (Sym.t * Definition.Predicate.t) list ->
-  A.sigma_cn_datatype list ->
-  (Sym.t * C.ctype) list ->
-  A.sigma_cn_predicate list ->
-  ((Locations.t * A.sigma_declaration)
-  * CF.GenTypes.genTypeCategory A.sigma_function_definition)
+  AilSyntax.sigma_cn_datatype list ->
+  (Sym.t * Ctype.ctype) list ->
+  AilSyntax.sigma_cn_predicate list ->
+  ((Locations.t * AilSyntax.sigma_declaration)
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
     list
-  * A.sigma_tag_definition option list
+  * AilSyntax.sigma_tag_definition option list
 
 val cn_to_ail_pre_post
   :  without_ownership_checking:bool ->
   with_loop_leak_checks:bool ->
-  A.sigma_cn_datatype list ->
+  AilSyntax.sigma_cn_datatype list ->
   (Sym.t * Definition.Predicate.t) list ->
-  (Sym.t * C.ctype) list ->
-  C.ctype ->
+  (Sym.t * Ctype.ctype) list ->
+  Ctype.ctype ->
   Extract.fn_args_and_body option ->
   ail_executable_spec
 
 val cn_to_ail_assume_predicates
   :  (Sym.t * Definition.Predicate.t) list ->
-  A.sigma_cn_datatype list ->
-  (Sym.t * C.ctype) list ->
+  AilSyntax.sigma_cn_datatype list ->
+  (Sym.t * Ctype.ctype) list ->
   (Sym.t * Definition.Predicate.t) list ->
-  (A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition) list
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
+    list
 
 val cn_to_ail_assume_pre
-  :  A.sigma_cn_datatype list ->
-  C.union_tag ->
-  (C.union_tag * (BT.t * C.ctype)) list ->
-  (C.union_tag * C.ctype) list ->
-  (C.union_tag * Definition.Predicate.t) list ->
+  :  AilSyntax.sigma_cn_datatype list ->
+  Ctype.union_tag ->
+  (Ctype.union_tag * (BaseTypes.t * Ctype.ctype)) list ->
+  (Ctype.union_tag * Ctype.ctype) list ->
+  (Ctype.union_tag * Definition.Predicate.t) list ->
   'a LogicalArgumentTypes.t ->
-  A.sigma_declaration * CF.GenTypes.genTypeCategory A.sigma_function_definition
+  AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -1,0 +1,23 @@
+module Extract = Extract
+module Cn_to_ail = Cn_to_ail
+module Internal = Internal
+module Ownership = Ownership
+module Utils = Utils
+
+val get_instrumented_filename : string -> string
+
+val get_cn_helper_filename : string -> string
+
+val main
+  :  ?without_ownership_checking:bool ->
+  ?without_loop_invariants:bool ->
+  ?with_loop_leak_checks:bool ->
+  ?with_test_gen:bool ->
+  ?copy_source_dir:bool ->
+  String.t ->
+  use_preproc:bool ->
+  Sym.t option * Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
+  string option ->
+  string option ->
+  unit Mucore.file ->
+  unit

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -1,5 +1,7 @@
 open PPrint
 open Utils
+module CF = Cerb_frontend
+module C = CF.Ctype
 module A = CF.AilSyntax
 module AT = ArgumentTypes
 module OE = Ownership

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -1,11 +1,6 @@
-module CB = Cerb_backend
 open PPrint
 open Utils
-module BT = BaseTypes
 module A = CF.AilSyntax
-module IT = IndexTerms
-module LRT = LogicalReturnTypes
-module LAT = LogicalArgumentTypes
 module AT = ArgumentTypes
 module OE = Ownership
 

--- a/lib/fulminate/internal.mli
+++ b/lib/fulminate/internal.mli
@@ -1,26 +1,20 @@
-module CB = Cerb_backend
-module BT = BaseTypes
-module A = Cn_to_ail.A
-module IT = IndexTerms
-module LRT = LogicalReturnTypes
-module LAT = LogicalArgumentTypes
-module AT = ArgumentTypes
+open Cerb_frontend
 
 type executable_spec =
-  { pre_post : (A.ail_identifier * (string list * string list)) list;
+  { pre_post : (AilSyntax.ail_identifier * (string list * string list)) list;
     in_stmt : (Cerb_location.t * string list) list;
     returns :
       (Cerb_location.t
-      * (Cerb_frontend.GenTypes.genTypeCategory A.expression option * string list))
+      * (GenTypes.genTypeCategory AilSyntax.expression option * string list))
         list
   }
 
 val generate_c_assume_pres_internal
   :  Extract.instrumentation list ->
-  Cerb_frontend.GenTypes.genTypeCategory A.sigma ->
+  GenTypes.genTypeCategory AilSyntax.sigma ->
   unit Mucore.file ->
-  (Cn_to_ail.A.sigma_declaration
-  * Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma_function_definition)
+  (AilSyntax.sigma_declaration
+  * GenTypes.genTypeCategory AilSyntax.sigma_function_definition)
     list
 
 val generate_c_specs
@@ -28,47 +22,45 @@ val generate_c_specs
   bool ->
   bool ->
   Extract.instrumentation list ->
-  Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma ->
+  GenTypes.genTypeCategory AilSyntax.sigma ->
   unit Mucore.file ->
   executable_spec
 
 val generate_c_records
-  :  (Sym.t
-     * (Cerb_location.t * Cerb_frontend.Annot.attributes * Cn_to_ail.C.tag_definition))
-       list ->
+  :  (Sym.t * (Cerb_location.t * Annot.attributes * Ctype.tag_definition)) list ->
   string
 
 val generate_c_datatypes
-  :  Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma ->
+  :  GenTypes.genTypeCategory AilSyntax.sigma ->
   (Cerb_location.t * string) list
 
 val generate_c_struct_strs
-  :  (A.ail_identifier
-     * (Cerb_location.t * Cerb_frontend.Annot.attributes * Cn_to_ail.C.tag_definition))
+  :  (AilSyntax.ail_identifier
+     * (Cerb_location.t * Annot.attributes * Ctype.tag_definition))
        list ->
   string
 
-val generate_cn_versions_of_structs : Cn_to_ail.A.sigma_tag_definition list -> string
+val generate_cn_versions_of_structs : AilSyntax.sigma_tag_definition list -> string
 
 val generate_c_functions
-  :  Cerb_frontend.GenTypes.genTypeCategory A.sigma ->
-  (A.ail_identifier * Definition.Function.t) list ->
+  :  GenTypes.genTypeCategory AilSyntax.sigma ->
+  (AilSyntax.ail_identifier * Definition.Function.t) list ->
   string * string * Cerb_location.t list
 
 val generate_c_predicates
-  :  Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma ->
+  :  GenTypes.genTypeCategory AilSyntax.sigma ->
   (Sym.t * Definition.Predicate.t) list ->
   string * string * Cerb_location.t list
 
-val generate_ownership_functions : bool -> Cn_to_ail.C.ctype list -> string * string
+val generate_ownership_functions : bool -> Ctype.ctype list -> string * string
 
 val generate_conversion_and_equality_functions
-  :  Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma ->
+  :  GenTypes.genTypeCategory AilSyntax.sigma ->
   string * string
 
-val has_main : Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma -> bool
+val has_main : GenTypes.genTypeCategory AilSyntax.sigma -> bool
 
 val generate_ownership_global_assignments
-  :  Cerb_frontend.GenTypes.genTypeCategory Cn_to_ail.A.sigma ->
+  :  GenTypes.genTypeCategory AilSyntax.sigma ->
   unit Mucore.file ->
   (Sym.t * (string list * string list)) list

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -1,4 +1,5 @@
 open Utils
+module CF = Cerb_frontend
 module A = CF.AilSyntax
 module C = CF.Ctype
 

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -1,4 +1,3 @@
-module CF = Cerb_frontend
 open Utils
 module A = CF.AilSyntax
 module C = CF.Ctype

--- a/lib/fulminate/ownership.mli
+++ b/lib/fulminate/ownership.mli
@@ -1,13 +1,11 @@
-module CF = Cerb_frontend
-module A = Utils.A
-module C = Utils.C
+open Cerb_frontend
 
 type ail_bindings_and_statements =
-  A.bindings * CF.GenTypes.genTypeCategory A.statement_ list
+  AilSyntax.bindings * GenTypes.genTypeCategory AilSyntax.statement_ list
 
 type return_kind =
   | ReturnVoid
-  | ReturnExpr of CF.GenTypes.genTypeCategory A.expression
+  | ReturnExpr of GenTypes.genTypeCategory AilSyntax.expression
 
 type injection_kind =
   | ReturnInj of return_kind
@@ -31,23 +29,26 @@ val cn_loop_leak_check_and_put_back_ownership_sym : Sym.t
 
 val get_ownership_global_init_stats
   :  unit ->
-  Cerb_frontend.GenTypes.genTypeCategory A.statement_ list
+  GenTypes.genTypeCategory AilSyntax.statement_ list
 
 val generate_c_local_ownership_entry_fcall
-  :  A.ail_identifier * Utils.C.ctype ->
-  Cerb_frontend.GenTypes.genTypeCategory Utils.A.expression
+  :  AilSyntax.ail_identifier * Ctype.ctype ->
+  GenTypes.genTypeCategory AilSyntax.expression
 
 val generate_c_local_ownership_exit
-  :  A.ail_identifier * Utils.C.ctype ->
-  Cerb_frontend.GenTypes.genTypeCategory A.statement_
+  :  AilSyntax.ail_identifier * Ctype.ctype ->
+  GenTypes.genTypeCategory AilSyntax.statement_
 
 val get_c_fn_local_ownership_checking_injs
-  :  C.union_tag ->
-  CF.GenTypes.genTypeCategory A.sigma ->
-  (((C.union_tag
-    * ((Cerb_location.t * A.storageDuration * bool) * 'a option * C.qualifiers * C.ctype))
+  :  Ctype.union_tag ->
+  GenTypes.genTypeCategory AilSyntax.sigma ->
+  (((Ctype.union_tag
+    * ((Cerb_location.t * AilSyntax.storageDuration * bool)
+      * 'a option
+      * Ctype.qualifiers
+      * Ctype.ctype))
       list
-   * CF.GenTypes.genTypeCategory A.statement_ list)
-  * ('b list * CF.GenTypes.genTypeCategory A.statement_ list))
+   * GenTypes.genTypeCategory AilSyntax.statement_ list)
+  * ('b list * GenTypes.genTypeCategory AilSyntax.statement_ list))
     option
   * ownership_injection list

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -1,4 +1,4 @@
-open Utils
+module CF = Cerb_frontend
 module BT = BaseTypes
 module IT = IndexTerms
 module LRT = LogicalReturnTypes

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -1,8 +1,5 @@
-module CF = Cerb_frontend
-module CB = Cerb_backend
 open Utils
 module BT = BaseTypes
-module A = CF.AilSyntax
 module IT = IndexTerms
 module LRT = LogicalReturnTypes
 module LAT = LogicalArgumentTypes

--- a/lib/fulminate/records.mli
+++ b/lib/fulminate/records.mli
@@ -1,0 +1,7 @@
+val populate_record_map : Extract.instrumentation list -> unit Mucore.file -> unit
+
+val generate_all_record_strs : unit -> string
+
+val generate_c_record_funs
+  :  Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
+  string * string

--- a/lib/fulminate/source_injection.mli
+++ b/lib/fulminate/source_injection.mli
@@ -5,7 +5,7 @@ type 'a cn_injection =
     program : 'a AilSyntax.ail_program;
       (** The processed form of the program in [filename].
         This is used to find the locations of the symbols in [pre_post]. *)
-    pre_post : (Symbol.sym * (string list * string list)) list;
+    pre_post : (Sym.t * (string list * string list)) list;
       (** Pre- and post-condition checks to inject for the given symbols.
         The locations of the symbols are found by consulting [program]. *)
     in_stmt : (Cerb_location.t * string list) list;

--- a/lib/fulminate/utils.mli
+++ b/lib/fulminate/utils.mli
@@ -1,33 +1,30 @@
-module CF = Cerb_frontend
-module A = CF.AilSyntax
-module C = CF.Ctype
-module Cn = CF.Cn
+open Cerb_frontend
 
-val empty_attributes : CF.Annot.attributes
+val empty_attributes : Annot.attributes
 
-val mk_ctype : ?annots:Cerb_frontend.Annot.annot list -> C.ctype_ -> C.ctype
+val mk_ctype : ?annots:Annot.annot list -> Ctype.ctype_ -> Ctype.ctype
 
-val rm_ctype : C.ctype -> C.ctype_
+val rm_ctype : Ctype.ctype -> Ctype.ctype_
 
-val get_typedef_string : C.ctype -> string option
+val get_typedef_string : Ctype.ctype -> string option
 
 val mk_expr
   :  ?loc:Cerb_location.t ->
-  CF.GenTypes.genTypeCategory A.expression_ ->
-  CF.GenTypes.genTypeCategory A.expression
+  GenTypes.genTypeCategory AilSyntax.expression_ ->
+  GenTypes.genTypeCategory AilSyntax.expression
 
-val mk_stmt : 'a A.statement_ -> 'a A.statement
+val mk_stmt : 'a AilSyntax.statement_ -> 'a AilSyntax.statement
 
-val rm_expr : 'a A.expression -> 'a A.expression_
+val rm_expr : 'a AilSyntax.expression -> 'a AilSyntax.expression_
 
-val empty_ail_expr : 'a A.expression_
+val empty_ail_expr : 'a AilSyntax.expression_
 
 val generate_sym_with_suffix
   :  ?suffix:string ->
   ?uppercase:bool ->
   ?lowercase:bool ->
-  C.union_tag ->
-  C.union_tag
+  Ctype.union_tag ->
+  Ctype.union_tag
 
 val list_split_three : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list
 
@@ -35,16 +32,20 @@ val ifndef_wrap : string -> string -> string
 
 val generate_include_header : string * bool -> string
 
-val get_ctype_without_ptr : C.ctype -> C.ctype
+val get_ctype_without_ptr : Ctype.ctype -> Ctype.ctype
 
-val str_of_ctype : C.ctype -> string
+val str_of_ctype : Ctype.ctype -> string
 
-val execCtypeEqual : C.ctype -> C.ctype -> bool
+val execCtypeEqual : Ctype.ctype -> Ctype.ctype -> bool
 
 val create_binding
   :  'a ->
   'b ->
-  'a * ((Cerb_location.t * A.storageDuration * bool) * 'c option * C.qualifiers * 'b)
+  'a
+  * ((Cerb_location.t * AilSyntax.storageDuration * bool)
+    * 'c option
+    * Ctype.qualifiers
+    * 'b)
 
 val find_ctype_from_bindings : (Sym.t * ('a * 'b * 'c * 'd)) list -> Sym.t -> 'd
 
@@ -52,4 +53,4 @@ val get_start_loc : ?offset:int -> Cerb_location.t -> Cerb_location.t
 
 val get_end_loc : ?offset:int -> Cerb_location.t -> Cerb_location.t
 
-val concat_map_newline : Pp.document list -> Pp.document
+val concat_map_newline : PPrint.document list -> PPrint.document


### PR DESCRIPTION
Module aliases in mli files get exported in users of the module, which pollutes their namespace. This PR tidies that up, along with a few commits to remove redundant name prefixes (for which we have modules).