### PR TITLE
[CN-exec] Change Fulminate's behaviour for unannotated functions

### DIFF
--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3974,7 +3974,12 @@ let cn_to_ail_pre_post
 let has_spec =
   let has_post = function LRT.I -> false | _ -> true in
   let has_stats = List.non_empty in
-  let has_loop_inv = List.non_empty in
+  let has_loop_inv (loops : Extract.loops) =
+    List.fold_left
+      ( || )
+      false
+      (List.map (fun (contains_user_spec, _, _, _) -> contains_user_spec) loops)
+  in
   let has_spec_lat = function
     | LAT.I (ReturnTypes.Computational (_, _, post), (stats, loops)) ->
       has_post post || has_stats stats || has_loop_inv loops

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3971,7 +3971,7 @@ let cn_to_ail_pre_post
   | None -> empty_ail_executable_spec
 
 
-let has_spec =
+let has_cn_spec =
   let has_post = function LRT.I -> false | _ -> true in
   let has_stats = List.non_empty in
   let has_loop_inv (loops : Extract.loops) =

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3971,26 +3971,29 @@ let cn_to_ail_pre_post
   | None -> empty_ail_executable_spec
 
 
-let has_cn_spec =
-  let has_post = function LRT.I -> false | _ -> true in
-  let has_stats = List.non_empty in
-  let has_loop_inv (loops : Extract.loops) =
-    List.fold_left
-      ( || )
-      false
-      (List.map (fun (contains_user_spec, _, _, _) -> contains_user_spec) loops)
+let has_cn_spec (instrumentation : Extract.instrumentation) =
+  let has_cn_spec_aux =
+    let has_post = function LRT.I -> false | _ -> true in
+    let has_stats = List.non_empty in
+    let has_loop_inv (loops : Extract.loops) =
+      List.fold_left
+        ( || )
+        false
+        (List.map (fun (contains_user_spec, _, _, _) -> contains_user_spec) loops)
+    in
+    let has_spec_lat = function
+      | LAT.I (ReturnTypes.Computational (_, _, post), (stats, loops)) ->
+        has_post post || has_stats stats || has_loop_inv loops
+      | _ -> true
+    in
+    let rec has_spec_at = function
+      | AT.Computational (_, _, at) -> has_spec_at at
+      | AT.Ghost _ -> true
+      | AT.L lat -> has_spec_lat lat
+    in
+    function Some internal -> has_spec_at internal | None -> false
   in
-  let has_spec_lat = function
-    | LAT.I (ReturnTypes.Computational (_, _, post), (stats, loops)) ->
-      has_post post || has_stats stats || has_loop_inv loops
-    | _ -> true
-  in
-  let rec has_spec_at = function
-    | AT.Computational (_, _, at) -> has_spec_at at
-    | AT.Ghost _ -> true
-    | AT.L lat -> has_spec_lat lat
-  in
-  function Some internal -> has_spec_at internal | None -> false
+  instrumentation.trusted || has_cn_spec_aux instrumentation.internal
 
 
 (* CN test generation *)

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3971,6 +3971,23 @@ let cn_to_ail_pre_post
   | None -> empty_ail_executable_spec
 
 
+let has_spec =
+  let has_post = function LRT.I -> false | _ -> true in
+  let has_stats = List.non_empty in
+  let has_loop_inv = List.non_empty in
+  let has_spec_lat = function
+    | LAT.I (ReturnTypes.Computational (_, _, post), (stats, loops)) ->
+      has_post post || has_stats stats || has_loop_inv loops
+    | _ -> true
+  in
+  let rec has_spec_at = function
+    | AT.Computational (_, _, at) -> has_spec_at at
+    | AT.Ghost _ -> true
+    | AT.L lat -> has_spec_lat lat
+  in
+  function Some internal -> has_spec_at internal | None -> false
+
+
 (* CN test generation *)
 
 let generate_assume_ownership_function ~without_ownership_checking ctype

--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -204,7 +204,7 @@ val cn_to_ail_pre_post
   Extract.fn_args_and_body option ->
   ail_executable_spec
 
