### PR TITLE
Free spec-checking memory on function exit

### DIFF
--- a/lib/fulminate/source_injection.ml
+++ b/lib/fulminate/source_injection.ml
@@ -209,6 +209,7 @@ let inject st inj =
          ^ indent
          ^ "/* EXECUTABLE CN PRECONDITION */"
          ^ "\n"
+         ^ "cn_bump_frame_id cn_frame_id = cn_bump_get_frame_id();\n"
          ^ indent
          ^ (if CF.AilTypesAux.is_void ret_ty then
               ""
@@ -250,7 +251,7 @@ let inject st inj =
          if CF.AilTypesAux.is_void ret_ty then
            indent ^ ";\n"
          else
-           indent ^ "\nreturn __cn_ret;\n\n")
+           indent ^ "\ncn_bump_free_after(cn_frame_id);\n" ^ "\nreturn __cn_ret;\n\n")
     | DeleteMain pre ->
       if pre then do_output st "\n#if 0\n" else do_output st "\n#endif\n"
     | WrapStatic (prefix, decl) ->

--- a/runtime/libcn/include/cn-executable/hash_table.h
+++ b/runtime/libcn/include/cn-executable/hash_table.h
@@ -55,6 +55,7 @@ void ht_destroy(hash_table* table);
 
 void* ht_get(hash_table* table, int64_t* key);
 
+/** Note: the value pointer is stored in the table, but the key's is not */
 int64_t* ht_set(hash_table* table, int64_t* key, void* value);
 
 int ht_size(hash_table* table);

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -434,9 +434,10 @@ cn_bool *default_cn_bool(void);
 
 #define CN_GEN_MAP_GET(CNTYPE)                                                           \
   static inline void *cn_map_get_##CNTYPE(cn_map *m, cn_integer *key) {                  \
-    int64_t *key_ptr = cn_bump_malloc(sizeof(int64_t));                                  \
+    int64_t *key_ptr = cn_fl_malloc(sizeof(int64_t));                                    \
     *key_ptr = key->val;                                                                 \
     void *res = ht_get(m, key_ptr);                                                      \
+    cn_fl_free(key_ptr);                                                                 \
     if (!res) {                                                                          \
       return (void *)default_##CNTYPE();                                                 \
     }                                                                                    \


### PR DESCRIPTION
Closes https://github.com/rems-project/cerberus/issues/859

All bump-allocated memory has a lifetime that is not longer than the allocating function's.
Therefore, we can store the bump allocator's pointer before pre-condition checking, and restore it after post-condition checking.
