### PR TITLE
Add ghost arguments to backend

### DIFF
--- a/lib/argumentTypes.ml
+++ b/lib/argumentTypes.ml
@@ -112,16 +112,6 @@ let alpha_unique ss =
   f ss
 
 
-(* let binders i_binders i_subst = *)
-(*   let rec aux = function *)
-(*     | Computational ((s, bt), _, t) -> *)
-(*       let s, t = alpha_rename i_subst s t in *)
-(*       let here = Locations.other __LOC__ in *)
-(*       (Id.make here (Sym.pp_string s), bt) :: aux t *)
-(*     | L t -> LAT.binders i_binders i_subst t *)
-(*   in *)
-(*   aux *)
-
 let of_rt (rt : RT.t) (rest : 'i LAT.t) : 'i t =
   let (RT.Computational ((name, t), info, lrt)) = rt in
   Computational ((name, t), info, L (LAT.of_lrt lrt rest))

--- a/lib/argumentTypes.ml
+++ b/lib/argumentTypes.ml
@@ -7,6 +7,7 @@ module LAT = LogicalArgumentTypes
 
 type 'i t =
   | Computational of (Sym.t * BT.t) * info * 'i t
+  | Ghost of (Sym.t * BT.t) * info * 'i t
   | L of 'i LAT.t
 
 let mComputational (name, bound, info) t = Computational ((name, bound), info, t)
@@ -18,6 +19,9 @@ let rec subst i_subst (substitution : _ Subst.t) at =
   | Computational ((name, bt), info, t) ->
     let name, t = suitably_alpha_rename i_subst substitution.relevant name t in
     Computational ((name, bt), info, subst i_subst substitution t)
+  | Ghost ((name, bt), info, t) ->
+    let name, t = suitably_alpha_rename i_subst substitution.relevant name t in
+    Ghost ((name, bt), info, subst i_subst substitution t)
   | L t -> L (LAT.subst i_subst substitution t)
 
 
@@ -38,6 +42,9 @@ let simp i_subst simp_i simp_it simp_lc simp_re =
     | Computational ((s, bt), info, t) ->
       let s, t = alpha_rename i_subst s t in
       Computational ((s, bt), info, aux t)
+    | Ghost ((s, bt), info, t) ->
+      let s, t = alpha_rename i_subst s t in
+      Ghost ((s, bt), info, aux t)
     | L lt -> L (LAT.simp i_subst simp_i simp_it simp_lc simp_re lt)
   in
   aux
@@ -49,6 +56,9 @@ let pp i_pp ft =
     | Computational ((name, bt), _info, t) ->
       let op = if !unicode then utf8string "\u{03A0}" else !^"AC" in
       group (op ^^^ typ (Sym.pp name) (BT.pp bt) ^^ dot) :: aux t
+    | Ghost ((name, bt), _info, t) ->
+      let op = if !unicode then utf8string "\u{2200}" else !^"AL" in
+      group (op ^^^ typ (Sym.pp name) (BT.pp bt) ^^ dot) :: aux t
     | L t -> LAT.pp_aux i_pp t
   in
   flow (break 1) (aux ft)
@@ -56,20 +66,31 @@ let pp i_pp ft =
 
 let rec get_return = function
   | Computational (_, _, ft) -> get_return ft
+  | Ghost (_, _, ft) -> get_return ft
   | L t -> LAT.get_return t
 
 
-let rec get_lat = function Computational (_, _, ft) -> get_lat ft | L t -> t
+let rec get_lat = function
+  | Computational (_, _, ft) -> get_lat ft
+  | Ghost (_, _, ft) -> get_lat ft
+  | L t -> t
+
 
 let rec get_computational = function
   | Computational (sbt, _, ft) -> sbt :: get_computational ft
+  | Ghost (_, _, ft) -> get_computational ft
   | L _ -> []
 
 
-let rec count_computational = function
-  | Computational (_, _, ft) -> 1 + count_computational ft
-  | L _ -> 0
+let rec get_ghost = function
+  | Computational (_, _, ft) -> get_ghost ft
+  | Ghost (sbt, _, ft) -> sbt :: get_ghost ft
+  | L _ -> []
 
+
+let count_computational at = List.length (get_computational at)
+
+let count_ghost at = List.length (get_ghost at)
 
 module LRT = LogicalReturnTypes
 module RT = ReturnTypes
@@ -82,21 +103,24 @@ let alpha_unique ss =
       let name, t = rename_if ss name t in
       let t = f (Sym.Set.add name ss) t in
       Computational ((name, bt), info, t)
+    | Ghost ((name, bt), info, t) ->
+      let name, t = rename_if ss name t in
+      let t = f (Sym.Set.add name ss) t in
+      Ghost ((name, bt), info, t)
     | L t -> L (LAT.alpha_unique ss t)
   in
   f ss
 
 
-let binders i_binders i_subst =
-  let rec aux = function
-    | Computational ((s, bt), _, t) ->
-      let s, t = alpha_rename i_subst s t in
-      let here = Locations.other __LOC__ in
-      (Id.make here (Sym.pp_string s), bt) :: aux t
-    | L t -> LAT.binders i_binders i_subst t
-  in
-  aux
-
+(* let binders i_binders i_subst = *)
+(*   let rec aux = function *)
+(*     | Computational ((s, bt), _, t) -> *)
+(*       let s, t = alpha_rename i_subst s t in *)
+(*       let here = Locations.other __LOC__ in *)
+(*       (Id.make here (Sym.pp_string s), bt) :: aux t *)
+(*     | L t -> LAT.binders i_binders i_subst t *)
+(*   in *)
+(*   aux *)
 
 let of_rt (rt : RT.t) (rest : 'i LAT.t) : 'i t =
   let (RT.Computational ((name, t), info, lrt)) = rt in
@@ -106,6 +130,7 @@ let of_rt (rt : RT.t) (rest : 'i LAT.t) : 'i t =
 let rec map (f : 'i -> 'j) (at : 'i t) : 'j t =
   match at with
   | Computational (bound, info, at) -> Computational (bound, info, map f at)
+  | Ghost (bound, info, at) -> Ghost (bound, info, map f at)
   | L t -> L (LAT.map f t)
 
 
@@ -123,6 +148,7 @@ let dtree dtree_i =
   let rec aux = function
     | Computational ((s, _bt), _, lat) ->
       Dnode (pp_ctor "Computational", [ Dleaf (Sym.pp s); aux lat ])
+    | Ghost ((s, _bt), _, lat) -> Dnode (pp_ctor "Ghost", [ Dleaf (Sym.pp s); aux lat ])
     | L l -> LAT.dtree dtree_i l
   in
   aux

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -551,7 +551,7 @@ let rec symb_exec_expr ctxt state_vars expr =
                   (Pp_mucore.pp_expr expr))
              [@alert "-deprecated"]
          })
-  | Eccall (_act, fun_pe, args_pe) ->
+  | Eccall (_act, fun_pe, args_pe, gargs) ->
     let@ fun_it = symb_exec_pexpr ctxt var_map fun_pe in
     let@ args_its = ListM.mapM (symb_exec_pexpr ctxt var_map) args_pe in
     let fail_fun_it msg =
@@ -565,32 +565,36 @@ let rec symb_exec_expr ctxt state_vars expr =
             [@alert "-deprecated"]
         }
     in
