### PR TITLE
Unify suffixes for `cn instrument` and `cn test`

### DIFF
--- a/doc/README-FULMINATE.md
+++ b/doc/README-FULMINATE.md
@@ -18,9 +18,9 @@ cn instrument <your-file>.c
 
 This will produce three files: 
 
-* `<your-file>-exec.c`, the instrumented source
-* `cn.h`, a header file containing various definitions and prototypes, including C struct definitions representing CN datatypes, structs and records, as well as function prototypes for the various translated top-level CN functions and predicates.
-* `cn.c`, a file that includes `cn.h` and provides definitions for the aforementioned prototypes
+* `<your-file>.exec.c`, the instrumented source
+* `<your-file>.cn.h`, a header file containing various definitions and prototypes, including C struct definitions representing CN datatypes, structs and records, as well as function prototypes for the various translated top-level CN functions and predicates.
+* `<your-file>.cn.c`, a file that includes `<your-file>.cn.h` and provides definitions for the aforementioned prototypes
 
 
 These are all produced in the directory the command was run from. Alternatively, one can provide an output directory for these three files (after creating the directory) using the `--output-dir` argument:

--- a/lib/seqTests/buildScript.ml
+++ b/lib/seqTests/buildScript.ml
@@ -56,12 +56,12 @@ let compile ~filename_base =
           ([ "cc";
              "-c";
              "-o";
-             "\"./" ^ filename_base ^ "_test.o\"";
-             "\"./" ^ filename_base ^ "_test.c\""
+             "\"./" ^ filename_base ^ ".test.o\"";
+             "\"./" ^ filename_base ^ ".test.c\""
            ]
            @ cc_flags ()))
-       ("Compiled '" ^ filename_base ^ "_test.c'.")
-       ("Failed to compile '" ^ filename_base ^ "_test.c' in ${TEST_DIR}.")
+       ("Compiled '" ^ filename_base ^ ".test.c'.")
+       ("Failed to compile '" ^ filename_base ^ ".test.c' in ${TEST_DIR}.")
   ^^ (if Config.with_static_hack () then
         empty
       else
@@ -72,19 +72,25 @@ let compile ~filename_base =
                 ([ "cc";
                    "-c";
                    "-o";
-                   "\"./" ^ filename_base ^ "-exec.o\"";
-                   "\"./" ^ filename_base ^ "-exec.c\""
+                   "\"./" ^ filename_base ^ ".exec.o\"";
+                   "\"./" ^ filename_base ^ ".exec.c\""
                  ]
                  @ cc_flags ()))
-             ("Compiled '" ^ filename_base ^ "-exec.c'.")
-             ("Failed to compile '" ^ filename_base ^ "-exec.c' in ${TEST_DIR}.")
+             ("Compiled '" ^ filename_base ^ ".exec.c'.")
+             ("Failed to compile '" ^ filename_base ^ ".exec.c' in ${TEST_DIR}.")
         ^^ twice hardline
         ^^ attempt
              (String.concat
                 " "
-                ([ "cc"; "-c"; "-o"; "\"./cn.o\""; "\"./cn.c\"" ] @ cc_flags ()))
-             "Compiled 'cn.c'."
-             "Failed to compile 'cn.c' in ${TEST_DIR}.")
+                ([ "cc";
+                   "-c";
+                   "-o";
+                   "\"./" ^ filename_base ^ ".cn.o\"";
+                   "\"./" ^ filename_base ^ ".cn.c\""
+                 ]
+                 @ cc_flags ()))
+             ("Compiled '" ^ filename_base ^ ".cn.c'.")
+             ("Failed to compile '" ^ filename_base ^ ".cn.c' in ${TEST_DIR}."))
   ^^ hardline
 
 
@@ -102,12 +108,12 @@ let link ~filename_base =
              "-o";
              "\"./tests.out\"";
              (filename_base
-              ^ "_test.o"
+              ^ ".test.o"
               ^
               if Config.with_static_hack () then
                 ""
               else
-                " " ^ filename_base ^ "-exec.o cn.o");
+                " " ^ filename_base ^ ".exec.o " ^ filename_base ^ ".cn.o");
              "\"${RUNTIME_PREFIX}/libcn_exec.a\"";
              "\"${RUNTIME_PREFIX}/libcn_test.a\"";
              "\"${RUNTIME_PREFIX}/libcn_replica.a\""
