### PR TITLE
Fix local `run-cn-test-gen.sh`

### DIFF
--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -62,7 +62,7 @@ size_t cn_gen_compute_size(enum cn_gen_sizing_strategy strategy,
     longjmp(buf_##FuncName, 1);                                                          \
   }                                                                                      \
                                                                                          \
-  enum cn_test_result cn_test_const_##FuncName(struct cn_test_input) {                   \
+  enum cn_test_result cn_test_const_##FuncName(struct cn_test_input _input) {            \
     if (setjmp(buf_##FuncName)) {                                                        \
       return CN_TEST_FAIL;                                                               \
     }                                                                                    \


### PR DESCRIPTION
Similar to #86, `run-cn-test-gen.sh` was also broken locally by #55, but not in CI. Same issue as #85.