### PR TITLE
git: ignore `_opam` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Dune build directory
+# Build directories
 _build
+_opam
 
 # Dune temporary files
 *.install


### PR DESCRIPTION
This directory is created if CN is built in a local switch. Though this isn't the prescribed build process, I don't think there's any other natural way for this directory to appear, and I don't see any harm in ignoring it.