### PR TITLE
Add ghost arguments to functions

### DIFF
--- a/coq/Cn/ArgumentTypes.v
+++ b/coq/Cn/ArgumentTypes.v
@@ -11,6 +11,7 @@ Require Import False.
 (* Define the argument type *)
 Inductive argument_type (i : Type) : Type :=
   | Computational : (Sym.t * BaseTypes.t) -> info -> argument_type i -> argument_type i
+  | Ghost : (Sym.t * BaseTypes.t) -> info -> argument_type i -> argument_type i
   | L : LogicalArgumentTypes.t i -> argument_type i.
 
 (* Type alias for the main type *)

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -504,7 +504,7 @@ let rec symb_exec_expr ctxt state_vars expr =
         }
     in
     let@ () =
-      if not (List.is_empty gargs) then
+      if not (List.is_empty gargs.args) then
         fail_fun_it "cannot translate runs with ghost arguments yet"
       else
         return ()
@@ -583,7 +583,7 @@ let rec symb_exec_expr ctxt state_vars expr =
         }
     in
     let@ () =
-      if not (List.is_empty gargs) then
+      if not (List.is_empty gargs.args) then
         fail_fun_it "cannot translate function calls with ghost arguments yet"
       else
         return ()

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1044,7 +1044,6 @@ end = struct
     k rt
 
 
-  (* let spine rt_subst rt_pp loc situation args { loc = ghost_loc; args = gargs } ftyp k = *)
   let spine rt_subst rt_pp loc situation args gargs_opt ftyp k =
     let open ArgumentTypes in
     let original_ftyp = ftyp in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1786,6 +1786,8 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
                    [@alert "-deprecated"]
                })
          in
+         let@ its = ListM.mapM (cn_prog_sub_let IT.subst) its in
+         let its = List.map snd its in
          (* checks pes against their annotations, and that they match ft's argument types *)
          Spine.calltype_ft
            loc
@@ -2138,6 +2140,8 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          | Some (lt, lkind, _) -> return (lt, lkind)
        in
        let@ original_resources = all_resources_tagged loc in
+       let@ its = ListM.mapM (cn_prog_sub_let IT.subst) its in
+       let its = List.map snd its in
        Spine.calltype_lt loc pes its (lt, lkind) (fun False ->
          let@ () = all_empty loc original_resources in
          return ()))

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1631,3 +1631,8 @@ let statement
       (Cn.CN_statement (loc, stmt_))
   =
   Handle.with_loads loc allocations old_states (C_vars.cn_statement env (loc, stmt_))
+
+
+let expr_ghost allocations old_states env expr =
+  let (Cn.CNExpr (loc, _)) = expr in
+  Handle.with_loads loc allocations old_states (C_vars.cn_expr Sym.Set.empty env expr)