-    let@ nm =
-      match IT.is_sym fun_it with
-      | None -> fail_fun_it "not a constant function address"
-      | Some (nm, _) -> return nm
-    in
-    if Sym.Map.mem nm ctxt.c_fun_pred_map then (
-      let loc, l_sym = Sym.Map.find nm ctxt.c_fun_pred_map in
-      let@ def = Global.get_logical_function_def loc l_sym in
-      rcval (IT.apply_ l_sym args_its def.Definition.Function.return_bt loc) state)
-    else (
-      let bail = fail_fun_it "not a function with a pure/logical interpretation" in
-      match Sym.has_id nm with
-      | None -> bail
-      | Some s ->
-        let wrap_int x = IT.wrapI_ (signed_int_ity, x) in
-        if String.equal s "ctz_proxy" then
-          rcval
-            (wrap_int (IT.arith_unop Terms.BW_CTZ_NoSMT (List.hd args_its) loc) loc)
-            state
-        else if List.exists (String.equal s) [ "ffs_proxy"; "ffsl_proxy"; "ffsll_proxy" ]
-        then
-          rcval
-            (wrap_int (IT.arith_unop Terms.BW_FFS_NoSMT (List.hd args_its) loc) loc)
-            state
-        else
-          bail)
+    if not (List.is_empty gargs) then
+      fail_fun_it "cannot translate function calls with ghost arguments yet"
+    else
+      let@ nm =
+        match IT.is_sym fun_it with
+        | None -> fail_fun_it "not a constant function address"
+        | Some (nm, _) -> return nm
+      in
+      if Sym.Map.mem nm ctxt.c_fun_pred_map then (
+        let loc, l_sym = Sym.Map.find nm ctxt.c_fun_pred_map in
+        let@ def = Global.get_logical_function_def loc l_sym in
+        rcval (IT.apply_ l_sym args_its def.Definition.Function.return_bt loc) state)
+      else (
+        let bail = fail_fun_it "not a function with a pure/logical interpretation" in
+        match Sym.has_id nm with
+        | None -> bail
+        | Some s ->
+          let wrap_int x = IT.wrapI_ (signed_int_ity, x) in
+          if String.equal s "ctz_proxy" then
+            rcval
+              (wrap_int (IT.arith_unop Terms.BW_CTZ_NoSMT (List.hd args_its) loc) loc)
+              state
+          else if
+            List.exists (String.equal s) [ "ffs_proxy"; "ffsl_proxy"; "ffsll_proxy" ]
+          then
+            rcval
+              (wrap_int (IT.arith_unop Terms.BW_FFS_NoSMT (List.hd args_its) loc) loc)
+              state
+          else
+            bail)
   | CN_progs _ -> rcval (IT.unit_ loc) state
   | _ ->
     fail_n
@@ -708,6 +712,14 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
         Typing.bind
           (Typing.add_a s bt (loc, lazy (Pp.item "argument" (Sym.pp s))))
           (fun () -> in_computational_ctxt args_and_body m)
+      | Ghost (_, _, _) ->
+        fail_n
+          { loc;
+            msg =
+              Generic
+                Pp.(!^"cannot translate function with ghost arguments:" ^^^ Sym.pp fsym)
+              [@alert "-deprecated"]
+          }
       | L _ -> m
     in
     let@ arg_map, (body, labels, rt) = mk_var_map Sym.Map.empty args_and_body def_args in

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -491,7 +491,24 @@ let rec symb_exec_expr ctxt state_vars expr =
         return (If_Else (t, r_x, r_y))
     in
     cont1 state [] exps