@@ -138,7 +144,7 @@ let[@warning "-32" (* unused-value-declaration *)] coverage ~filename_base =
   ^^ string "echo"
   ^^ hardline
   ^^ attempt
-       ("gcov \"" ^ filename_base ^ "_test.c\"")
+       ("gcov \"" ^ filename_base ^ ".test.c\"")
        "Recorded coverage via gcov."
        "Failed to record coverage."
   ^^ twice hardline

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -150,12 +150,15 @@ let create_test_file
   let open Pp in
   (if Config.with_static_hack () then
      string "#include "
-     ^^ dquotes (string (filename_base ^ "-exec.c"))
+     ^^ dquotes (string (filename_base ^ ".exec.c"))
      ^^ hardline
      ^^ string "#include "
      ^^ dquotes (string "cn.c")
    else
-     string "#include " ^^ dquotes (string "cn.h") ^^ twice hardline ^^ fun_decls)
+     string "#include "
+     ^^ dquotes (string (filename_base ^ ".cn.h"))
+     ^^ twice hardline
+     ^^ fun_decls)
   ^^ twice hardline
   ^^ string "int main"
   ^^ parens (string "int argc, char* argv[]")
@@ -262,7 +265,7 @@ let rec gen_sequence
           let _ =
             save
               output_dir
-              (filename_base ^ "_test.c")
+              (filename_base ^ ".test.c")
               (create_test_file (seq_so_far ^^ curr_test) filename_base fun_decls)
           in
           let output, status = out_to_list (output_dir ^ "/run_tests.sh") in
@@ -441,7 +444,7 @@ let generate
   =
   if List.is_empty insts then failwith "No testable functions";
   let filename_base = filename |> Filename.basename |> Filename.chop_extension in
-  let test_file = filename_base ^ "_test.c" in
+  let test_file = filename_base ^ ".test.c" in
   let script_doc = BuildScript.generate ~output_dir ~filename_base in
   let src_code, _ = out_to_list ("cat " ^ filename) in
   save ~perm:0o777 output_dir "run_tests.sh" script_doc;

--- a/lib/testGeneration/buildScript.ml
+++ b/lib/testGeneration/buildScript.ml
@@ -69,12 +69,12 @@ let compile ~filename_base =
           ([ "cc";
              "-c";
              "-o";
-             "\"./" ^ filename_base ^ "_test.o\"";
-             "\"./" ^ filename_base ^ "_test.c\""
+             "\"./" ^ filename_base ^ ".test.o\"";
+             "\"./" ^ filename_base ^ ".test.c\""
            ]
            @ cc_flags ()))
-       ("Compiled '" ^ filename_base ^ "_test.c'.")
-       ("Failed to compile '" ^ filename_base ^ "_test.c' in ${TEST_DIR}.")
+       ("Compiled '" ^ filename_base ^ ".test.c'.")
+       ("Failed to compile '" ^ filename_base ^ ".test.c' in ${TEST_DIR}.")
   ^^ (if Config.with_static_hack () then
         empty
       else
@@ -85,19 +85,25 @@ let compile ~filename_base =
                 ([ "cc";
                    "-c";
                    "-o";
-                   "\"./" ^ filename_base ^ "-exec.o\"";
-                   "\"./" ^ filename_base ^ "-exec.c\""
+                   "\"./" ^ filename_base ^ ".exec.o\"";
+                   "\"./" ^ filename_base ^ ".exec.c\""
                  ]
                  @ cc_flags ()))
-             ("Compiled '" ^ filename_base ^ "-exec.c'.")
-             ("Failed to compile '" ^ filename_base ^ "-exec.c' in ${TEST_DIR}.")
+             ("Compiled '" ^ filename_base ^ ".exec.c'.")
+             ("Failed to compile '" ^ filename_base ^ ".exec.c' in ${TEST_DIR}.")
         ^^ twice hardline
         ^^ attempt
              (String.concat
                 " "
-                ([ "cc"; "-c"; "-o"; "\"./cn.o\""; "\"./cn.c\"" ] @ cc_flags ()))
-             "Compiled 'cn.c'."
-             "Failed to compile 'cn.c' in ${TEST_DIR}.")
+                ([ "cc";
+                   "-c";
+                   "-o";
+                   "\"./" ^ filename_base ^ ".cn.o\"";
+                   "\"./" ^ filename_base ^ ".cn.c\""
+                 ]
+                 @ cc_flags ()))
+             ("Compiled '" ^ filename_base ^ ".cn.c'.")
+             ("Failed to compile '" ^ filename_base ^ ".cn.c' in ${TEST_DIR}."))
   ^^ hardline
 
 