--- a/lib/compile.mli
+++ b/lib/compile.mli
@@ -157,3 +157,10 @@ val statement
   env ->
   (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement ->
   Cnstatement.statement Cnprog.t Or_Error.t
+
+val expr_ghost
+  :  (Sym.t -> Cerb_frontend.Ctype.ctype) ->
+  C_vars.named_scopes ->
+  env ->
+  (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_expr ->
+  IndexTerms.Surface.t Cnprog.t Or_Error.t

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -826,8 +826,8 @@ let rec n_expr
       match parsed_ghosts with
       (* Handling the empty case separately because rems-project/cerberus@f58daf7
         only adds markers if there is a magic comment, otherwise Option.get throws an exception *)
-      | [] -> return []
-      | _ :: _ ->
+      | _, [] -> return Mu.{ loc = None; args = [] }
+      | ghost_loc, _ :: _ ->
         let marker_id = Option.get (CF.Annot.get_marker annots) in
         let marker_id_object_types =
           Option.get (CF.Annot.get_marker_object_types annots)
@@ -858,10 +858,10 @@ let rec n_expr
                  Translate.expr_ghost get_c_obj old_states env desugared_ghost
                in
                return ghost)
-            parsed_ghosts
+            (snd parsed_ghosts)
         in
         let ghost_args = List.map (Cnprog.map IT.Surface.proj) ghosts in
-        return ghost_args
+        return Mu.{ loc = ghost_loc; args = ghost_args }
     in
     return (wrap (Eccall (ct1, e2, es, ghost_args)))
   | Eproc (_a, name, es) ->
@@ -950,7 +950,7 @@ let rec n_expr
     let pes = List.map n_pexpr pes in
     let ghost_args = [] in
     (* TODO: https://github.com/rems-project/cn/issues/123 *)
-    return (wrap (Erun (sym1, pes, ghost_args)))
+    return (wrap (Erun (sym1, pes, { loc = None; args = ghost_args })))
   | Epar _es -> assert_error loc !^"core_anormalisation: Epar"
   | Ewait _tid1 -> assert_error loc !^"core_anormalisation: Ewait"
   | Eannot _ -> assert_error loc !^"core_anormalisation: Eannot"

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -840,8 +840,9 @@ let rec n_expr
         let get_c_obj sym =
           match List.assoc_opt Sym.equal sym visible_objects with
           | Some obj_ty -> obj_ty
-          | None -> failwith ("use of C obj without known type: " ^ Sym.pp_string sym)
-          (* should not occur since Cerberus guarantees every C object in scope has a type *)
+          | None ->
+            (* should not occur since Cerberus guarantees every C object in scope has a type *)
+            failwith ("use of C obj without known type: " ^ Sym.pp_string sym)
         in
         let@ ghosts =
           ListM.mapM

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -826,8 +826,6 @@ let rec n_expr
     let@ parsed_ghosts = Parse.cn_ghost_args annots in
     let@ ghost_args =
       match parsed_ghosts with
-      (* Handling the empty case separately because rems-project/cerberus@f58daf7
-        only adds markers if there is a magic comment, otherwise Option.get throws an exception *)
       | None -> return None
       | Some (ghost_loc, args) ->
         let marker_id = Option.get (CF.Annot.get_marker annots) in

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -828,8 +828,8 @@ let rec n_expr
       match parsed_ghosts with
       (* Handling the empty case separately because rems-project/cerberus@f58daf7
         only adds markers if there is a magic comment, otherwise Option.get throws an exception *)
-      | _, [] -> return Mu.{ loc = None; args = [] }
-      | ghost_loc, _ :: _ ->
+      | None -> return None
+      | Some (ghost_loc, args) ->
         let marker_id = Option.get (CF.Annot.get_marker annots) in
         let marker_id_object_types =
           Option.get (CF.Annot.get_marker_object_types annots)
@@ -860,10 +860,10 @@ let rec n_expr
                  Translate.expr_ghost get_c_obj old_states env desugared_ghost
                in
                return ghost)
-            (snd parsed_ghosts)
+            args
         in
         let ghost_args = List.map (Cnprog.map IT.Surface.proj) ghosts in
-        return Mu.{ loc = ghost_loc; args = ghost_args }
+        return (Some (ghost_loc, ghost_args))
     in
     return (wrap (Eccall (ct1, e2, es, ghost_args)))
   | Eproc (_a, name, es) ->
@@ -950,9 +950,8 @@ let rec n_expr
     assert_error loc !^"core_anormalisation: Esave"
   | Erun (_a, sym1, pes) ->
     let pes = List.map n_pexpr pes in
-    let ghost_args = [] in
     (* TODO: https://github.com/rems-project/cn/issues/123 *)
-    return (wrap (Erun (sym1, pes, { loc = None; args = ghost_args })))
+    return (wrap (Erun (sym1, pes)))
   | Epar _es -> assert_error loc !^"core_anormalisation: Epar"
   | Ewait _tid1 -> assert_error loc !^"core_anormalisation: Ewait"
   | Eannot _ -> assert_error loc !^"core_anormalisation: Eannot"

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -841,6 +841,7 @@ let rec n_expr
           match List.assoc_opt Sym.equal sym visible_objects with
           | Some obj_ty -> obj_ty
           | None -> failwith ("use of C obj without known type: " ^ Sym.pp_string sym)
+          (* should not occur since Cerberus guarantees every C object in scope has a type *)
         in
         let@ ghosts =
           ListM.mapM
@@ -906,6 +907,7 @@ let rec n_expr
              match List.assoc_opt Sym.equal sym visible_objects with
              | Some obj_ty -> obj_ty
              | None -> failwith ("use of C obj without known type: " ^ Sym.pp_string sym)
+             (* should not occur since Cerberus guarantees every C object in scope has a type *)
            in
            let@ desugared_stmts_and_stmts =
              ListM.mapM
@@ -1386,6 +1388,8 @@ module Spec = struct
     let cross_fst x =
       match x with None -> [] | Some (a, bs) -> List.map (fun b -> (a, b)) bs
     in
+    (* TODO: replace cross_fst2 with correct locations:
+      https://github.com/rems-project/cn/issues/200 *)
     let cross_fst2 x =
       match x with
       | None -> ([], [])

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -288,17 +288,13 @@ type 'TY memop =
   | Va_end of 'TY pexpr
   | CopyAllocId of ('TY pexpr * 'TY pexpr)
 
-type ghost_args =
-  { loc : Locations.t option;
-    args : IndexTerms.t Cnprog.t list
-  }
-
 type 'TY expr_ =
   | Epure of 'TY pexpr
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * ghost_args
+  | Eccall of
+      act * 'TY pexpr * 'TY pexpr list * (Locations.t * IndexTerms.t Cnprog.t list) option
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -306,7 +302,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * ghost_args
+  | Erun of Sym.t * 'TY pexpr list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -293,7 +293,7 @@ type 'TY expr_ =
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t Cnprog.t list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -301,7 +301,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t list
+  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t Cnprog.t list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -288,12 +288,17 @@ type 'TY memop =
   | Va_end of 'TY pexpr
   | CopyAllocId of ('TY pexpr * 'TY pexpr)
 
+type ghost_args =
+  { loc : Locations.t option;
+    args : IndexTerms.t Cnprog.t list
+  }
+
 type 'TY expr_ =
   | Epure of 'TY pexpr
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t Cnprog.t list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * ghost_args
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -301,7 +306,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t Cnprog.t list
+  | Erun of Sym.t * 'TY pexpr list * ghost_args
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -200,12 +200,17 @@ type 'TY memop =
   | Va_end of 'TY pexpr
   | CopyAllocId of ('TY pexpr * 'TY pexpr)
 
+type ghost_args =
+  { loc : Locations.t option;
+    args : IndexTerms.t Cnprog.t list
+  }
+
 type 'TY expr_ =
   | Epure of 'TY pexpr
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t Cnprog.t list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * ghost_args
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -213,7 +218,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t Cnprog.t list
+  | Erun of Sym.t * 'TY pexpr list * ghost_args
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -205,7 +205,7 @@ type 'TY expr_ =
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t list
+  | Eccall of act * 'TY pexpr * 'TY pexpr list * IndexTerms.t Cnprog.t list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -213,7 +213,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t list
+  | Erun of Sym.t * 'TY pexpr list * IndexTerms.t Cnprog.t list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -200,17 +200,13 @@ type 'TY memop =
   | Va_end of 'TY pexpr
   | CopyAllocId of ('TY pexpr * 'TY pexpr)
 
-type ghost_args =
-  { loc : Locations.t option;
-    args : IndexTerms.t Cnprog.t list
-  }
-
 type 'TY expr_ =
   | Epure of 'TY pexpr
   | Ememop of 'TY memop
   | Eaction of 'TY paction
   | Eskip
-  | Eccall of act * 'TY pexpr * 'TY pexpr list * ghost_args
+  | Eccall of
+      act * 'TY pexpr * 'TY pexpr list * (Locations.t * IndexTerms.t Cnprog.t list) option
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
   | Ewseq of 'TY pattern * 'TY expr * 'TY expr
@@ -218,7 +214,7 @@ type 'TY expr_ =
   | Eif of 'TY pexpr * 'TY expr * 'TY expr
   | Ebound of 'TY expr
   | End of 'TY expr list
-  | Erun of Sym.t * 'TY pexpr list * ghost_args
+  | Erun of Sym.t * 'TY pexpr list
   | CN_progs of
       (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_statement list
       * Cnstatement.statement Cnprog.t list

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -126,7 +126,13 @@ let not_too_many_snippets = function
 
 
 let cn_ghost_args annots =
-  annots |> A.get_cerb_magic_attr |> ListM.concat_mapM (parse C_parser.cn_ghost_args)
+  (* annots |> A.get_cerb_magic_attr |> ListM.concat_mapM (parse C_parser.cn_ghost_args) *)
+  match A.get_cerb_magic_attr annots with
+  | [] -> return (None, [])
+  | [ (loc, str) ] ->
+    let@ args = (parse C_parser.cn_ghost_args) (loc, str) in
+    return (Some loc, args)
+  | (_loc1, _) :: (_loc2, _) :: _ -> failwith "Impossible by frontend"
 
 
 let function_spec (A.Attrs attributes) =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -132,7 +132,7 @@ let cn_ghost_args annots =
   | [ (loc, str) ] ->
     let@ args = (parse C_parser.cn_ghost_args) (loc, str) in
     return (Some loc, args)
-  | (_loc1, _) :: (_loc2, _) :: _ -> failwith "Impossible by frontend"
+  | (loc1, _) :: (loc2, _) :: _ -> Monad.fail { loc = loc2; msg = Split_spec loc1 }
 
 
 let function_spec (A.Attrs attributes) =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -131,7 +131,7 @@ let cn_ghost_args annots =
   | [ (loc, str) ] ->
     let@ args = (parse C_parser.cn_ghost_args) (loc, str) in
     return (Some (loc, args))
-  | (loc1, _) :: (loc2, _) :: _ -> Monad.fail { loc = loc2; msg = Split_spec loc1 }
+  | _ :: _ :: _ -> failwith "frontend should guarantee unreachable"
 
 
 let function_spec (A.Attrs attributes) =

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -128,10 +128,10 @@ let not_too_many_snippets = function
 let cn_ghost_args annots =
   (* annots |> A.get_cerb_magic_attr |> ListM.concat_mapM (parse C_parser.cn_ghost_args) *)
   match A.get_cerb_magic_attr annots with
-  | [] -> return (None, [])
+  | [] -> return None
   | [ (loc, str) ] ->
     let@ args = (parse C_parser.cn_ghost_args) (loc, str) in
-    return (Some loc, args)
+    return (Some (loc, args))
   | (loc1, _) :: (loc2, _) :: _ -> Monad.fail { loc = loc2; msg = Split_spec loc1 }
 
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -125,6 +125,10 @@ let not_too_many_snippets = function
   | _ -> return ()
 
 
+let cn_ghost_args annots =
+  annots |> A.get_cerb_magic_attr |> ListM.concat_mapM (parse C_parser.cn_ghost_args)
+
+
 let function_spec (A.Attrs attributes) =
   let magic_attrs = A.get_cerb_magic_attr [ A.Aattrs (Attrs (List.rev attributes)) ] in
   let@ () = not_too_many_snippets magic_attrs in

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -126,7 +126,6 @@ let not_too_many_snippets = function
 
 
 let cn_ghost_args annots =
-  (* annots |> A.get_cerb_magic_attr |> ListM.concat_mapM (parse C_parser.cn_ghost_args) *)
   match A.get_cerb_magic_attr annots with
   | [] -> return None
   | [ (loc, str) ] ->

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -583,7 +583,10 @@ module Make (Config : CONFIG) = struct
                   (comma_list
                      pp_actype_or_pexpr
                      (Right pe :: (List.map (fun pe -> Either.Right pe)) pes))
-             ^^ Pp.parens (comma_list IndexTerms.pp its)
+             ^^ Pp.parens
+                  (Cn_Pp.list
+                     Pp_ast.pp_doc_tree
+                     (List.map (Cnprog.dtree IndexTerms.dtree) its))
            | CN_progs (_, stmts) ->
              pp_keyword "cn_prog"
              ^^ Pp.parens
@@ -636,7 +639,10 @@ module Make (Config : CONFIG) = struct
            | Erun (sym, pes, its) ->
              pp_keyword "run"
              ^^^ Cn_Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes)
-             ^^ Pp.parens (comma_list IndexTerms.pp its))
+             ^^ Pp.parens
+                  (Cn_Pp.list
+                     Pp_ast.pp_doc_tree
+                     (List.map (Cnprog.dtree IndexTerms.dtree) its)))
     in
     pp budget expr
 

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -586,7 +586,7 @@ module Make (Config : CONFIG) = struct
              ^^ Pp.parens
                   (Cn_Pp.list
                      Pp_ast.pp_doc_tree
-                     (List.map (Cnprog.dtree IndexTerms.dtree) its))
+                     (List.map (Cnprog.dtree IndexTerms.dtree) its.args))
            | CN_progs (_, stmts) ->
              pp_keyword "cn_prog"
              ^^ Pp.parens
