### PR TITLE
[CN-exec] Implement `--only` and `--skip` within Fulminate

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -357,18 +357,6 @@ module Flags = struct
     Arg.(value & flag & info [ "no_timestamps" ] ~doc)
 
 
-  let only =
-    let doc = "Only type-check/instrument this function (or comma-separated names)" in
-    Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
-
-
-  let skip =
-    let doc =
-      "skip type-checking/instrumenting this function (or comma-separated names)"
-    in
-    Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
-
-
   let csv_times =
     let doc = "file in which to output csv timing information" in
     Arg.(value & opt (some string) None & info [ "times" ] ~docv:"FILE" ~doc)

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -357,6 +357,18 @@ module Flags = struct
     Arg.(value & flag & info [ "no_timestamps" ] ~doc)
 
 
+  let only =
+    let doc = "Only type-check/instrument this function (or comma-separated names)" in
+    Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
+
+
+  let skip =
+    let doc =
+      "skip type-checking/instrumenting this function (or comma-separated names)"
+    in
+    Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
+
+
   let csv_times =
     let doc = "file in which to output csv timing information" in
     Arg.(value & opt (some string) None & info [ "times" ] ~docv:"FILE" ~doc)

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -239,6 +239,16 @@ module Flags = struct
       "Print successful stages, such as instrumentation, compilation and linking."
     in
     Arg.(value & flag & info [ "print-steps" ] ~doc)
+
+
+  let only =
+    let doc = "Only instrument this function (or comma-separated names)" in
+    Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
+
+
+  let skip =
+    let doc = "Skip instrumenting this function (or comma-separated names)" in
+    Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
 end
 
 let cmd =
@@ -254,8 +264,8 @@ let cmd =
     $ Common.Flags.print_level
     $ Common.Flags.print_sym_nums
     $ Common.Flags.no_timestamps
-    $ Common.Flags.only
-    $ Common.Flags.skip
+    $ Flags.only
+    $ Flags.skip
     $ Verify.Flags.diag
     $ Common.Flags.csv_times
     $ Common.Flags.log_times

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -87,6 +87,8 @@ let generate_executable_specs
       print_level
       print_sym_nums
       no_timestamps
+      only
+      skip
       diag
       csv_times
       log_times
@@ -113,6 +115,7 @@ let generate_executable_specs
   Pp.print_level := print_level;
   Sym.print_nums := print_sym_nums;
   Pp.print_timestamps := not no_timestamps;
+  Check.skip_and_only := (skip, only);
   IndexTerms.use_vip := not dont_use_vip;
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
@@ -251,6 +254,8 @@ let cmd =
     $ Common.Flags.print_level
     $ Common.Flags.print_sym_nums
     $ Common.Flags.no_timestamps
+    $ Common.Flags.only
+    $ Common.Flags.skip
     $ Verify.Flags.diag
     $ Common.Flags.csv_times
     $ Common.Flags.log_times

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -162,6 +162,18 @@ module Flags = struct
     Arg.(value & flag & info [ "try-hard" ] ~doc)
 
 
+  let only =
+    let doc = "Only type-check/instrument this function (or comma-separated names)" in
+    Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
+
+
+  let skip =
+    let doc =
+      "skip type-checking/instrumenting this function (or comma-separated names)"
+    in
+    Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
+
+
   (* TODO remove this when VIP impl complete *)
   let dont_use_vip =
     let doc = "(temporary) disable VIP rules" in
@@ -239,8 +251,8 @@ let verify_t : unit Term.t =
   $ CoqMucore_flags.coq_mucore
   $ CoqProofLog_flags.coq_proof_log
   $ CoqCheckProofLog_flags.coq_check_proof_log
-  $ Common.Flags.only
-  $ Common.Flags.skip
+  $ Flags.only
+  $ Flags.skip
   $ Common.Flags.csv_times
   $ Common.Flags.log_times
   $ Flags.solver_logging

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -163,14 +163,12 @@ module Flags = struct
 
 
   let only =
-    let doc = "Only type-check/instrument this function (or comma-separated names)" in
+    let doc = "Only type-check this function (or comma-separated names)" in
     Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
 
 
   let skip =
-    let doc =
-      "skip type-checking/instrumenting this function (or comma-separated names)"
-    in
+    let doc = "Skip type-checking of this function (or comma-separated names)" in
     Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
 
 

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -162,16 +162,6 @@ module Flags = struct
     Arg.(value & flag & info [ "try-hard" ] ~doc)
 
 
-  let only =
-    let doc = "only type-check this function (or comma-separated names)" in
-    Arg.(value & opt (list string) [] & info [ "only" ] ~doc)
-
-
-  let skip =
-    let doc = "skip type-checking of this function (or comma-separated names)" in
-    Arg.(value & opt (list string) [] & info [ "skip" ] ~doc)
-
-
   (* TODO remove this when VIP impl complete *)
   let dont_use_vip =
     let doc = "(temporary) disable VIP rules" in
@@ -249,8 +239,8 @@ let verify_t : unit Term.t =
   $ CoqMucore_flags.coq_mucore
   $ CoqProofLog_flags.coq_proof_log
   $ CoqCheckProofLog_flags.coq_check_proof_log