@@ -115,12 +121,12 @@ let link ~filename_base =
              "-o";
              "\"./tests.out\"";
              (filename_base
-              ^ "_test.o"
+              ^ ".test.o"
               ^
               if Config.with_static_hack () then
                 ""
               else
-                " " ^ filename_base ^ "-exec.o cn.o");
+                " " ^ filename_base ^ ".exec.o " ^ filename_base ^ ".cn.o");
              "\"${RUNTIME_PREFIX}/libcn_exec.a\"";
              "\"${RUNTIME_PREFIX}/libcn_test.a\"";
              "\"${RUNTIME_PREFIX}/libcn_replica.a\""
@@ -249,10 +255,10 @@ let coverage ~filename_base =
             "--directory .";
             "--remove coverage.info";
             "-o coverage_filtered.info";
-            realpath "cn.c";
-            realpath "cn.h";
-            realpath (filename_base ^ "_test.c");
-            realpath (filename_base ^ "_gen.h")
+            realpath (filename_base ^ ".cn.c");
+            realpath (filename_base ^ ".cn.h");
+            realpath (filename_base ^ ".test.c");
+            realpath (filename_base ^ ".gen.h")
           ])
        "Exclude test harnesses from coverage via lcov."
        "Failed to exclude test harnesses from coverage."

--- a/lib/testGeneration/genCodeGen.ml
+++ b/lib/testGeneration/genCodeGen.ml
@@ -527,7 +527,8 @@ let compile_gen_def
   (sigma_decl, sigma_def)
 
 
-let compile (sigma : CF.GenTypes.genTypeCategory A.sigma) (ctx : GR.context) : Pp.document
+let compile filename (sigma : CF.GenTypes.genTypeCategory A.sigma) (ctx : GR.context)
+  : Pp.document
   =
   let defs =
     ctx
@@ -572,7 +573,10 @@ let compile (sigma : CF.GenTypes.genTypeCategory A.sigma) (ctx : GR.context) : P
   ^^ twice hardline
   ^^ string "#include <cn-testing/prelude.h>"
   ^^ twice hardline