@@ -642,7 +642,7 @@ module Make (Config : CONFIG) = struct
              ^^ Pp.parens
                   (Cn_Pp.list
                      Pp_ast.pp_doc_tree
-                     (List.map (Cnprog.dtree IndexTerms.dtree) its)))
+                     (List.map (Cnprog.dtree IndexTerms.dtree) its.args)))
     in
     pp budget expr
 

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -576,7 +576,10 @@ module Make (Config : CONFIG) = struct
                   (Pp_mem.pp_memop memop ^^ Pp.comma ^^^ comma_list pp_actype_or_pexpr pes)
            | Eaction (Paction (p, Action (_, act))) -> pp_polarity p (pp_action act)
            | Eskip -> pp_keyword "skip"
-           | Eccall (pe_ty, pe, pes, its) ->
+           | Eccall (pe_ty, pe, pes, gargs_opt) ->
+             let ghost_args =
+               match gargs_opt with None -> [] | Some (_loc, ghost_args) -> ghost_args
+             in
              pp_keyword "ccall"
              ^^ Pp.parens (pp_ct pe_ty.ct)
              ^^ Pp.parens
@@ -586,7 +589,7 @@ module Make (Config : CONFIG) = struct
              ^^ Pp.parens
                   (Cn_Pp.list
                      Pp_ast.pp_doc_tree
-                     (List.map (Cnprog.dtree IndexTerms.dtree) its.args))
+                     (List.map (Cnprog.dtree IndexTerms.dtree) ghost_args))
            | CN_progs (_, stmts) ->
              pp_keyword "cn_prog"
              ^^ Pp.parens