-  | Erun (sym, args) ->
+  | Erun (sym, args, gargs) ->
+    let fail_fun_it msg =
+      fail_n
+        { loc;
+          msg =
+            Generic
+              (Pp.item
+                 ("getting expr from C syntax: run val: " ^ msg)
+                 (Pp_mucore.pp_expr expr))
+            [@alert "-deprecated"]
+        }
+    in
+    let@ () =
+      if not (List.is_empty gargs) then
+        fail_fun_it "cannot translate runs with ghost arguments yet"
+      else
+        return ()
+    in
     let@ arg_vs = ListM.mapM (symb_exec_pexpr ctxt var_map) args in
     (match Pmap.lookup sym ctxt.label_defs with
      | Some (Return _) ->

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -714,14 +714,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
         Typing.bind
           (Typing.add_a s bt (loc, lazy (Pp.item "argument" (Sym.pp s))))
           (fun () -> in_computational_ctxt args_and_body m)
-      | Ghost (_, _, _) ->
-        fail_n
-          { loc;
-            msg =
-              Generic
-                Pp.(!^"cannot translate function with ghost arguments:" ^^^ Sym.pp fsym)
-              [@alert "-deprecated"]
-          }
+      | Ghost (_, _, _) -> fail_n { loc; msg = Not_impl_ghost_args_in_pure_C_function }
       | L _ -> m
     in
     let@ arg_map, (body, labels, rt) = mk_var_map Sym.Map.empty args_and_body def_args in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1140,11 +1140,11 @@ end = struct
         | _ :: _, _, L _ | [], _, Computational _ ->
           let expect = count_computational original_ftyp in
           let has = List.length original_args in
-          WellTyped.ensure_same_argument_number loc `Other has ~expect
+          WellTyped.ensure_same_argument_number loc `Computational has ~expect
         | _, _ :: _, L _ | _, [], Ghost _ ->
           let expect = count_ghost original_ftyp in
           let has = List.length original_gargs in
-          WellTyped.ensure_same_argument_number loc `Other has ~expect
+          WellTyped.ensure_same_argument_number loc `Ghost has ~expect
       in
       fun args gargs ftyp k -> aux [] args gargs ftyp k
     in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -2162,7 +2162,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          check_expr labels e2 (fun it2 ->
            let@ () = remove_as bound_a in
            k it2))
-     | Erun (label_sym, pes) ->
+     | Erun (label_sym, pes, its) ->
        let@ () = WellTyped.ensure_base_type loc ~expect Unit in
        let@ lt, lkind =
          match Sym.Map.find_opt label_sym labels with
@@ -2176,7 +2176,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          | Some (lt, lkind, _) -> return (lt, lkind)
        in
        let@ original_resources = all_resources_tagged loc in
-       Spine.calltype_lt loc pes [] (lt, lkind) (fun False ->
+       Spine.calltype_lt loc pes its (lt, lkind) (fun False ->
          let@ () = all_empty loc original_resources in
          return ()))
 

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1096,11 +1096,6 @@ end = struct
     check_pexpr pe k
 
 
-  let check_arg_it loc it_arg ~(expect : BT.t) k =
-    let@ it_arg = WellTyped.check_term loc expect it_arg in
-    k it_arg
-
-
   let spine rt_subst rt_pp loc situation args gargs ftyp k =
     let open ArgumentTypes in
     let original_ftyp = ftyp in
@@ -1124,8 +1119,8 @@ end = struct
               (subst rt_subst (make_subst [ (s, arg) ]) ftyp)
               k)
         | _, garg :: gargs, Ghost ((s, bt), info, ftyp) ->
-          check_arg_it (fst info) garg ~expect:bt (fun garg ->
-            aux args_acc args gargs (subst rt_subst (make_subst [ (s, garg) ]) ftyp) k)
+          let@ garg = WellTyped.check_term (fst info) bt garg in
+          aux args_acc args gargs (subst rt_subst (make_subst [ (s, garg) ]) ftyp) k
         | [], [], L ftyp ->
           let@ () =
             match situation with

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1043,6 +1043,7 @@ module Spine : sig
     :  Loc.t ->
     fsym:Sym.t ->
     BT.t Mu.pexpr list ->
+    IT.t list ->
     AT.ft ->
     (RT.t -> unit m) ->
     unit m
@@ -1050,6 +1051,7 @@ module Spine : sig
   val calltype_lt
     :  Loc.t ->
     BT.t Mu.pexpr list ->
+    IT.t list ->
     AT.lt * Where.label ->
     (False.t -> unit m) ->
     unit m
@@ -1057,7 +1059,7 @@ module Spine : sig
   val calltype_lemma
     :  Loc.t ->
     lemma:Sym.t ->
-    (Loc.t * IT.t) list ->
+    IT.t list ->
     AT.lemmat ->
     (LRT.t -> unit m) ->
     unit m
@@ -1087,10 +1089,32 @@ end = struct
     k rt
 
 
-  let spine check_arg rt_subst rt_pp loc (situation : call_situation) args ftyp k =
+  let check_arg_pexpr (pe : BT.t Mu.pexpr) ~expect k =
+    let@ () =
+      WellTyped.ensure_base_type (Mu.loc_of_pexpr pe) ~expect (Mu.bt_of_pexpr pe)
+    in
+    check_pexpr pe k
+
+
+  let check_arg_it loc it_arg ~(expect : BT.t) k =
+    let@ it_arg = WellTyped.check_term loc expect it_arg in
+    k it_arg
+
+
+  let spine
+        rt_subst
+        rt_pp
+        loc
+        (situation : call_situation)
+        args
+        (gargs : IT.t list)
+        ftyp
+        k
+    =
     let open ArgumentTypes in
     let original_ftyp = ftyp in
     let original_args = args in
+    let original_gargs = gargs in
     let@ () =
       print_with_ctxt (fun ctxt ->
         debug 6 (lazy (call_situation situation));
@@ -1098,16 +1122,35 @@ end = struct
         debug 6 (lazy (item "spec" (pp rt_pp ftyp))))
     in
     let check =