-  ^^ string "#include \"cn.h\""
+  ^^ string
+       ("#include \""
+        ^ (Filename.remove_extension (Fulminate.get_cn_helper_filename filename) ^ ".h")
+        ^ "\"")
   ^^ twice hardline
   ^^ CF.Pp_ail.(
        with_executable_spec

--- a/lib/testGeneration/genCodeGen.mli
+++ b/lib/testGeneration/genCodeGen.mli
@@ -1,4 +1,5 @@
 val compile
-  :  Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
+  :  string ->
+  Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
   GenRuntime.context ->
   Pp.document

--- a/lib/testGeneration/specTests.ml
+++ b/lib/testGeneration/specTests.ml
@@ -81,6 +81,7 @@ let compile_constant_tests
 
 
 let compile_generators
+      (filename : string)
       (sigma : CF.GenTypes.genTypeCategory A.sigma)
       (prog5 : unit Mucore.file)
       (insts : FExtract.instrumentation list)
@@ -98,7 +99,7 @@ let compile_generators
   debug_stage "Optimize" (ctx |> GenDefinitions.pp_context |> Pp.plain ~width:80);
   let ctx = ctx |> GenRuntime.elaborate in
   debug_stage "Elaborated" (ctx |> GenRuntime.pp |> Pp.plain ~width:80);
-  ctx |> GenCodeGen.compile sigma
+  ctx |> GenCodeGen.compile filename sigma
 
 
 let convert_from ((x, ct) : Sym.t * C.ctype) =

--- a/lib/testGeneration/specTests.mli
+++ b/lib/testGeneration/specTests.mli
@@ -8,7 +8,8 @@ val compile_constant_tests
   Test.t list * Pp.document
 
 val compile_generators
-  :  CF.GenTypes.genTypeCategory A.sigma ->
+  :  string ->
+  CF.GenTypes.genTypeCategory A.sigma ->
   unit Mucore.file ->
   FExtract.instrumentation list ->
   Pp.document

--- a/lib/testGeneration/testGeneration.ml
+++ b/lib/testGeneration/testGeneration.ml
@@ -146,17 +146,17 @@ let compile_includes ~filename_base =
   ^^ angles (string "cn-replicate/shape.h")
   ^^ hardline
   ^^ string "#include "
-  ^^ dquotes (string (filename_base ^ "_gen.h"))
+  ^^ dquotes (string (filename_base ^ ".gen.h"))
   ^^ hardline
   ^^
   if Config.with_static_hack () then
     string "#include "
-    ^^ dquotes (string (filename_base ^ "-exec.c"))
+    ^^ dquotes (string (filename_base ^ ".exec.c"))
     ^^ hardline
     ^^ string "#include "
-    ^^ dquotes (string "cn.c")
+    ^^ dquotes (string (filename_base ^ ".cn.c"))
   else
-    string "#include " ^^ dquotes (string "cn.h")
+    string "#include " ^^ dquotes (string (filename_base ^ ".cn.h"))
 
 
 let compile_test test =
@@ -232,11 +232,12 @@ let save_generators
   =
   let generators_doc =
     SpecTests.compile_generators
+      (filename_base ^ ".c")
       sigma
       prog5
       (List.filter (fun inst -> not (is_constant_function sigma inst)) insts)
   in
-  let generators_fn = filename_base ^ "_gen.h" in
+  let generators_fn = filename_base ^ ".gen.h" in
   save output_dir generators_fn generators_doc
 
 
@@ -252,7 +253,7 @@ let save_tests
   let tests_doc =
     compile_test_file ~without_ownership_checking filename_base sigma prog5 insts
   in
-  save output_dir (filename_base ^ "_test.c") tests_doc
+  save output_dir (filename_base ^ ".test.c") tests_doc
 
 
 let save_build_script ~output_dir ~filename_base =

--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -61,7 +61,7 @@ EXEC_DIR=$(mktemp -d -t 'cn-exec.XXXX')
 # Instrument code with CN
 if cn instrument "${INPUT_FN}" \
     --run --print-steps \
-    --output="${INPUT_BASENAME}-exec.c" \
+    --output="${INPUT_BASENAME}.exec.c" \
     --output-dir="${EXEC_DIR}" \
     ${NO_CHECK_OWNERSHIP}; then
   [ "${QUIET}" ] || echo "Success!"

--- a/tests/cn-exec-performance-stats.py
+++ b/tests/cn-exec-performance-stats.py
@@ -84,11 +84,11 @@ def print_and_error(error_str):
 def gen_instr_cmd(f, input_basename):
     instr_cmd_prefix = "cn instrument"
     instr_cmd = time_cmd_str + instr_cmd_prefix + " " + tests_path + "/" + f
-    instr_cmd += " --output-decorated=" + input_basename + "-exec.c"
+    instr_cmd += " --output-decorated=" + input_basename + ".exec.c"
     return instr_cmd
 
 def gen_compile_cmd(input_basename, instrumented):
-    c_files = input_basename + "-exec.c cn.c" if instrumented else tests_path + "/" + input_basename + ".c "
+    c_files = input_basename + ".exec.c " + input_basename + ".cn.c" if instrumented else tests_path + "/" + input_basename + ".c "
     if not instrumented:
         c_files += "cn_uninstr_defs.c"
     compile_cmd = time_cmd_str + "cc "
@@ -101,7 +101,7 @@ def gen_compile_cmd(input_basename, instrumented):
     return compile_cmd
 
 def gen_link_cmd(input_basename, instrumented):
-    o_files = input_basename + "-exec.o cn.o " if instrumented else input_basename + ".o "
+    o_files = input_basename + ".exec.o " + input_basename + ".cn.o " if instrumented else input_basename + ".o "
     if not instrumented:
         o_files += " cn_uninstr_defs.o "
     bin_file = input_basename + "-exec-output.bin " if instrumented else input_basename + "-output.bin "


### PR DESCRIPTION
Changes the following names, to something more consistent:

- `<my-file>-exec.c` -> `<my-file>.exec.c`
- `cn.c` -> `<my-file>.cn.c`
- `cn.h` -> `<my-file>.cn.h`
- `<my-file>_test.c` -> `<my-file>.test.c`
- `<my-file>_gen.h` -> `<my-file>.gen.h`