@@ -636,13 +639,8 @@ module Make (Config : CONFIG) = struct
              ^^ pp e2
            | End es -> pp_keyword "nd" ^^ Pp.parens (comma_list pp es)
            | Ebound e -> Cn_Pp.c_app (pp_keyword "bound") [ pp e ]
-           | Erun (sym, pes, its) ->
-             pp_keyword "run"
-             ^^^ Cn_Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes)
-             ^^ Pp.parens
-                  (Cn_Pp.list
-                     Pp_ast.pp_doc_tree
-                     (List.map (Cnprog.dtree IndexTerms.dtree) its.args)))
+           | Erun (sym, pes) ->
+             pp_keyword "run" ^^^ Cn_Pp.c_app (pp_symbol sym) (List.map pp_pexpr pes))
     in
     pp budget expr
 

--- a/lib/pp_mucore_ast.ml
+++ b/lib/pp_mucore_ast.ml
@@ -177,7 +177,7 @@ module PP = struct
       Dnode
         ( pp_pure_ctor "Erun",
           [ Dnode (pp_ctor "Args", List.map dtree_of_pexpr asyms);
-            Dnode (pp_ctor "Ghost args", List.map IndexTerms.dtree its)
+            Dnode (pp_ctor "Ghost args", List.map (Cnprog.dtree IndexTerms.dtree) its)
           ] )
     | Ebound e -> Dnode (pp_ctor "Ebound", [ dtree_of_expr e ])
     | Ememop _ | Eccall (_, _, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->

--- a/lib/pp_mucore_ast.ml
+++ b/lib/pp_mucore_ast.ml
@@ -177,7 +177,7 @@ module PP = struct
       Dnode
         ( pp_pure_ctor "Erun",
           [ Dnode (pp_ctor "Args", List.map dtree_of_pexpr asyms);
-            Dnode (pp_ctor "Ghost args", List.map (Cnprog.dtree IndexTerms.dtree) its)
+            Dnode (pp_ctor "Ghost args", List.map (Cnprog.dtree IndexTerms.dtree) its.args)
           ] )
     | Ebound e -> Dnode (pp_ctor "Ebound", [ dtree_of_expr e ])
     | Ememop _ | Eccall (_, _, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->

--- a/lib/pp_mucore_ast.ml
+++ b/lib/pp_mucore_ast.ml
@@ -173,12 +173,9 @@ module PP = struct
         ( pp_ctor "Esseq" (* ^^^ P.group (Pp_core.Basic.pp_pattern pat) *),
           (*add_std_annot*)
           [ (* Dleaf (pp_ctor "TODO_pattern") ; *) dtree_of_expr e1; dtree_of_expr e2 ] )
-    | Erun (_l, asyms, its) ->
+    | Erun (_l, asyms) ->
       Dnode
-        ( pp_pure_ctor "Erun",
-          [ Dnode (pp_ctor "Args", List.map dtree_of_pexpr asyms);
-            Dnode (pp_ctor "Ghost args", List.map (Cnprog.dtree IndexTerms.dtree) its.args)
-          ] )
+        (pp_pure_ctor "Erun", [ Dnode (pp_ctor "Args", List.map dtree_of_pexpr asyms) ])
     | Ebound e -> Dnode (pp_ctor "Ebound", [ dtree_of_expr e ])
     | Ememop _ | Eccall (_, _, _, _) | Eunseq _ | End _ | CN_progs (_, _) ->
       Dnode (pp_ctor "TExpr(TODO)", [ Dleaf (Pp_mucore.pp_expr expr) ])

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1816,14 +1816,17 @@ and pp_expr pp_type = function
          | Ememop m -> pp_constructor1 "Ememop" [ pp_memop pp_type m ]
          | Eaction pa -> pp_constructor1 "Eaction" [ pp_paction pp_type pa ]
          | Eskip -> pp_constructor1 "Eskip" []
-         | Eccall (act, f, args, ghost_args) ->
+         | Eccall (act, f, args, gargs_opt) ->
+           let ghost_args =
+             match gargs_opt with None -> [] | Some (_loc, ghost_args) -> ghost_args
+           in
            pp_constructor1
              "Eccall"
              [ pp_tuple
                  [ pp_act act;
                    pp_pexpr pp_type f;
                    pp_list (pp_pexpr pp_type) args;
-                   pp_list (pp_cn_prog pp_index_term) ghost_args.args
+                   pp_list (pp_cn_prog pp_index_term) ghost_args
                  ]
              ]
          | Elet (pat, e1, e2) ->
@@ -1849,15 +1852,10 @@ and pp_expr pp_type = function
              [ pp_tuple [ pp_pexpr pp_type c; pp_expr pp_type t; pp_expr pp_type e ] ]
          | Ebound e -> pp_constructor1 "Ebound" [ pp_expr pp_type e ]
          | End exprs -> pp_constructor1 "End" [ pp_list (pp_expr pp_type) exprs ]
-         | Erun (sym, args, its) ->
+         | Erun (sym, args) ->
            pp_constructor1
              "Erun"
-             [ pp_tuple
-                 [ pp_symbol sym;
-                   pp_list (pp_pexpr pp_type) args;
-                   pp_list (pp_cn_prog pp_index_term) its.args
-                 ]
-             ]
+             [ pp_tuple [ pp_symbol sym; pp_list (pp_pexpr pp_type) args ] ]
          | CN_progs (stmts, progs) ->
            pp_constructor1
              "CN_progs"

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1737,13 +1737,15 @@ let pp_cnprog_load (r : Cnprog.load) =
     [ ("CNProgs.ct", pp_sctype r.ct); ("CNProgs.pointer", pp_index_term r.pointer) ]
 
 
-let rec pp_cn_prog = function
+let rec pp_cn_prog f = function
   | Cnprog.Let (loc, (name, l), prog) ->
     pp_constructor
       "CNProgs.CLet"
-      [ pp_location loc; pp_tuple [ pp_symbol name; pp_cnprog_load l ]; pp_cn_prog prog ]
-  | Pure (loc, stmt) ->
-    pp_constructor "CNProgs.Statement" [ pp_location loc; pp_cnprog_statement stmt ]
+      [ pp_location loc;
+        pp_tuple [ pp_symbol name; pp_cnprog_load l ];
+        pp_cn_prog f prog
+      ]
+  | Pure (loc, x) -> pp_constructor "CNProgs" [ pp_location loc; f x ]
 
 
 let rec pp_cn_statement ppfa ppfty (CF.Cn.CN_statement (loc, stmt)) =
@@ -1821,7 +1823,7 @@ and pp_expr pp_type = function
                  [ pp_act act;
                    pp_pexpr pp_type f;
                    pp_list (pp_pexpr pp_type) args;
-                   pp_list pp_index_term ghost_args
+                   pp_list (pp_cn_prog pp_index_term) ghost_args
                  ]
              ]
          | Elet (pat, e1, e2) ->
@@ -1853,7 +1855,7 @@ and pp_expr pp_type = function
              [ pp_tuple
                  [ pp_symbol sym;
                    pp_list (pp_pexpr pp_type) args;
-                   pp_list pp_index_term its
+                   pp_list (pp_cn_prog pp_index_term) its
                  ]
              ]
          | CN_progs (stmts, progs) ->
@@ -1861,7 +1863,7 @@ and pp_expr pp_type = function
              "CN_progs"
              [ pp_tuple
                  [ pp_list (pp_cn_statement pp_symbol pp_ctype) stmts;
-                   pp_list pp_cn_prog progs
+                   pp_list (pp_cn_prog pp_cnprog_statement) progs
                  ]
              ])
       ]

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1823,7 +1823,7 @@ and pp_expr pp_type = function
                  [ pp_act act;
                    pp_pexpr pp_type f;
                    pp_list (pp_pexpr pp_type) args;
-                   pp_list (pp_cn_prog pp_index_term) ghost_args
+                   pp_list (pp_cn_prog pp_index_term) ghost_args.args
                  ]
              ]
          | Elet (pat, e1, e2) ->