-val has_cn_spec : Extract.fn_args_and_body option -> bool
+val has_cn_spec : Extract.instrumentation -> bool
 
 val cn_to_ail_assume_predicates
   :  string ->

--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -204,6 +204,8 @@ val cn_to_ail_pre_post
   Extract.fn_args_and_body option ->
   ail_executable_spec
 
+val has_spec : Extract.fn_args_and_body option -> bool
+
 val cn_to_ail_assume_predicates
   :  string ->
   (Sym.t * Definition.Predicate.t) list ->

--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -204,7 +204,7 @@ val cn_to_ail_pre_post
   Extract.fn_args_and_body option ->
   ail_executable_spec
 
-val has_spec : Extract.fn_args_and_body option -> bool
+val has_cn_spec : Extract.fn_args_and_body option -> bool
 
 val cn_to_ail_assume_predicates
   :  string ->

--- a/lib/fulminate/extract.ml
+++ b/lib/fulminate/extract.ml
@@ -102,7 +102,7 @@ let from_fn (fn, decl) =
            (rt, (stmts, loops)))
         args_and_body
     in
-    let trusted_flag = trusted != Mucore.Checked in
+    let trusted_flag = match trusted with Mucore.Trusted _ -> true | _ -> false in
     { fn; fn_loc; internal = Some internal; trusted = trusted_flag }
 
 

--- a/lib/fulminate/extract.ml
+++ b/lib/fulminate/extract.ml
@@ -47,7 +47,8 @@ let fn_largs_and_body_subst subst (lat : fn_largs_and_body) : fn_largs_and_body 
 type instrumentation =
   { fn : Sym.t;
     fn_loc : Locations.t;
-    internal : fn_args_and_body option
+    internal : fn_args_and_body option;
+    trusted : bool
   }
 
 (* replace `s_replace` of basetype `bt` with `s_with` *)
@@ -90,8 +91,8 @@ let from_loop ((_label_sym : Sym.t), (label_def : _ label_def)) : loop option =
 
 let from_fn (fn, decl) =
   match decl with
-  | ProcDecl (fn_loc, _fn) -> { fn; fn_loc; internal = None }
-  | Proc { loc = fn_loc; args_and_body; _ } ->
+  | ProcDecl (fn_loc, _fn) -> { fn; fn_loc; internal = None; trusted = false }
+  | Proc { loc = fn_loc; args_and_body; trusted } ->
     let args_and_body = Core_to_mucore.at_of_arguments Fun.id args_and_body in
     let internal =
       ArgumentTypes.map
@@ -101,7 +102,8 @@ let from_fn (fn, decl) =
            (rt, (stmts, loops)))
         args_and_body
     in
-    { fn; fn_loc; internal = Some internal }
+    let trusted_flag = trusted != Mucore.Checked in
+    { fn; fn_loc; internal = Some internal; trusted = trusted_flag }
 
 
 let from_file (file : _ Mucore.file) =

--- a/lib/fulminate/extract.mli
+++ b/lib/fulminate/extract.mli
@@ -32,7 +32,8 @@ val fn_largs_and_body_subst
 type instrumentation =
   { fn : Sym.t;
     fn_loc : Locations.t;
-    internal : fn_args_and_body option
+    internal : fn_args_and_body option;
+    trusted : bool
   }
 
 val collect_instrumentation

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -167,11 +167,13 @@ let filter_unspecified_fns
   Printf.printf
     "# fns filtered in instrumentation: %d\n"
     (List.length filtered_instrumentation);
-  let instrumented_fn_syms =
+  let specified_fn_syms =
     List.map (fun (i : Extract.instrumentation) -> i.fn) filtered_instrumentation
   in
+  Printf.printf "Functions with CN spec:\n";
+  List.iter (fun sym -> Printf.printf "%s\n" (Sym.pp_string sym)) specified_fn_syms;
   let is_fn_instrumented =
-    fun sym -> List.mem Sym.equal sym (instrumented_fn_syms @ get_main_sym prog5_fns_list)
+    fun sym -> List.mem Sym.equal sym (specified_fn_syms @ get_main_sym prog5_fns_list)
   in
   filter_selected_fns is_fn_instrumented (sigm, instrumentation)
 
