### PR TITLE
[CN-Exec] Do not inject synthesized terms

### DIFF
--- a/cn.opam
+++ b/cn.opam
@@ -23,7 +23,7 @@ depends: [
   "zarith" {>= "1.13"}
 ]
 pin-depends: [
-  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#ef237b3"]
+  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#6e3e8be"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/tests/cn/list_literal_type.error.c.verify
+++ b/tests/cn/list_literal_type.error.c.verify
@@ -1,5 +1,5 @@
 return code: 2
 tests/cn/list_literal_type.error.c:3:15: error: unexpected token after 'list' and before '<'
-Please add error message for state 1844 to parsers/c/c_parser_error.messages
+Please add error message for state 1846 to parsers/c/c_parser_error.messages
 function (list<integer>) nonempty_list() {
               ^ 

--- a/tests/cn/tree16/as_auto_mutual_dt/tree16.error.c.verify
+++ b/tests/cn/tree16/as_auto_mutual_dt/tree16.error.c.verify
@@ -1,5 +1,5 @@
 return code: 2
 tests/cn/tree16/as_auto_mutual_dt/tree16.error.c:30:21: error: unexpected token after 'list' and before '<'
-Please add error message for state 1014 to parsers/c/c_parser_error.messages
+Please add error message for state 1016 to parsers/c/c_parser_error.messages
   Node {i32 v, list <datatype tree> children}
                     ^ 


### PR DESCRIPTION
The injection model breaks down for `++a;` because the `++` part should just disappear but the previous handling doesn't know that. From what I've determined only `++a` and `--a` actually break the (wrongly assumed) invariant that the members of an AIL term have locations that actually represent their source position. #39 fails in the same way as processing `++a` but I don't think it's from the same cause. This needs https://github.com/rems-project/cerberus/pull/950 as its cerberus.