-  $ Flags.only
-  $ Flags.skip
+  $ Common.Flags.only
+  $ Common.Flags.skip
   $ Common.Flags.csv_times
   $ Common.Flags.log_times
   $ Flags.solver_logging

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -192,7 +192,7 @@ let filter_selected_fns
       (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
       (full_instrumentation : Extract.instrumentation list)
   =
-  (* Filtering based on Common.Flags.only and Common.Flags.skip *)
+  (* Filtering based on Check.skip_and_only *)
   let prog5_fns_list = List.map fst (Pmap.bindings_list prog5.funs) in
   let all_fns_sym_set = Sym.Set.of_list prog5_fns_list in
   let selected_function_syms =

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -1,3 +1,4 @@
+module CF = Cerb_frontend
 module Cn_to_ail = Cn_to_ail
 module Extract = Extract
 module Internal = Internal
@@ -186,6 +187,43 @@ let memory_accesses_injections ail_prog =
   !acc
 
 
+let filter_selected_fns
+      (prog5 : unit Mucore.file)
+      (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)
+      (full_instrumentation : Extract.instrumentation list)
+  =
+  (* Filtering based on Common.Flags.only and Common.Flags.skip *)
+  let prog5_fns_list = List.map fst (Pmap.bindings_list prog5.funs) in
+  let all_fns_sym_set = Sym.Set.of_list prog5_fns_list in
+  let selected_function_syms =
+    Sym.Set.elements (Check.select_functions all_fns_sym_set)
+  in
+  let main_sym =
+    List.filter (fun sym -> String.equal (Sym.pp_string sym) "main") prog5_fns_list
+  in
+  let is_sym_selected =
+    fun sym -> List.mem Sym.equal sym (selected_function_syms @ main_sym)
+  in
+  let filtered_instrumentation =
+    List.filter
+      (fun (i : Extract.instrumentation) -> is_sym_selected i.fn)
+      full_instrumentation
+  in
+  let filtered_ail_prog_decls =
+    List.filter (fun (decl_sym, _) -> is_sym_selected decl_sym) sigm.declarations
+  in
+  let filtered_ail_prog_defs =
+    List.filter (fun (def_sym, _) -> is_sym_selected def_sym) sigm.function_definitions
+  in
+  let filtered_sigm =
+    { sigm with
+      declarations = filtered_ail_prog_decls;
+      function_definitions = filtered_ail_prog_defs
+    }
+  in
+  (filtered_instrumentation, filtered_sigm)
+
+
 let output_to_oc oc str_list = List.iter (Stdlib.output_string oc) str_list
 
 open Internal
@@ -204,7 +242,8 @@ let main
       ?(copy_source_dir = false)
       filename
       ~use_preproc
-      ((_, sigm) as ail_prog)
+      ((startup_sym_opt, (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma)) as
+       ail_prog)
       output_decorated
       output_decorated_dir
       (prog5 : unit Mucore.file)
@@ -221,21 +260,17 @@ let main
   let (full_instrumentation : Extract.instrumentation list), _ =
     Extract.collect_instrumentation prog5
   in
-  let prog5_fn_bindings_list = Pmap.bindings_list prog5.funs in
-  let all_fns_sym_set = Sym.Set.of_list (List.map fst prog5_fn_bindings_list) in
-  let selected_functions = Sym.Set.elements (Check.select_functions all_fns_sym_set) in
-  let instrumentation =
-    List.filter
-      (fun (i : Extract.instrumentation) -> List.mem Sym.equal i.fn selected_functions)
-      full_instrumentation
+  let filtered_instrumentation, filtered_sigm =
+    filter_selected_fns prog5 sigm full_instrumentation
   in
-  Records.populate_record_map instrumentation prog5;
+  let filtered_ail_prog = (startup_sym_opt, filtered_sigm) in
+  Records.populate_record_map filtered_instrumentation prog5;
   let executable_spec =
     generate_c_specs
       without_ownership_checking
       without_loop_invariants
       with_loop_leak_checks
-      instrumentation
+      filtered_instrumentation
       sigm
       prog5
   in
@@ -317,7 +352,10 @@ let main
   in
   let toplevel_injections = List.map (fun loc -> (loc, [ "" ])) toplevel_locs in
   let accesses_stmt_injs =
-    if without_ownership_checking then [] else memory_accesses_injections ail_prog
+    if without_ownership_checking then
+      []
+    else
+      memory_accesses_injections filtered_ail_prog
   in
   let struct_locs = List.map (fun (_, (loc, _, _)) -> loc) sigm.tag_definitions in
   let struct_injs = List.map (fun loc -> (loc, [ "" ])) struct_locs in


### PR DESCRIPTION
Implement `--only` and `--skip` within Fulminate. These already existed as flags to be passed to CN when verifying code ~~so these have been extracted into `Common.Flags` and~~ . The filtering function `select_functions` from `Check.ml` has been reused.

NB: Currently this always instruments the `main` function (if it exists) so that ownership checks don't trivially fail. ~~Also, it _really_ only instruments the functions specified in `--only` - whereas CN verification will perform checking for whatever functions are passed in and also all of their callees.~~

Closes #76 