### PR TITLE
Add an optional `--cc=` argument common to all commands

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -25,6 +25,7 @@ let print_log_file =
 
 
 let frontend
+      ~cc
       ~macros
       ~incl_dirs
       ~incl_files
@@ -57,7 +58,7 @@ let frontend
   let@ stdlib = load_core_stdlib () in
   let@ impl = load_core_impl stdlib impl_name in
   let conf =
-    Setup.conf macros incl_dirs incl_files disable_linemarkers astprints save_cpp
+    Setup.conf cc macros incl_dirs incl_files disable_linemarkers astprints save_cpp
   in
   let cn_init_scope : CF.Cn_desugaring.init_scope =
     { predicates = [ Alloc.Predicate.(str, sym, Some loc) ];
@@ -123,6 +124,7 @@ let there_can_only_be_one =
 
 let with_well_formedness_check
       (* CLI arguments *)
+      ~cc
       ~filename
       ~macros
       ~incl_dirs
@@ -151,6 +153,7 @@ let with_well_formedness_check
   let cabs_tunit, prog, (markers_env, ail_prog), statement_locs =
     handle_frontend_error
       (frontend
+         ~cc
          ~macros
          ~incl_dirs
          ~incl_files
@@ -326,6 +329,11 @@ module Flags = struct
   let file =
     let doc = "Source C file" in
     Arg.(non_empty & pos_all non_dir_file [] & info [] ~docv:"FILE" ~doc)
+
+
+  let cc =
+    let doc = "C compiler to use" in
+    Arg.(value & opt string "cc" & info ~env:(Cmd.Env.info "CC") [ "cc" ] ~doc)
 
 
   (* copied from cerberus' executable (backend/driver/main.ml) *)

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -2,7 +2,7 @@ module CF = Cerb_frontend
 module CB = Cerb_backend
 open Cn
 
-let run_instrumented_file ~filename ~output ~output_dir ~print_steps =
+let run_instrumented_file ~filename ~cc ~output ~output_dir ~print_steps =
   let instrumented_filename =
     Option.value ~default:(Fulminate.get_instrumented_filename filename) output
   in
@@ -25,7 +25,8 @@ let run_instrumented_file ~filename ~output ~output_dir ~print_steps =
   in
   if
     Sys.command
-      ("cc -c "
+      (cc
+       ^ " -c "
        ^ flags
        ^ " "
        ^ includes
@@ -42,7 +43,8 @@ let run_instrumented_file ~filename ~output ~output_dir ~print_steps =
     exit 1);
   if
     Sys.command
-      ("cc "
+      (cc
+       ^ " "
        ^ flags
        ^ " "
        ^ includes
@@ -155,6 +157,7 @@ let generate_executable_specs
                 ~with_loop_leak_checks
                 ~with_testing
                 filename
+                cc
                 pp_file
                 out_file
                 output_dir
@@ -167,7 +170,7 @@ let generate_executable_specs
         ();
       Or_TypeError.return
         (if run then
-           run_instrumented_file ~filename ~output ~output_dir ~print_steps))
+           run_instrumented_file ~filename ~cc ~output ~output_dir ~print_steps))
 
 
 open Cmdliner

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -64,6 +64,7 @@ let run_instrumented_file ~filename ~output ~output_dir ~print_steps =
 
 let generate_executable_specs
       filename
+      cc
       macros
       incl_dirs
       incl_files
@@ -119,6 +120,7 @@ let generate_executable_specs
   in
   Common.with_well_formedness_check (* CLI arguments *)
     ~filename
+    ~cc
     ~macros:(("__CN_INSTRUMENT", None) :: macros)
     ~incl_dirs
     ~incl_files
@@ -251,6 +253,7 @@ let cmd =
   let instrument_t =
     const generate_executable_specs
     $ Common.Flags.file
+    $ Common.Flags.cc
     $ Common.Flags.macros
     $ Common.Flags.incl_dirs
     $ Common.Flags.incl_files

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -83,6 +83,7 @@ let run_seq_tests
              ~with_loop_leak_checks:false
              ~with_testing:true
              filename
+             cc
              pp_file
              out_file
              output_dir

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -5,6 +5,7 @@ open Cn
 let run_seq_tests
       (* Common *)
         filename
+      cc
       macros
       incl_dirs
       incl_files
@@ -44,6 +45,7 @@ let run_seq_tests
   let out_file = Fulminate.get_instrumented_filename basefile in
   Common.with_well_formedness_check (* CLI arguments *)
     ~filename
+    ~cc
     ~macros:(("__CN_SEQ_TEST", None) :: ("__CN_INSTRUMENT", None) :: macros)
     ~incl_dirs
     ~incl_files
@@ -145,6 +147,7 @@ let cmd =
   let test_t =
     const run_seq_tests
     $ Common.Flags.file
+    $ Common.Flags.cc
     $ Common.Flags.macros
     $ Common.Flags.incl_dirs
     $ Common.Flags.incl_files

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -5,6 +5,7 @@ open Cn
 let run_tests
       (* Common *)
         filename
+      cc
       macros
       incl_dirs
       incl_files
@@ -72,6 +73,7 @@ let run_tests
   let out_file = Fulminate.get_instrumented_filename basefile in
   Common.with_well_formedness_check (* CLI arguments *)
     ~filename
+    ~cc
     ~macros:(("__CN_TEST", None) :: ("__CN_INSTRUMENT", None) :: macros)
     ~incl_dirs
     ~incl_files
@@ -446,6 +448,7 @@ let cmd =
   let test_t =
     const run_tests
     $ Common.Flags.file
+    $ Common.Flags.cc
     $ Common.Flags.macros
     $ Common.Flags.incl_dirs
     $ Common.Flags.incl_files

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -141,6 +141,7 @@ let run_tests
                 ~with_loop_leak_checks:false
                 ~with_testing:true
                 filename
+                cc
                 pp_file
                 out_file
                 output_dir

--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -4,6 +4,7 @@ open Cn
 
 let verify
       filename
+      cc
       macros
       incl_dirs
       incl_files
@@ -70,6 +71,7 @@ let verify
   let filename = Common.there_can_only_be_one filename in
   Common.with_well_formedness_check (* CLI arguments *)
     ~filename
+    ~cc
     ~macros:(("__CN_VERIFY", None) :: macros)
     ~incl_dirs
     ~incl_files
@@ -233,6 +235,7 @@ let verify_t : unit Term.t =
   let open Term in
   const verify
   $ Common.Flags.file
+  $ Common.Flags.cc
   $ Common.Flags.macros
   $ Common.Flags.incl_dirs
   $ Common.Flags.incl_files

--- a/bin/wf.ml
+++ b/bin/wf.ml
@@ -4,6 +4,7 @@ open Cn
 
 let well_formed
       filename
+      cc
       macros
       incl_dirs
       incl_files
@@ -19,6 +20,7 @@ let well_formed
   let filename = Common.there_can_only_be_one filename in
   Common.with_well_formedness_check
     ~filename
+    ~cc
     ~macros
     ~incl_dirs
     ~incl_files
@@ -45,6 +47,7 @@ let cmd =
   let wf_t =
     const well_formed
     $ Common.Flags.file
+    $ Common.Flags.cc
     $ Common.Flags.macros
     $ Common.Flags.incl_dirs
     $ Common.Flags.incl_files

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -168,6 +168,7 @@ let main
       ?(with_loop_leak_checks = false)
       ?(with_testing = false)
       filename
+      cc
       in_filename (* WARNING: this file will be deleted after this function *)
       out_filename
       output_dir
@@ -187,7 +188,9 @@ let main
   let compile_commands_json_str =
     [ "[";
       "\n\t{ \"directory\": \"" ^ output_dir ^ "\",";
-      "\n\t\"command\": \"cc -I"
+      "\n\t\"command\": \""
+      ^ cc
+      ^ " -I"
       ^ opam_switch_prefix
       ^ "/lib/cn/runtime/include/ "
       ^ out_filename

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -17,6 +17,7 @@ val main
   String.t ->
   String.t ->
   String.t ->
+  String.t ->
   Cerb_frontend.Cabs.translation_unit ->
   Sym.t option * Cerb_frontend.GenTypes.genTypeCategory Cerb_frontend.AilSyntax.sigma ->
   unit Mucore.file ->

--- a/lib/setup.ml
+++ b/lib/setup.ml
@@ -6,10 +6,10 @@ let io = default_io_helpers
 let impl_name = "gcc_4.9.0_x86_64-apple-darwin10.8.0"
 
 (* adapting code from backend/driver/main.ml *)
-let cpp_str macros_def incl_dirs incl_files disable_linemarkers =
+let cpp_str cc macros_def incl_dirs incl_files disable_linemarkers =
   String.concat
     " "
-    ([ "cc -std=c11 -E -CC -Werror -nostdinc -undef -D__cerb__";
+    ([ cc ^ " -std=c11 -E -CC -Werror -nostdinc -undef -D__cerb__";
        "-I " ^ Cerb_runtime.in_runtime "libc/include";
        "-I " ^ Cerb_runtime.in_runtime "libcore";
        "-include " ^ Cerb_runtime.in_runtime "libc/include/builtins.h"
@@ -24,7 +24,7 @@ let cpp_str macros_def incl_dirs incl_files disable_linemarkers =
      @ if disable_linemarkers then [ " -P" ] else [])
 
 
-let conf macros incl_dirs incl_files disable_linemarkers astprints save_cpp =
+let conf cc macros incl_dirs incl_files disable_linemarkers astprints save_cpp =
   { debug_level = 0;
     pprints = [];
     astprints;
@@ -33,7 +33,7 @@ let conf macros incl_dirs incl_files disable_linemarkers astprints save_cpp =
     typecheck_core = true;
     rewrite_core = true;
     sequentialise_core = true;
-    cpp_cmd = cpp_str macros incl_dirs incl_files disable_linemarkers;
+    cpp_cmd = cpp_str cc macros incl_dirs incl_files disable_linemarkers;
     cpp_stderr = true;
     cpp_save = save_cpp
   }

--- a/lib/setup.mli
+++ b/lib/setup.mli
@@ -7,7 +7,8 @@ val io : Cerb_backend.Pipeline.io_helpers
 val impl_name : string
 
 val conf
-  :  (string * string option) list ->
+  :  string ->
+  (string * string option) list ->
   string list ->
   string list ->
   bool ->


### PR DESCRIPTION
This allows the user to specify which external C compiler should be used by CN. If the argument is absent, the CC env variable is read. If that is not defined, we fallback to using `cc` (like previously).

This first commit only updates the call to the preprocessor by the cerberus pipeline.