@@ -1855,7 +1855,7 @@ and pp_expr pp_type = function
              [ pp_tuple
                  [ pp_symbol sym;
                    pp_list (pp_pexpr pp_type) args;
-                   pp_list (pp_cn_prog pp_index_term) its
+                   pp_list (pp_cn_prog pp_index_term) its.args
                  ]
              ]
          | CN_progs (stmts, progs) ->

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2104,11 +2104,7 @@ module BaseTyping = struct
           let@ pes = ListM.map2M check_pexpr arg_bt_specs pes in
           let its = match gargs_opt with None -> [] | Some (_, its) -> its in
           let@ its = ListM.mapM (check_cnprog (fun _ it -> WIT.infer it)) its in
-          let gargs_opt =
-            match gargs_opt with
-            | None -> None
-            | Some (ghost_loc, _) -> Some (ghost_loc, its)
-          in
+          let gargs_opt = Option.map (fun (ghost_loc, _) -> (ghost_loc, its)) gargs_opt in
           return (Memory.bt_of_sct ret_ct, Eccall (act, f_pe, pes, gargs_opt))
         | Eif (c_pe, e1, e2) ->
           let@ c_pe = check_pexpr Bool c_pe in

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2176,6 +2176,8 @@ module BaseTyping = struct
                 wrong_number_computational_args ()
               | AT.Ghost _, _ -> wrong_number_ghost_args ()
             in