-      let rec aux args_acc args ftyp k =
-        match (args, ftyp) with
-        | arg :: args, Computational ((s, bt), _info, ftyp) ->
-          check_arg arg ~expect:bt (fun arg ->
+      let rec aux args_acc gargs_acc args gargs ftyp k =
+        match (args, gargs, ftyp) with
+        | arg :: args, _, Computational ((s, bt), _info, ftyp) ->
+          check_arg_pexpr arg ~expect:bt (fun arg ->
             aux
               (args_acc @ [ arg ])
+              gargs_acc
               args
+              gargs
               (subst rt_subst (make_subst [ (s, arg) ]) ftyp)
               k)
-        | [], L ftyp ->
+        | _ :: _, _, _ | [], _, Computational _ ->
+          let expect = count_computational original_ftyp in
+          let has = List.length original_args in
+          WellTyped.ensure_same_argument_number loc `Other has ~expect
+        | [], garg :: gargs, Ghost ((s, bt), info, ftyp) ->
+          check_arg_it (fst info) garg ~expect:bt (fun garg ->
+            aux
+              args_acc
+              (gargs_acc @ [ garg ])
+              args
+              gargs
+              (subst rt_subst (make_subst [ (s, garg) ]) ftyp)
+              k)
+        | [], _ :: _, L _ | [], [], Ghost _ ->
+          let expect = count_ghost original_ftyp in
+          let has = List.length original_gargs in
+          WellTyped.ensure_same_argument_number loc `Other has ~expect
+        | [], [], L ftyp ->
           let@ () =
             match situation with
             | FunctionCall fsym -> record_action (Call (fsym, args_acc), loc)
@@ -1117,38 +1160,22 @@ end = struct
             | _ -> return ()
           in
           k ftyp
-        | _ ->
-          let expect = count_computational original_ftyp in
-          let has = List.length original_args in
-          WellTyped.ensure_same_argument_number loc `Other has ~expect
       in
-      fun args ftyp k -> aux [] args ftyp k
+      fun args gargs ftyp k -> aux [] [] args gargs ftyp k
     in
-    check args ftyp (fun lftyp -> spine_l rt_subst rt_pp loc situation lftyp k)
+    check args gargs ftyp (fun lftyp -> spine_l rt_subst rt_pp loc situation lftyp k)
 
 
-  let check_arg_pexpr (pe : BT.t Mu.pexpr) ~expect k =
-    let@ () =
-      WellTyped.ensure_base_type (Mu.loc_of_pexpr pe) ~expect (Mu.bt_of_pexpr pe)
-    in
-    check_pexpr pe k
+  let calltype_ft loc ~fsym args gargs (ftyp : AT.ft) k =
+    spine RT.subst RT.pp loc (FunctionCall fsym) args gargs ftyp k
 
 
-  let check_arg_it (loc, it_arg) ~(expect : BT.t) k =
-    let@ it_arg = WellTyped.check_term loc expect it_arg in
-    k it_arg
+  let calltype_lt loc args gargs ((ltyp : AT.lt), label_kind) k =
+    spine False.subst False.pp loc (LabelCall label_kind) args gargs ltyp k
 
 
-  let calltype_ft loc ~fsym args (ftyp : AT.ft) k =
-    spine check_arg_pexpr RT.subst RT.pp loc (FunctionCall fsym) args ftyp k
-
-
-  let calltype_lt loc args ((ltyp : AT.lt), label_kind) k =
-    spine check_arg_pexpr False.subst False.pp loc (LabelCall label_kind) args ltyp k
-
-
-  let calltype_lemma loc ~lemma args lemma_typ k =
-    spine check_arg_it LRT.subst LRT.pp loc (LemmaApplication lemma) args lemma_typ k
+  let calltype_lemma loc ~lemma gargs lemma_typ k =
+    spine LRT.subst LRT.pp loc (LemmaApplication lemma) [] gargs lemma_typ k
 
 
   (* The "subtyping" judgment needs the same resource/lvar/constraint
@@ -1786,7 +1813,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
      | Eskip ->
        let@ () = WellTyped.ensure_base_type loc ~expect Unit in
        k (unit_ loc)
-     | Eccall (act, f_pe, pes) ->
+     | Eccall (act, f_pe, pes, its) ->
        let@ () = WellTyped.check_ct act.loc act.ct in
        (* copied TS's, from wellTyped.ml *)
        (* let@ (_ret_ct, _arg_cts) = match act.ct with *)
@@ -1813,13 +1840,19 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
                })
          in
          (* checks pes against their annotations, and that they match ft's argument types *)
-         Spine.calltype_ft loc ~fsym pes ft (fun (Computational ((_, bt), _, _) as rt) ->
-           let@ () = WellTyped.ensure_base_type loc ~expect bt in
-           let@ _, members =
-             make_return_record loc (call_prefix (FunctionCall fsym)) (RT.binders rt)
-           in
-           let@ lvt = bind_return loc members rt in
-           k lvt))
+         Spine.calltype_ft
+           loc
+           ~fsym
+           pes
+           its
+           ft
+           (fun (Computational ((_, bt), _, _) as rt) ->
+              let@ () = WellTyped.ensure_base_type loc ~expect bt in
+              let@ _, members =
+                make_return_record loc (call_prefix (FunctionCall fsym)) (RT.binders rt)
+              in
+              let@ lvt = bind_return loc members rt in
+              k lvt))
      | Eif (c_pe, e1, e2) ->
        let@ () =
          WellTyped.ensure_base_type (Mu.loc_of_expr e1) ~expect (Mu.bt_of_expr e1)
@@ -2058,7 +2091,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
               add_c loc (LC.T (eq_ (apply_ f args def.return_bt loc, body) loc)))
          | Apply (lemma, args) ->
            let@ _loc, lemma_typ = Global.get_lemma loc lemma in
-           let args = List.map (fun arg -> (loc, arg)) args in
            Spine.calltype_lemma loc ~lemma args lemma_typ (fun lrt ->
              let@ _, members =
                make_return_record
@@ -2164,7 +2196,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          | Some (lt, lkind, _) -> return (lt, lkind)
        in
        let@ original_resources = all_resources_tagged loc in
-       Spine.calltype_lt loc pes (lt, lkind) (fun False ->
+       Spine.calltype_lt loc pes [] (lt, lkind) (fun False ->
          let@ () = all_empty loc original_resources in
          return ()))
 
@@ -2210,6 +2242,9 @@ let bind_arguments (_loc : Locations.t) (full_args : _ Mu.arguments) =
   let rec aux_a = function
     | Mu.Computational ((s, bt), info, args) ->
       let@ () = add_a s bt (fst info, lazy (Sym.pp s)) in
+      aux_a args
+    | Mu.Ghost ((s, bt), info, args) ->
+      let@ () = add_l s bt (fst info, lazy (Sym.pp s)) in
       aux_a args
     | L args -> aux_l [] args
   in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1101,16 +1101,7 @@ end = struct
     k it_arg
 
 
-  let spine
-        rt_subst
-        rt_pp
-        loc
-        (situation : call_situation)
-        args
-        (gargs : IT.t list)
-        ftyp
-        k
-    =
+  let spine rt_subst rt_pp loc situation args gargs ftyp k =
     let open ArgumentTypes in
     let original_ftyp = ftyp in
     let original_args = args in

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1606,10 +1606,10 @@ let lemma env (def : _ Cn.cn_lemma) =
   let rec aux env = function
     | (sym, bTy) :: args' ->
       let bTy = base_type env bTy in
-      let env = add_computational sym bTy env in
+      let env = add_logical sym bTy env in
       let@ at = aux env args' in
       let info = (def.cn_lemma_loc, None) in
-      return (ArgumentTypes.Computational ((sym, SBT.proj bTy), info, at))
+      return (ArgumentTypes.Ghost ((sym, SBT.proj bTy), info, at))
     | [] ->
       let@ lat =
         logical_arg env C_vars.init (def.cn_lemma_requires, def.cn_lemma_ensures)

--- a/lib/consistent.ml
+++ b/lib/consistent.ml
@@ -99,6 +99,10 @@ let argumentTypes i_welltyped i_pp kind loc at : unit Typing.t =
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
       let@ () = add_a name bt (fst info, lazy (Sym.pp name)) in
       aux at
+    | AT.Ghost ((name, bt), info, at) ->
+      (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
+      let@ () = add_l name bt (fst info, lazy (Sym.pp name)) in
+      aux at
     | L at -> logicalArgumentTypes i_welltyped i_pp kind loc at
   in
   pure (aux at)
@@ -173,6 +177,10 @@ let arguments
     | Mucore.Computational ((name, bt), info, at) ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
       let@ () = add_a name bt (fst info, lazy (Sym.pp name)) in
+      aux at
+    | Mucore.Ghost ((name, bt), info, at) ->
+      (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
+      let@ () = add_l name bt (fst info, lazy (Sym.pp name)) in
       aux at
     | L at -> logicalArguments i_welltyped kind loc at
   in

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -811,7 +811,9 @@ let rec n_expr
       | _ -> return @@ n_pexpr e2
     in
     let es = List.map n_pexpr es in
-    return (wrap (Eccall (ct1, e2, es)))
+    let ghost_args = [] in
+    (* TODO *)
+    return (wrap (Eccall (ct1, e2, es, ghost_args)))
   | Eproc (_a, name, es) ->
     let es = List.map n_pexpr es in
     (match (name, es) with
@@ -917,6 +919,7 @@ let rec lat_of_arguments f_i = function
 let rec at_of_arguments f_i = function
   | Mu.Computational (bound, info, a) ->
     AT.Computational (bound, info, at_of_arguments f_i a)
+  | Mu.Ghost (bound, info, a) -> AT.Ghost (bound, info, at_of_arguments f_i a)
   | L l -> AT.L (lat_of_arguments f_i l)
 
 
@@ -930,6 +933,7 @@ let rec arguments_of_lat f_i = function
 let rec arguments_of_at f_i = function
   | AT.Computational (bound, info, at) ->
     Mu.Computational (bound, info, arguments_of_at f_i at)
+  | AT.Ghost (bound, info, at) -> Mu.Ghost (bound, info, arguments_of_at f_i at)
   | AT.L lat -> L (arguments_of_lat f_i lat)
 
 
@@ -1523,8 +1527,7 @@ let normalise_fun_map_decl
            (List.combine (List.combine ail_args arg_cts) args)
            (accesses, requires)
        in
-       let desugared_spec = Mu.{ accesses = List.map snd accesses; requires; ensures } in
-       return (Some (Mu.Proc { loc; args_and_body; trusted; desugared_spec }, functions))
+       return (Some (Mu.Proc { loc; args_and_body; trusted }, functions))
      | Mi_ProcDecl (loc, ret_bt, _bts) ->
        (match Sym.Map.find_opt fname fun_specs with
         | Some parsed_decl_spec ->

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -812,7 +812,7 @@ let rec n_expr
     in
     let es = List.map n_pexpr es in
     let ghost_args = [] in
-    (* TODO *)
+    (* TODO: https://github.com/rems-project/cn/issues/123 *)
     return (wrap (Eccall (ct1, e2, es, ghost_args)))
   | Eproc (_a, name, es) ->
     let es = List.map n_pexpr es in

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -899,7 +899,9 @@ let rec n_expr
     assert_error loc !^"core_anormalisation: Esave"
   | Erun (_a, sym1, pes) ->
     let pes = List.map n_pexpr pes in
-    return (wrap (Erun (sym1, pes)))
+    let ghost_args = [] in
+    (* TODO: https://github.com/rems-project/cn/issues/123 *)
+    return (wrap (Erun (sym1, pes, ghost_args)))
   | Epar _es -> assert_error loc !^"core_anormalisation: Epar"
   | Ewait _tid1 -> assert_error loc !^"core_anormalisation: Ewait"
   | Eannot _ -> assert_error loc !^"core_anormalisation: Eannot"

--- a/lib/explain.ml
+++ b/lib/explain.ml
@@ -18,8 +18,15 @@ type action =
   | Write of IndexTerms.t * IndexTerms.t
   | Create of IndexTerms.t
   | Kill of IndexTerms.t
-  | Call of Sym.t * IndexTerms.t list
-  | Return of IndexTerms.t
+  | Call of
+      { fsym : Sym.t;
+        args : IndexTerms.t list;
+        gargs : IndexTerms.t list
+      }
+  | Return of
+      { arg : IndexTerms.t;
+        gargs : IndexTerms.t list
+      }
 
 type log_entry =
   | Action of action * Locations.t

--- a/lib/explain.mli
+++ b/lib/explain.mli
@@ -4,8 +4,15 @@ type action =
   | Write of IndexTerms.t * IndexTerms.t
   | Create of IndexTerms.t
   | Kill of IndexTerms.t
-  | Call of Sym.t * IndexTerms.t list
-  | Return of IndexTerms.t
+  | Call of
+      { fsym : Sym.t;
+        args : IndexTerms.t list;
+        gargs : IndexTerms.t list
+      }
+  | Return of
+      { arg : IndexTerms.t;
+        gargs : IndexTerms.t list
+      }
 
 (** Info about what happened *)
 type log_entry =

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3661,17 +3661,7 @@ let rec cn_to_ail_loop_inv_aux
       cn_to_ail_loop_inv_aux filename dts globals preds spec_mode_opt subst_loop
     in
     ((cond_loc, (cond_bs, cond_ss)), (loop_loc, (loop_bs, loop_ss)))
-  | AT.Ghost ((sym, bt), _, at') ->
-    let cn_sym = generate_sym_with_suffix ~suffix:"_addr_cn" sym in
-    let subst_loop =
-      ESE.loop_subst
-        (ESE.sym_subst (sym, bt, cn_sym))
-        (contains_user_spec, cond_loc, loop_loc, at')
-    in
-    let (_, (cond_bs, cond_ss)), (_, (loop_bs, loop_ss)) =
-      cn_to_ail_loop_inv_aux dts globals preds spec_mode_opt subst_loop
-    in
-    ((cond_loc, (cond_bs, cond_ss)), (loop_loc, (loop_bs, loop_ss)))
+  | AT.Ghost _ -> failwith "TODO Fulminate: Ghost arguments not yet supported at runtime"
   | L lat ->
     let rec modify_decls_for_loop decls modified_stats =
       let rec collect_initialised_syms_and_exprs = function
@@ -3933,24 +3923,7 @@ let rec cn_to_ail_pre_post_aux
         subst_at
     in
     prepend_to_precondition ail_executable_spec ([ binding ], [ decl ])
-  | AT.Ghost ((sym, bt), _info, at) ->
-    let cn_sym = generate_sym_with_suffix ~suffix:"_cn" sym in
-    let cn_ctype = bt_to_ail_ctype bt in
-    let binding = create_binding cn_sym cn_ctype in
-    let rhs = wrap_with_convert_to A.(AilEident sym) bt in
-    let decl = A.(AilSdeclaration [ (cn_sym, Some (mk_expr rhs)) ]) in
-    let subst_at = ESE.fn_args_and_body_subst (ESE.sym_subst (sym, bt, cn_sym)) at in
-    let ail_executable_spec =
-      cn_to_ail_pre_post_aux
-        without_ownership_checking
-        with_loop_leak_checks
-        dts
-        preds
-        globals
-        c_return_type
-        subst_at
-    in
-    prepend_to_precondition ail_executable_spec ([ binding ], [ decl ])
+  | AT.Ghost _ -> failwith "TODO Fulminate: Ghost arguments not yet supported at runtime"
   | AT.L lat ->
     cn_to_ail_lat_2
       without_ownership_checking

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -108,6 +108,7 @@ let add_records_to_map_from_instrumentation (i : Extract.instrumentation) =
   in
   let rec aux_at = function
     | AT.Computational ((_, _), _, at) -> aux_at at
+    | AT.Ghost ((_, _), _, at) -> aux_at at
     | L lat -> aux_lat lat
   in
   match i.internal with

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -194,6 +194,7 @@ let try_coerce_res (ftyp : AT.lemmat) =
   let rec coerce_at t =
     match t with
     | AT.Computational (v, info, t) -> AT.Computational (v, info, coerce_at t)
+    | AT.Ghost (v, info, t) -> AT.Ghost (v, info, coerce_at t)
     | AT.L t ->
       let computationals, t = coerce_lat t in
       AT.mComputationals computationals (AT.L t)
@@ -229,7 +230,10 @@ let scan (ftyp : AT.lemmat) =
     | LAT.I t -> scan_lrt t
   in
   let rec scan_at t =
-    match t with AT.Computational (_, _, t) -> scan_at t | AT.L t -> scan_lat t
+    match t with
+    | AT.Computational (_, _, t) -> scan_at t
+    | AT.Ghost (_, _, t) -> scan_at t
+    | AT.L t -> scan_lat t
   in
   let x = scan_at ftyp in
   if Option.is_none x.res then
@@ -1223,7 +1227,8 @@ let ftyp_to_coq loc global list_mono (ftyp : AT.lemmat) =
   in
   let rec at_doc t =
     match t with
-    | AT.Computational ((sym, bt), _, t) ->
+    | AT.Computational _ -> failwith "lemma with unexpected computational argument"
+    | AT.Ghost ((sym, bt), _, t) ->
       let@ d = at_doc t in
       (match d with
        | None -> return None

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -294,7 +294,6 @@ type 'TY expr_ =
   | Eaction of 'TY paction
   | Eskip
   | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t list
-  (* pexpr list is computational arguments; IndexTerms.t list is logical arguments *)
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -301,7 +301,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list
+  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnprog.t list

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -293,7 +293,8 @@ type 'TY expr_ =
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t list
+  (* pexpr list is computational arguments; IndexTerms.t list is logical arguments *)
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -338,6 +339,7 @@ let mResources res t = List.fold_right mResource res t
 
 type 'i arguments =
   | Computational of (Sym.t * BaseTypes.t) * Locations.info * 'i arguments
+  | Ghost of (Sym.t * BaseTypes.t) * Locations.info * 'i arguments
   | L of 'i arguments_l
 
 let mComputational (bound, info) t = Computational (bound, info, t)
@@ -364,6 +366,7 @@ let dtree_of_arguments dtree_i =
   let rec aux = function
     | Computational ((s, _bt), _, lat) ->
       Dnode (pp_ctor "Computational", [ Dleaf (Sym.pp s); aux lat ])
+    | Ghost ((s, _bt), _, lat) -> Dnode (pp_ctor "Ghost", [ Dleaf (Sym.pp s); aux lat ])
     | L l -> dtree_of_arguments_l dtree_i l
   in
   aux
@@ -388,12 +391,6 @@ type trusted =
   | Trusted of Locations.t
   | Checked
 
-type desugared_spec =
-  { accesses : (Sym.t * Cerb_frontend.Ctype.ctype) list;
-    requires : (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_condition list;
-    ensures : (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_condition list
-  }
-
 type 'TY args_and_body =
   ('TY expr * (Sym.t, 'TY label_def) Pmap.map * ReturnTypes.t) arguments
 
@@ -401,8 +398,7 @@ type 'TY fun_map_decl =
   | Proc of
       { loc : Locations.t;
         args_and_body : 'TY args_and_body;
-        trusted : trusted;
-        desugared_spec : desugared_spec
+        trusted : trusted
       }
   | ProcDecl of Locations.t * ArgumentTypes.ft option
 

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -205,7 +205,7 @@ type 'TY expr_ =
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -260,6 +260,7 @@ val mResources
 
 type 'i arguments =
   | Computational of (Sym.t * BaseTypes.t) * Locations.info * 'i arguments
+  | Ghost of (Sym.t * BaseTypes.t) * Locations.info * 'i arguments
   | L of 'i arguments_l
 
 val mComputational
@@ -291,12 +292,6 @@ type trusted =
   | Trusted of Locations.t
   | Checked
 
-type desugared_spec =
-  { accesses : (Sym.t * Cerb_frontend.Ctype.ctype) list;
-    requires : (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_condition list;
-    ensures : (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_condition list
-  }
-
 type 'TY args_and_body =
   ('TY expr * (Sym.t, 'TY label_def) Pmap.map * ReturnTypes.t) arguments
 
@@ -304,8 +299,7 @@ type 'TY fun_map_decl =
   | Proc of
       { loc : Locations.t;
         args_and_body : 'TY args_and_body;
-        trusted : trusted;
-        desugared_spec : desugared_spec
+        trusted : trusted
       }
   | ProcDecl of Locations.t * ArgumentTypes.ft option
 

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -213,7 +213,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list
+  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnprog.t list

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -631,8 +631,10 @@ module Make (Config : CONFIG) = struct
              ^^ pp e2
            | End es -> pp_keyword "nd" ^^ Pp.parens (comma_list pp es)
            | Ebound e -> Cn_Pp.c_app (pp_keyword "bound") [ pp e ]
-           | Erun (sym, pes) ->
-             pp_keyword "run" ^^^ Cn_Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes))
+           | Erun (sym, pes, its) ->
+             pp_keyword "run"
+             ^^^ Cn_Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes)
+             ^^ Pp.parens (comma_list IndexTerms.pp its))
     in
     pp budget expr
 

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -576,13 +576,14 @@ module Make (Config : CONFIG) = struct
                   (Pp_mem.pp_memop memop ^^ Pp.comma ^^^ comma_list pp_actype_or_pexpr pes)
            | Eaction (Paction (p, Action (_, act))) -> pp_polarity p (pp_action act)
            | Eskip -> pp_keyword "skip"
-           | Eccall (pe_ty, pe, pes) ->
+           | Eccall (pe_ty, pe, pes, its) ->
              pp_keyword "ccall"
              ^^ Pp.parens (pp_ct pe_ty.ct)
              ^^ Pp.parens
                   (comma_list
                      pp_actype_or_pexpr
                      (Right pe :: (List.map (fun pe -> Either.Right pe)) pes))
+             ^^ Pp.parens (comma_list IndexTerms.pp its)
            | CN_progs (_, stmts) ->
              pp_keyword "cn_prog"
              ^^ Pp.parens
@@ -673,6 +674,8 @@ module Make (Config : CONFIG) = struct
   let rec pp_arguments ppf = function
     | Computational ((s, bt), _info, a) ->
       Pp.parens (Cn_Pp.typ (pp_symbol s) (pp_bt bt)) ^^^ pp_arguments ppf a
+    | Ghost ((s, bt), _info, a) ->
+      Pp.parens (!^"ghost" ^^^ Cn_Pp.typ (pp_symbol s) (pp_bt bt)) ^^^ pp_arguments ppf a
     | L l -> pp_arguments_l ppf l
 
 

--- a/lib/pp_mucore_ast.ml
+++ b/lib/pp_mucore_ast.ml
@@ -175,7 +175,7 @@ module PP = struct
           [ (* Dleaf (pp_ctor "TODO_pattern") ; *) dtree_of_expr e1; dtree_of_expr e2 ] )
     | Erun (_l, asyms) -> Dnode (pp_pure_ctor "Erun", List.map dtree_of_pexpr asyms)
     | Ebound e -> Dnode (pp_ctor "Ebound", [ dtree_of_expr e ])
-    | Ememop _ | Eccall (_, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->
+    | Ememop _ | Eccall (_, _, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->
       Dnode (pp_ctor "TExpr(TODO)", [ Dleaf (Pp_mucore.pp_expr expr) ])
 
 

--- a/lib/pp_mucore_ast.ml
+++ b/lib/pp_mucore_ast.ml
@@ -173,7 +173,12 @@ module PP = struct
         ( pp_ctor "Esseq" (* ^^^ P.group (Pp_core.Basic.pp_pattern pat) *),
           (*add_std_annot*)
           [ (* Dleaf (pp_ctor "TODO_pattern") ; *) dtree_of_expr e1; dtree_of_expr e2 ] )
-    | Erun (_l, asyms) -> Dnode (pp_pure_ctor "Erun", List.map dtree_of_pexpr asyms)
+    | Erun (_l, asyms, its) ->
+      Dnode
+        ( pp_pure_ctor "Erun",
+          [ Dnode (pp_ctor "Args", List.map dtree_of_pexpr asyms);
+            Dnode (pp_ctor "Ghost args", List.map IndexTerms.dtree its)
+          ] )
     | Ebound e -> Dnode (pp_ctor "Ebound", [ dtree_of_expr e ])
     | Ememop _ | Eccall (_, _, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->
       Dnode (pp_ctor "TExpr(TODO)", [ Dleaf (Pp_mucore.pp_expr expr) ])

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1847,10 +1847,15 @@ and pp_expr pp_type = function
              [ pp_tuple [ pp_pexpr pp_type c; pp_expr pp_type t; pp_expr pp_type e ] ]
          | Ebound e -> pp_constructor1 "Ebound" [ pp_expr pp_type e ]
          | End exprs -> pp_constructor1 "End" [ pp_list (pp_expr pp_type) exprs ]
-         | Erun (sym, args) ->
+         | Erun (sym, args, its) ->
            pp_constructor1
              "Erun"
-             [ pp_tuple [ pp_symbol sym; pp_list (pp_pexpr pp_type) args ] ]
+             [ pp_tuple
+                 [ pp_symbol sym;
+                   pp_list (pp_pexpr pp_type) args;
+                   pp_list pp_index_term its
+                 ]
+             ]
          | CN_progs (stmts, progs) ->
            pp_constructor1
              "CN_progs"

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -186,6 +186,7 @@ type message =
       { spec : int;
         decl : int
       }
+  | Not_impl_ghost_args_in_pure_C_function
 
 type t =
   { loc : Locations.t;
@@ -627,6 +628,11 @@ let pp_message = function
       ^^^ !^(string_of_int decl)
     in
     { short; descr = Some descr; state = None }
+  | Not_impl_ghost_args_in_pure_C_function ->
+    let short =
+      !^"Cannot lift a pure C function which uses ghost arguments (not implemented)."
+    in
+    { short; descr = None; state = None }
 
 
 (** Convert a possibly-relative filepath into an absolute one. *)

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -276,6 +276,9 @@ let pp_welltyped = function
       ^^^ !^(string_of_int has)
     in
     { short; descr = Some descr; state = None }
+  | Unexpected_computational_args_in_lemma ->
+    let short = !^"Unexpected computational arguments in lemma definition" in
+    { short; descr = None; state = None }
   | Mismatch { has; expect } ->
     let short = !^"Mismatched types." in
     let descr =

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -273,7 +273,7 @@ let pp_welltyped = function
       | `Input -> "input"
       | `Output -> "output"
     in
-    let short = !^"Wrong number" ^^^ !^type_ ^^^ !^"of arguments" in
+    let short = !^"Wrong number of" ^^^ !^type_ ^^^ !^"arguments" in
     let descr =
       !^"Expected"
       ^^^ !^(string_of_int expect)

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -266,7 +266,12 @@ let pp_welltyped = function
     { short; descr = None; state = None }
   | Number_arguments { type_; has; expect } ->
     let type_ =
-      match type_ with `Other -> "" | `Input -> "input" | `Output -> "output"
+      match type_ with
+      | `Computational -> "C"
+      | `Ghost -> "ghost"
+      | `Other -> ""
+      | `Input -> "input"
+      | `Output -> "output"
     in
     let short = !^"Wrong number" ^^^ !^type_ ^^^ !^"of arguments" in
     let descr =

--- a/lib/typeErrors.mli
+++ b/lib/typeErrors.mli
@@ -131,6 +131,7 @@ type message =
       { spec : int;
         decl : int
       }
+  | Not_impl_ghost_args_in_pure_C_function
 
 type t =
   { loc : Locations.t;

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -24,7 +24,7 @@ type message =
         reason : string
       }
   | Number_arguments of
-      { type_ : [ `Other | `Input | `Output ];
+      { type_ : [ `Computational | `Ghost | `Other | `Input | `Output ];
         has : int;
         expect : int
       }
@@ -979,7 +979,7 @@ module WIT = struct
       | Apply (name, args) ->
         let@ def = get_logical_function_def loc name in
         let has_args, expect_args = (List.length args, List.length def.args) in
-        let@ () = ensure_same_argument_number loc `Other has_args ~expect:expect_args in
+        let@ () = ensure_same_argument_number loc `Ghost has_args ~expect:expect_args in
         let@ args =
           ListM.map2M
             (fun has_arg (_, def_arg_bt) ->

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1915,7 +1915,7 @@ module BaseTyping = struct
         let wrong_number_arguments () =
           let has = List.length its in
           let expect = AT.count_ghost lemma_typ in
-          fail { loc; msg = Number_arguments { type_ = `Other; has; expect } }
+          fail { loc; msg = Number_arguments { type_ = `Ghost; has; expect } }
         in
         let rec check_args lemma_typ its =
           match (lemma_typ, its) with

--- a/lib/wellTyped.mli
+++ b/lib/wellTyped.mli
@@ -14,7 +14,7 @@ type message =
         reason : string
       }
   | Number_arguments of
-      { type_ : [ `Other | `Input | `Output ];
+      { type_ : [ `Computational | `Ghost | `Other | `Input | `Output ];
         has : int;
         expect : int
       }

--- a/lib/wellTyped.mli
+++ b/lib/wellTyped.mli
@@ -18,6 +18,7 @@ type message =
         has : int;
         expect : int
       }
+  | Unexpected_computational_args_in_lemma
   | Missing_member of Id.t
   | NIA of
       { it : IndexTerms.t;

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -7,7 +7,7 @@ module type S = sig
 
   val ensure_same_argument_number
     :  Locations.t ->
-    [ `Other | `Input | `Output ] ->
+    [ `Computational | `Ghost | `Other | `Input | `Output ] ->
     int ->
     expect:int ->
     unit t


### PR DESCRIPTION
This also simplifies spine checking and uses index term locations in typechecking.