@@ -230,7 +232,7 @@ let main
   let filtered_instrumentation, filtered_sigm =
     filter_using_skip_and_only (prog5, sigm, full_instrumentation)
   in
-  let filtered_instrumentation', filtered_sigm' =
+  let filtered_instrumentation', _ =
     filter_unspecified_fns (prog5, filtered_sigm, filtered_instrumentation)
   in
   let static_funcs =
@@ -240,7 +242,7 @@ let main
     |> List.map (fun (inst : Extract.instrumentation) -> inst.fn)
     |> Sym.Set.of_list
   in
-  let filtered_ail_prog = (startup_sym_opt, filtered_sigm') in
+  let filtered_ail_prog = (startup_sym_opt, filtered_sigm) in
   Records.populate_record_map filtered_instrumentation' prog5;
   let executable_spec =
     generate_c_specs

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -222,7 +222,7 @@ let generate_c_specs_internal
       (sigm : _ CF.AilSyntax.sigma)
       (prog5 : unit Mucore.file)
   =
-  let contains_user_spec = Cn_to_ail.has_cn_spec instrumentation.internal in
+  let contains_user_spec = Cn_to_ail.has_cn_spec instrumentation in
   (* C stack-local variable ownership checking: needed regardless of whether user has provided CN spec *)
   let stack_local_var_inj_info : stack_local_var_inj_info =
     generate_stack_local_var_inj_strs instrumentation.fn sigm

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -160,6 +160,8 @@ void cn_free_sized(void *, size_t len);
 
 void cn_print_nr_u64(int i, unsigned long u);
 void cn_print_u64(const char *str, unsigned long u);
+void dump_ownership_ghost_state(int stack_depth);
+_Bool is_mapped(void *ptr);
 
 /* cn_failure callbacks */
 enum cn_failure_mode {

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 #include <signal.h>  // for SIGABRT
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -401,6 +402,31 @@ void c_ownership_check(char* access_kind,
     }
   }
   // cn_printf(CN_LOGGING_INFO, "\n");
+}
+
+void dump_ownership_ghost_state(int stack_depth) {
+  hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
+  cn_printf(CN_LOGGING_INFO, "ADDRESS \t\t\tCN STACK DEPTH\n")
+      cn_printf(CN_LOGGING_INFO, "====================\n") while (ht_next(&it)) {
+    int64_t* key = it.key;
+    int* depth = it.value;
+    if (*depth == stack_depth) {
+      cn_printf(CN_LOGGING_INFO, "[%p] => depth: %d\n", (void*)*key, *depth);
+    }
+  }
+}
+
+_Bool is_mapped(void* ptr) {
+  hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
+  while (ht_next(&it)) {
+    int64_t* key = it.key;
+    if (*key == (int64_t)ptr) {
+      int* depth = it.value;
+      cn_printf(CN_LOGGING_INFO, "[%p] => depth: %d\n", (void*)*key, *depth);
+      return true;
+    }
+  }
+  return false;
 }
 
 /* TODO: Need address of and size of every stack-allocated variable - could store in struct and pass through. But this is an optimisation */


### PR DESCRIPTION
Previously, Fulminate would "completely" instrument everything it saw, regardless of whether a function had user-provided CN specification(s) or not. This led to annoying ownership errors in places where no CN spec had yet been written, since the ghost stack depth would still get bumped up and down on entry and exit to these functions, but access checks would fail without the right specs for taking and putting back ownership. (This behaviour was at odds with the entire idea of being able to test partial specs!)

Now, in functions with no CN spec, access checks are preserved, but the stack depth counter no longer gets bumped in these functions, so now the ghost stack depth represents the depth of the call stack of _CN-annotated_ functions, with any unannotated functions no longer being accounted for by this number. (=> we now definitely need better error message reporting for ownership failures as a result, so that users don't need to do some mental arithmetic of how many functions they've annotated and what the entire call stack looks like to know what an error means...TODO: Rini)