+            (* TODO: fix duplication wrt Check.check_expr, cf.
+                     https://github.com/rems-project/cn/issues/210 *)
             check_args [] lt pes
           in
           return (Unit, Erun (l, pes))

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2102,7 +2102,7 @@ module BaseTyping = struct
              can't when f_pe is dynamic *)
           let arg_bt_specs = List.map (fun ct -> Memory.bt_of_sct ct) arg_cts in
           let@ pes = ListM.map2M check_pexpr arg_bt_specs pes in
-          let@ its = ListM.mapM WIT.infer its in
+          let@ its = ListM.mapM (check_cnprog (fun _ it -> WIT.infer it)) its in
           return (Memory.bt_of_sct ret_ct, Eccall (act, f_pe, pes, its))
         | Eif (c_pe, e1, e2) ->
           let@ c_pe = check_pexpr Bool c_pe in
@@ -2170,7 +2170,7 @@ module BaseTyping = struct
                 let@ pe = check_pexpr bt pe in
                 check_args (acc_pes @ [ pe ]) acc_its lt' pes' its
               | AT.Ghost ((_s, bt), info, lt'), _, it :: its' ->
-                let@ it = WIT.check (fst info) bt it in
+                let@ it = (check_cnprog (fun _ it -> WIT.check (fst info) bt it)) it in
                 check_args acc_pes (acc_its @ [ it ]) lt' pes its'
               | AT.L _lat, [], [] -> return (acc_pes, acc_its)
               | AT.Computational _, [], _ | AT.L _, _ :: _, _ ->

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2081,7 +2081,6 @@ module BaseTyping = struct
           in
           return (bTy, Eaction (Paction (pol, Action (aloc, action_))))
         | Eskip -> return (Unit, Eskip)
-        (* | Eccall (act, f_pe, pes, { loc = ghost_loc; args = its }) -> *)
         | Eccall (act, f_pe, pes, gargs_opt) ->
           let@ () = WCT.is_ct act.loc act.ct in
           let@ ret_ct, arg_cts =

--- a/tests/cn/ghost_arguments.c
+++ b/tests/cn/ghost_arguments.c
@@ -1,0 +1,19 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 n, i32 m, i32 k;
+  n + m + k == p;
+ensures
+  return == n + m + k;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  int v = 1;
+  int* p = &v;
+  return foo(6 /*@ 2i32, x + *p - *p, *p @*/);
+}

--- a/tests/cn/ghost_arguments.c.coq
+++ b/tests/cn/ghost_arguments.c.coq
@@ -1,0 +1,6 @@
+return code: 0
+[1/1] tests/cn/ghost_arguments.c:
+  CN verify:    SUCCESS
+  Coq compile:  SUCCESS
+
+All 1 tests passed!

--- a/tests/cn/ghost_arguments.c.verify
+++ b/tests/cn/ghost_arguments.c.verify
@@ -1,0 +1,6 @@
+return code: 0
+tests/cn/ghost_arguments.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 n, i32 m, i32 k;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- pass

--- a/tests/cn/ghost_arguments.error.c
+++ b/tests/cn/ghost_arguments.error.c
@@ -1,0 +1,19 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 n, i32 m, i32 k;
+  n + m + k == p;
+ensures
+  return == n + m + k;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  int v = 1;
+  int* p = &v;
+  return foo(6 /*@ 2i32, x + *p, *p @*/);
+}

