### PR TITLE
[CN-exec/CN-test-gen] Disable linemarkers

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -32,6 +32,7 @@ let frontend
       ~filename
       ~magic_comment_char_dollar
       ~save_cpp
+      ~disable_linemarkers
   =
   Cerb_global.set_cerb_conf
     ~backend_name:"Cn"
@@ -55,7 +56,9 @@ let frontend
   let ( let@ ) = CF.Exception.except_bind in
   let@ stdlib = load_core_stdlib () in
   let@ impl = load_core_impl stdlib impl_name in
-  let conf = Setup.conf macros incl_dirs incl_files astprints save_cpp in
+  let conf =
+    Setup.conf macros incl_dirs incl_files disable_linemarkers astprints save_cpp
+  in
   let cn_init_scope : CF.Cn_desugaring.init_scope =
     { predicates = [ Alloc.Predicate.(str, sym, Some loc) ];
       functions = List.map (fun (str, sym) -> (str, sym, None)) Builtins.fun_names;
@@ -134,6 +137,7 @@ let with_well_formedness_check
       ~no_inherit_loc
       ~magic_comment_char_dollar
       ~save_cpp
+      ~disable_linemarkers
       ~(* Callbacks *)
        handle_error
       ~(f :
@@ -153,7 +157,8 @@ let with_well_formedness_check
          ~astprints
          ~filename
          ~magic_comment_char_dollar
-         ~save_cpp)
+         ~save_cpp
+         ~disable_linemarkers)
   in
   Cerb_debug.maybe_open_csv_timing_file ();
   Pp.maybe_open_times_channel

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -132,6 +132,7 @@ let generate_executable_specs
     ~no_inherit_loc
     ~magic_comment_char_dollar (* Callbacks *)
     ~save_cpp:(Some pp_file)
+    ~disable_linemarkers:true
     ~handle_error
     ~f:(fun ~cabs_tunit ~prog5 ~ail_prog ~statement_locs:_ ~paused:_ ->
       if run && Option.is_none prog5.main then (

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -58,6 +58,7 @@ let run_seq_tests
     ~no_inherit_loc
     ~magic_comment_char_dollar (* Callbacks *)
     ~save_cpp:(Some pp_file)
+    ~disable_linemarkers:true
     ~handle_error
     ~f:(fun ~cabs_tunit ~prog5 ~ail_prog ~statement_locs:_ ~paused:_ ->
       Cerb_colour.without_colour

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -87,6 +87,7 @@ let run_tests
     ~no_inherit_loc
     ~magic_comment_char_dollar (* Callbacks *)
     ~save_cpp:(Some pp_file)
+    ~disable_linemarkers:true
     ~handle_error
     ~f:(fun ~cabs_tunit ~prog5 ~ail_prog ~statement_locs:_ ~paused:_ ->
       let config : TestGeneration.config =

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -83,6 +83,7 @@ let verify
     ~no_inherit_loc
     ~magic_comment_char_dollar
     ~save_cpp:None
+    ~disable_linemarkers:false
     ~handle_error:(Common.handle_type_error ~json ?output_dir ~serialize_json:json_trace)
     ~f:(fun ~cabs_tunit:_ ~prog5:_ ~ail_prog:_ ~statement_locs:_ ~paused ->
       let check (functions, global_var_constraints, lemmas) =

--- a/bin/wf.ml
+++ b/bin/wf.ml
@@ -32,6 +32,7 @@ let well_formed
     ~no_inherit_loc
     ~magic_comment_char_dollar
     ~save_cpp:None
+    ~disable_linemarkers:false
     ~handle_error:(Common.handle_type_error ~json ?output_dir ~serialize_json:json_trace)
     ~f:(fun ~cabs_tunit:_ ~prog5:_ ~ail_prog:_ ~statement_locs:_ ~paused:_ ->
       Or_TypeError.return ())

--- a/lib/setup.ml
+++ b/lib/setup.ml
@@ -6,7 +6,7 @@ let io = default_io_helpers
 let impl_name = "gcc_4.9.0_x86_64-apple-darwin10.8.0"
 
 (* adapting code from backend/driver/main.ml *)
-let cpp_str macros_def incl_dirs incl_files =
+let cpp_str macros_def incl_dirs incl_files disable_linemarkers =
   String.concat
     " "
     ([ "cc -std=c11 -E -CC -Werror -nostdinc -undef -D__cerb__";
@@ -20,10 +20,11 @@ let cpp_str macros_def incl_dirs incl_files =
          macros_def
      @ List.map (fun str -> "-I " ^ str) incl_dirs
      @ List.map (fun str -> "-include " ^ str) incl_files
-     @ [ " -DDEBUG -DCN_MODE" ])
+     @ [ " -DDEBUG -DCN_MODE" ]
+     @ if disable_linemarkers then [ " -P" ] else [])
 
 
-let conf macros incl_dirs incl_files astprints save_cpp =
+let conf macros incl_dirs incl_files disable_linemarkers astprints save_cpp =
   { debug_level = 0;
     pprints = [];
     astprints;
@@ -32,7 +33,7 @@ let conf macros incl_dirs incl_files astprints save_cpp =
     typecheck_core = true;
     rewrite_core = true;
     sequentialise_core = true;
-    cpp_cmd = cpp_str macros incl_dirs incl_files;
+    cpp_cmd = cpp_str macros incl_dirs incl_files disable_linemarkers;
     cpp_stderr = true;
     cpp_save = save_cpp
   }

--- a/lib/setup.mli
+++ b/lib/setup.mli
@@ -10,6 +10,7 @@ val conf
   :  (string * string option) list ->
   string list ->
   string list ->
+  bool ->
   Cerb_backend.Pipeline.language list ->
   string option ->
   Cerb_backend.Pipeline.configuration


### PR DESCRIPTION
Disable linemarkers in the produced output from CN's internal call to cpp - a simple way to make output gdb-friendly