### PR TITLE
Fix diff-prog.py for macOS

### DIFF
--- a/tests/cn/verify.json
+++ b/tests/cn/verify.json
@@ -1,6 +1,6 @@
 {
     "name": "verify",
-    "args": ["verify"],
+    "args": ["verify", "--output-dir=/tmp"],
     "filter": "^(.*\\.c)$",
     "timeout": 60
 }

--- a/tests/cn_vip_testsuite/no_annot.json
+++ b/tests/cn_vip_testsuite/no_annot.json
@@ -1,6 +1,6 @@
 {
     "name": "no_annot",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "--solver-type=cvc5" ],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "--solver-type=cvc5", "--output-dir=/tmp"],
     "filter": "^(.*\\.c)$",
     "timeout": 35
 }

--- a/tests/cn_vip_testsuite/non_det_false.json
+++ b/tests/cn_vip_testsuite/non_det_false.json
@@ -1,6 +1,6 @@
 {
     "name": "non_det_false",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_FALSE", "--solver-type=cvc5" ],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_FALSE", "--solver-type=cvc5", "--output-dir=/tmp"],
     "filter": "^(.*\\.nondet.c)$",
     "timeout": 35
 }

--- a/tests/cn_vip_testsuite/non_det_true.json
+++ b/tests/cn_vip_testsuite/non_det_true.json
@@ -1,6 +1,6 @@
 {
     "name": "non_det_true",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_TRUE", "--solver-type=cvc5" ],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_TRUE", "--solver-type=cvc5", "--output-dir=/tmp"],
     "filter": "^(.*\\.nondet\\.c)$",
     "timeout": 35
 }

--- a/tests/cn_vip_testsuite/with_annot.json
+++ b/tests/cn_vip_testsuite/with_annot.json
@@ -1,6 +1,6 @@
 {
     "name": "with_annot",
-    "args": ["verify", "-DVIP", "-DANNOT", "-DNO_ROUND_TRIP", "--solver-type=cvc5" ],
+    "args": ["verify", "-DVIP", "-DANNOT", "-DNO_ROUND_TRIP", "--solver-type=cvc5", "--output-dir=/tmp"],
     "filter": "^((pointer_from_int_disambiguation_3\\.error\\.c)|(.*\\.annot\\.c))$",
     "timeout": 35
 }

--- a/tests/diff-prog.py
+++ b/tests/diff-prog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, sys, re, subprocess, json, difflib, argparse, concurrent.futures, math
+import os, sys, re, subprocess, json, difflib, argparse, concurrent.futures, math, multiprocessing
 
 def eprint(*args, then_exit=True, **kwargs):
     print('Error:', *args, file=sys.stderr, **kwargs)
@@ -8,7 +8,7 @@ def eprint(*args, then_exit=True, **kwargs):
         exit(1)
 
 def time_cmd(cmd):
-    return ["/usr/bin/time", "--quiet", "--format", "%e"] + cmd
+    return ["/usr/bin/time", "-p"] + cmd
 
 class Prog:
 
@@ -33,8 +33,8 @@ class Prog:
         try:
             completed = self.run(test_rel_path);
             lines = completed.stdout.splitlines(True)
-            time = float(lines[-1])
-            return { 'time': time, 'lines' : [("return code: %d\n" % completed.returncode)] + lines[:-1] }
+            time = float(lines[-3].split()[1])
+            return { 'time': time, 'lines' : [("return code: %d\n" % completed.returncode)] + lines[:-3] }
         except subprocess.TimeoutExpired:
             return { 'time': float(self.timeout), 'lines': ["TIMEOUT\n"] }
 
@@ -123,5 +123,7 @@ parser.add_argument('--max-workers', help='Specify max number of workers for pro
 parser.set_defaults(func=main)
 
 # parse args and call func (as set using set_defaults)
-opts = parser.parse_args()
-exit(opts.func(opts))
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    opts = parser.parse_args()
+    exit(opts.func(opts))


### PR DESCRIPTION
Specifically, guard the script with a __main__ check, and use the POSIX time format.

multiprocessing.freeze_support() is really relevant on Windows (e.g. for py2exe or cx_Freeze, see
https://docs.python.org/3/library/multiprocessing.html); it has no effect on other cases (and for Windows, /usr/bin/time would not work anyways so will need updating then too).