--- a/tests/cn/ghost_arguments.error.c.verify
+++ b/tests/cn/ghost_arguments.error.c.verify
@@ -1,0 +1,13 @@
+return code: 1
+tests/cn/ghost_arguments.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 n, i32 m, i32 k;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments.error.c:18:10: error: Unprovable constraint
+  return foo(6 /*@ 2i32, x + *p, *p @*/);
+         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Constraint from tests/cn/ghost_arguments.error.c:5:3:
+  n + m + k == p;
+  ^~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__ghost_arguments.error.c__main.html

--- a/tests/cn/ghost_arguments_too_few.error.c
+++ b/tests/cn/ghost_arguments_too_few.error.c
@@ -1,0 +1,17 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost boolean b;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  return foo(6);
+}

--- a/tests/cn/ghost_arguments_too_few.error.c.verify
+++ b/tests/cn/ghost_arguments_too_few.error.c.verify
@@ -1,0 +1,10 @@
+return code: 1
+tests/cn/ghost_arguments_too_few.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost boolean b;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_too_few.error.c:16:10: error: Wrong number of ghost arguments
+  return foo(6);
+         ^~~~~~ 
+Expected 1, has 0

--- a/tests/cn/ghost_arguments_too_few_empty_magic.error.c
+++ b/tests/cn/ghost_arguments_too_few_empty_magic.error.c
@@ -1,0 +1,16 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 m, i32 n;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  return foo(6 /*@ @*/);
+}

--- a/tests/cn/ghost_arguments_too_few_empty_magic.error.c.verify
+++ b/tests/cn/ghost_arguments_too_few_empty_magic.error.c.verify
@@ -1,0 +1,10 @@
+return code: 1
+tests/cn/ghost_arguments_too_few_empty_magic.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 m, i32 n;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_too_few_empty_magic.error.c:15:10: error: Wrong number of ghost arguments
+  return foo(6 /*@ @*/);
+         ^~~~~~~~~~~~~~ 
+Expected 2, has 0

--- a/tests/cn/ghost_arguments_too_few_empty_magic.error.c.verify
+++ b/tests/cn/ghost_arguments_too_few_empty_magic.error.c.verify
@@ -4,7 +4,7 @@ tests/cn/ghost_arguments_too_few_empty_magic.error.c:4:3: warning: experimental 
   ^~~~~~~~ 
 [1/2]: foo -- pass
 [2/2]: main -- fail
-tests/cn/ghost_arguments_too_few_empty_magic.error.c:15:10: error: Wrong number of ghost arguments
+tests/cn/ghost_arguments_too_few_empty_magic.error.c:15:19: error: Wrong number of ghost arguments
   return foo(6 /*@ @*/);
-         ^~~~~~~~~~~~~~ 
+                  ^~ 
 Expected 2, has 0

--- a/tests/cn/ghost_arguments_too_few_magic.error.c
+++ b/tests/cn/ghost_arguments_too_few_magic.error.c
@@ -1,0 +1,16 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 m, i32 n;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  return foo(6 /*@ 0i32 @*/);
+}

--- a/tests/cn/ghost_arguments_too_few_magic.error.c.verify
+++ b/tests/cn/ghost_arguments_too_few_magic.error.c.verify
@@ -1,0 +1,10 @@
+return code: 1
+tests/cn/ghost_arguments_too_few_magic.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 m, i32 n;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_too_few_magic.error.c:15:19: error: Wrong number of ghost arguments
+  return foo(6 /*@ 0i32 @*/);
+                  ^~~~~~~ 
+Expected 2, has 1

--- a/tests/cn/ghost_arguments_too_many.error.c
+++ b/tests/cn/ghost_arguments_too_many.error.c
@@ -1,0 +1,17 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 n;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  return foo(6 /*@ x, x @*/);
+}

--- a/tests/cn/ghost_arguments_too_many.error.c.verify
+++ b/tests/cn/ghost_arguments_too_many.error.c.verify
@@ -4,7 +4,7 @@ tests/cn/ghost_arguments_too_many.error.c:4:3: warning: experimental keyword 'cn
   ^~~~~~~~ 
 [1/2]: foo -- pass
 [2/2]: main -- fail
-tests/cn/ghost_arguments_too_many.error.c:16:10: error: Wrong number of ghost arguments
+tests/cn/ghost_arguments_too_many.error.c:16:19: error: Wrong number of ghost arguments
   return foo(6 /*@ x, x @*/);
-         ^~~~~~~~~~~~~~~~~~~ 
+                  ^~~~~~~ 
 Expected 1, has 2

--- a/tests/cn/ghost_arguments_too_many.error.c.verify
+++ b/tests/cn/ghost_arguments_too_many.error.c.verify
@@ -1,0 +1,10 @@
+return code: 1
+tests/cn/ghost_arguments_too_many.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 n;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_too_many.error.c:16:10: error: Wrong number of ghost arguments
+  return foo(6 /*@ x, x @*/);
+         ^~~~~~~~~~~~~~~~~~~ 
+Expected 1, has 2

--- a/tests/cn/ghost_arguments_too_many_newline.error.c
+++ b/tests/cn/ghost_arguments_too_many_newline.error.c
@@ -1,0 +1,18 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost i32 n;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  return foo(6
+          /*@ 2i32, x @*/);
+}

--- a/tests/cn/ghost_arguments_too_many_newline.error.c.verify
+++ b/tests/cn/ghost_arguments_too_many_newline.error.c.verify
@@ -1,0 +1,10 @@
+return code: 1
+tests/cn/ghost_arguments_too_many_newline.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost i32 n;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_too_many_newline.error.c:17:14: error: Wrong number of ghost arguments
+          /*@ 2i32, x @*/);
+             ^~~~~~~~~~ 
+Expected 1, has 2

--- a/tests/cn/ghost_arguments_type_mismatch.error.c
+++ b/tests/cn/ghost_arguments_type_mismatch.error.c
@@ -1,0 +1,17 @@
+int foo(int p)
+/*@
+requires
+  cn_ghost boolean b;
+  true;
+ensures
+  true;
+@*/
+{
+  return p;
+}
+
+int main()
+{
+  int x = 3;
+  return foo(6 /*@ x @*/);
+}

--- a/tests/cn/ghost_arguments_type_mismatch.error.c.verify
+++ b/tests/cn/ghost_arguments_type_mismatch.error.c.verify
@@ -1,0 +1,13 @@
+return code: 1
+tests/cn/ghost_arguments_type_mismatch.error.c:4:3: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+  cn_ghost boolean b;
+  ^~~~~~~~ 
+[1/2]: foo -- pass
+[2/2]: main -- fail
+tests/cn/ghost_arguments_type_mismatch.error.c:15:11: error: Type error
+  int x = 3;
+          ^ 
+Expression '3'i32' has type 'i32'.
+I expected it to have type 'boolean' because of tests/cn/ghost_arguments_type_mismatch.error.c:1:1:
+int foo(int p)
+~~~~^~~~~~~~~~ 

--- a/tests/cn/ghost_bad_ordering.error.c
+++ b/tests/cn/ghost_bad_ordering.error.c
@@ -1,0 +1,11 @@
+int foo(int x)
+/*@
+  requires
+    x + n - n < MAXi32();
+    cn_ghost i32 n; true;
+  ensures
+    return == x + 1i32; 
+@*/
+{
+    return x + 1;
+}

--- a/tests/cn/ghost_bad_ordering.error.c.verify
+++ b/tests/cn/ghost_bad_ordering.error.c.verify
@@ -1,0 +1,8 @@
+return code: 1
+tests/cn/ghost_bad_ordering.error.c:5:5: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
+    cn_ghost i32 n; true;
+    ^~~~~~~~ 
+tests/cn/ghost_bad_ordering.error.c:5:5: error: unexpected token after ';' and before 'cn_ghost'
+Please add error message for state 1696 to parsers/c/c_parser_error.messages
+    cn_ghost i32 n; true;
+    ^~~~~~~~ 

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -99,6 +99,7 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "offsetof_int_const.c" \
     ! -name "issue_113.c" \
     ! -name "alloc_create.c" \
+    ! -name "ghost_arguments.c" \
 )
 
 # Include files which cause error for proof but not testing
@@ -161,6 +162,7 @@ BUGGY="\
        cn/offsetof_int_const.c \
        cn/accesses_on_spec/clientfile.c \
        cn/alloc_create.c \
+       cn/ghost_arguments.c \
        "
 
 # Exclude files which cause error for proof but not testing


### PR DESCRIPTION
Partially addresses #123 (need to add ghost arguments to loops).

Depends on https://github.com/rems-project/cerberus/pull/960.

It would be good to obviate cnprogs in another PR.

We will implement the Fulminate part in a follow-up PR.

~~I still need to disallow bad ordering or scoping of ghost arguments in function specifications, and add more tests for this.~~ This seems to be working.