### PR TITLE
Remove locations from Cnprog

### DIFF
--- a/lib/check.ml
+++ b/lib/check.ml
@@ -2063,13 +2063,13 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
        in
        let rec loop = function
          | [] -> k (unit_ loc)
-         | Cnprog.Let (loc, (sym, { ct; pointer }), cn_prog) :: cn_progs ->
+         | Cnprog.Let ((sym, { ct; pointer }), cn_prog) :: cn_progs ->
            let@ pointer = WellTyped.check_term loc (Loc ()) pointer in
            let@ () = WellTyped.check_ct loc ct in
            let@ value = load loc pointer ct in
            let subbed = Cnprog.subst (IT.make_subst [ (sym, value) ]) cn_prog in
            loop (subbed :: cn_progs)
-         | Cnprog.Statement (loc, cn_statement) :: cn_progs ->
+         | Cnprog.Statement cn_statement :: cn_progs ->
            (match cn_statement with
             | Cnprog.Split_case lc ->
               Pp.debug 5 (lazy (Pp.headline "checking split_case"));

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1220,22 +1220,21 @@ module C_vars = struct
               iargs = List.map IT.Surface.proj iargs
             } )
       in
-      return (Statement (loc, stmt))
+      return (Statement stmt)
     | CN_to_from_bytes (to_from, pred, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
       let@ name, pointer, iargs, _oargs_ty = cn_res_info ~pred_loc:loc env pred args in
       return
         (Statement
-           ( loc,
-             To_from_bytes
-               ( to_from,
-                 { name;
-                   pointer = IT.Surface.proj pointer;
-                   iargs = List.map IT.Surface.proj iargs
-                 } ) ))
+           (To_from_bytes
+              ( to_from,
+                { name;
+                  pointer = IT.Surface.proj pointer;
+                  iargs = List.map IT.Surface.proj iargs
+                } )))
     | CN_have assrt ->
       let@ assrt = cn_assrt env (loc, assrt) in
-      return (Statement (loc, Have assrt))
+      return (Statement (Have assrt))
     | CN_instantiate (to_instantiate, expr) ->
       let@ expr = cn_expr Sym.Set.empty env expr in
       let expr = IT.Surface.proj expr in
@@ -1245,10 +1244,10 @@ module C_vars = struct
         | I_Function f -> I_Function f
         | I_Good ct -> I_Good (Sctypes.of_ctype_unsafe loc ct)
       in
-      return (Statement (loc, Instantiate (to_instantiate, expr)))
+      return (Statement (Instantiate (to_instantiate, expr)))
     | CN_split_case e ->
       let@ e = cn_assrt env (loc, e) in
-      return (Statement (loc, Split_case e))
+      return (Statement (Split_case e))
     | CN_extract (attrs, to_extract, expr) ->
       let@ expr = cn_expr Sym.Set.empty env expr in
       let expr = IT.Surface.proj expr in
@@ -1261,23 +1260,23 @@ module C_vars = struct
           E_Pred (CN_block (Option.map (Sctypes.of_ctype_unsafe loc) oty))
         | E_Pred (CN_named pn) -> E_Pred (CN_named pn)
       in
-      return (Statement (loc, Extract (attrs, to_extract, expr)))
+      return (Statement (Extract (attrs, to_extract, expr)))
     | CN_unfold (s, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
       let args = List.map IT.Surface.proj args in
-      return (Statement (loc, Unfold (s, args)))
+      return (Statement (Unfold (s, args)))
     | CN_assert_stmt e ->
       let@ e = cn_assrt env (loc, e) in
-      return (Statement (loc, Assert e))
+      return (Statement (Assert e))
     | CN_apply (s, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
       let args = List.map IT.Surface.proj args in
-      return (Statement (loc, Apply (s, args)))
-    | CN_inline nms -> return (Statement (loc, Inline nms))
+      return (Statement (Apply (s, args)))
+    | CN_inline nms -> return (Statement (Inline nms))
     | CN_print expr ->
       let@ expr = cn_expr Sym.Set.empty env expr in
       let expr = IT.Surface.proj expr in
-      return (Statement (loc, Print expr))
+      return (Statement (Print expr))
 end
 
 module Handle = struct
@@ -1369,7 +1368,7 @@ module Handle = struct
       let value = IT.sym_ (value_s, value_bt, value_loc) in
       let@ prog = aux (k (Some value)) in
       let load = Cnprog.{ ct = pointee_ct; pointer = IT.Surface.proj pointer } in
-      return (Cnprog.Let (loc, (value_s, load), prog))
+      return (Cnprog.Let ((value_s, load), prog))
     in
     aux
 end

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -71,10 +71,10 @@ let add_records_to_map_from_cn_statement = function
 
 let add_records_to_map_from_cnprogs (_, cn_progs) =
   let rec aux = function
-    | Cnprog.Let (_, (_, { ct = _; pointer }), prog) ->
+    | Cnprog.Let ((_, { ct = _; pointer }), prog) ->
       add_records_to_map_from_it pointer;
       aux prog
-    | Statement (_, stmt) -> add_records_to_map_from_cn_statement stmt
+    | Statement stmt -> add_records_to_map_from_cn_statement stmt
   in
   List.iter aux cn_progs
 

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1737,12 +1737,15 @@ let pp_cnprog_load (r : Cnprog.load) =
     [ ("CNProgs.ct", pp_sctype r.ct); ("CNProgs.pointer", pp_index_term r.pointer) ]
 
 
-let rec pp_cn_prog = function
-  | Cnprog.Let (loc, (name, l), prog) ->
+let rec pp_cn_prog loc = function
+  | Cnprog.Let ((name, l), prog) ->
     pp_constructor
       "CNProgs.CLet"
-      [ pp_location loc; pp_tuple [ pp_symbol name; pp_cnprog_load l ]; pp_cn_prog prog ]
-  | Statement (loc, stmt) ->
+      [ pp_location loc;
+        pp_tuple [ pp_symbol name; pp_cnprog_load l ];
+        pp_cn_prog loc prog
+      ]
+  | Statement stmt ->
     pp_constructor "CNProgs.Statement" [ pp_location loc; pp_cnprog_statement stmt ]
 
 
@@ -1861,7 +1864,7 @@ and pp_expr pp_type = function
              "CN_progs"
              [ pp_tuple
                  [ pp_list (pp_cn_statement pp_symbol pp_ctype) stmts;
-                   pp_list pp_cn_prog progs
+                   pp_list (pp_cn_prog loc) progs
                  ]
              ])
       ]

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1945,18 +1945,18 @@ module BaseTyping = struct
       return (Split_case lc)
 
 
-  let check_cnprog p =
+  let check_cnprog loc p =
     let open Cnprog in
     let rec aux = function
-      | Let (loc, (s, { ct; pointer }), p') ->
+      | Let ((s, { ct; pointer }), p') ->
         let@ () = WCT.is_ct loc ct in
         let@ pointer = WIT.check loc (Loc ()) pointer in
         let@ () = add_l s (Memory.bt_of_sct ct) (loc, lazy (Sym.pp s)) in
         let@ p' = aux p' in
-        return (Let (loc, (s, { ct; pointer }), p'))
-      | Statement (loc, stmt) ->
+        return (Let ((s, { ct; pointer }), p'))
+      | Statement stmt ->
         let@ stmt = check_cn_statement loc stmt in
-        return (Statement (loc, stmt))
+        return (Statement stmt)
     in
     pure (aux p)
 
@@ -2183,7 +2183,7 @@ module BaseTyping = struct
           in
           return (Unit, Erun (l, pes, its))
         | CN_progs (surfaceprog, cnprogs) ->
-          let@ cnprogs = ListM.mapM check_cnprog cnprogs in
+          let@ cnprogs = ListM.mapM (check_cnprog loc) cnprogs in
           return (Unit, CN_progs (surfaceprog, cnprogs))
         | End _ -> todo ()
       in

--- a/tests/cn/and_or_precedence.error.c.verify
+++ b/tests/cn/and_or_precedence.error.c.verify
@@ -1,9 +1,9 @@
 return code: 1
 [1/1]: g1 -- fail
-tests/cn/and_or_precedence.error.c:15:13: error: Unprovable constraint
+tests/cn/and_or_precedence.error.c:15:12: error: Unprovable constraint
         /*@ assert (false); @*/
-            ^~~~~~~~~~~~~~~ 
-Constraint from tests/cn/and_or_precedence.error.c:15:13:
+           ^~~~~~~~~~~~~~~~~~ 
+Constraint from tests/cn/and_or_precedence.error.c:15:12:
         /*@ assert (false); @*/
-            ^~~~~~~~~~~~~~~ 
+           ^~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__and_or_precedence.error.c__g1.html

--- a/tests/cn/before_from_bytes.error.c.verify
+++ b/tests/cn/before_from_bytes.error.c.verify
@@ -2,9 +2,9 @@ return code: 1
 tests/cn/before_from_bytes.error.c:6:9: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
     /*@ to_bytes RW<int>(p); @*/
         ^~~~~~~~ 
-tests/cn/before_from_bytes.error.c:7:9: warning: focus: index added, no effect on existing resources (yet).
+tests/cn/before_from_bytes.error.c:7:8: warning: focus: index added, no effect on existing resources (yet).
     /*@ focus RW<char>, 2u64; @*/
-        ^~~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: main -- fail
 tests/cn/before_from_bytes.error.c:8:5: error: Missing resource for writing
     p_char[2] = 0xff;

--- a/tests/cn/extract_verbose.c.verify
+++ b/tests/cn/extract_verbose.c.verify
@@ -8,16 +8,16 @@ tests/cn/extract_verbose.c:11:22: warning: 'focus' prefers a 'u64', but '1' has 
 tests/cn/extract_verbose.c:14:22: warning: 'focus' prefers a 'u64', but '12' has type 'integer'.
   /*@ focus RW<int>, 12; @*/
                      ^
-tests/cn/extract_verbose.c:10:7: warning: focus: index added, no effect on existing resources (yet).
+tests/cn/extract_verbose.c:10:6: warning: focus: index added, no effect on existing resources (yet).
   /*@ focus RW<int>, 1; @*/
-      ^~~~~~~~~~~~~~~~~ 
-tests/cn/extract_verbose.c:11:7: warning: focus: index added, no effect on existing resources (yet).
+     ^~~~~~~~~~~~~~~~~~~~ 
+tests/cn/extract_verbose.c:11:6: warning: focus: index added, no effect on existing resources (yet).
   /*@ focus RW<int>, 1; @*/
-      ^~~~~~~~~~~~~~~~~ 
-tests/cn/extract_verbose.c:13:7: warning: focus: index added, no effect on existing resources (yet).
+     ^~~~~~~~~~~~~~~~~~~~ 
+tests/cn/extract_verbose.c:13:6: warning: focus: index added, no effect on existing resources (yet).
   /*@ focus RW<int>, 1u64; @*/
-      ^~~~~~~~~~~~~~~~~~~~ 
-tests/cn/extract_verbose.c:14:7: warning: focus: index added, no effect on existing resources (yet).
+     ^~~~~~~~~~~~~~~~~~~~~~~ 
+tests/cn/extract_verbose.c:14:6: warning: focus: index added, no effect on existing resources (yet).
   /*@ focus RW<int>, 12; @*/
-      ^~~~~~~~~~~~~~~~~~ 
+     ^~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: f -- pass

--- a/tests/cn/from_bytes.error.c.verify
+++ b/tests/cn/from_bytes.error.c.verify
@@ -6,6 +6,6 @@ tests/cn/from_bytes.error.c:6:9: warning: experimental keyword 'from_bytes' (use
     /*@ from_bytes Alloc(p); @*/ // <-- proof fails here, but this is a no-op in runtime
         ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn/from_bytes.error.c:6:9: error: byte conversion only supports W/RW
+tests/cn/from_bytes.error.c:6:8: error: byte conversion only supports W/RW
     /*@ from_bytes Alloc(p); @*/ // <-- proof fails here, but this is a no-op in runtime
-        ^~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~ 

--- a/tests/cn/get_from_arr.c.verify
+++ b/tests/cn/get_from_arr.c.verify
@@ -8,7 +8,7 @@ tests/cn/get_from_arr.c:9:18: warning: 'each' prefers a 'u64', but 'j' has type 
 tests/cn/get_from_arr.c:14:23: warning: 'focus' prefers a 'u64', but '4'i32' has type 'i32'.
   /*@ focus RW<char>, 4i32; @*/
                       ^
-tests/cn/get_from_arr.c:15:7: warning: nothing instantiated
+tests/cn/get_from_arr.c:15:6: warning: nothing instantiated
   /*@ instantiate good<char>, 4i32; @*/
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: get_from_arr -- pass

--- a/tests/cn/get_from_array.c.verify
+++ b/tests/cn/get_from_array.c.verify
@@ -9,7 +9,7 @@ tests/cn/get_from_array.c:40:23: warning: 'focus' prefers a 'u64', but '(i32)idx
   /*@ focus RW<int>, ((i32) idx); @*/
                       ^~~~~~~~~ 
 [1/2]: get_global_array_width_for_cn -- pass
-tests/cn/get_from_array.c:41:7: warning: nothing instantiated
+tests/cn/get_from_array.c:41:6: warning: nothing instantiated
   /*@ instantiate good<int>, ((i32) idx); @*/
-      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 [2/2]: set_a_pointer -- pass

--- a/tests/cn/implies2.error.c.verify
+++ b/tests/cn/implies2.error.c.verify
@@ -1,9 +1,9 @@
 return code: 1
 [1/1]: identity -- fail
-tests/cn/implies2.error.c:4:9: error: Unprovable constraint
+tests/cn/implies2.error.c:4:8: error: Unprovable constraint
     /*@ assert((x == 0i32) implies (y == 1i32));@*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-Constraint from tests/cn/implies2.error.c:4:9:
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Constraint from tests/cn/implies2.error.c:4:8:
     /*@ assert((x == 0i32) implies (y == 1i32));@*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 State file: file:///tmp/state__implies2.error.c__identity.html

--- a/tests/cn/memcpy.c.verify
+++ b/tests/cn/memcpy.c.verify
@@ -20,7 +20,7 @@ tests/cn/memcpy.c:19:16: warning: 'each' prefers a 'u64', but 'j' has type 'i32'
 tests/cn/memcpy.c:28:25: warning: 'focus' prefers a 'u64', but '(i32)read_&i0' has type 'i32'.
     /*@ focus RW<char>, (i32)i; @*/
                         ^~~~~~ 
-tests/cn/memcpy.c:29:9: warning: nothing instantiated
+tests/cn/memcpy.c:29:8: warning: nothing instantiated
     /*@ instantiate good<char>, (i32)i; @*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: naive_memcpy -- pass

--- a/tests/cn/partial_init_bytes.error.c.verify
+++ b/tests/cn/partial_init_bytes.error.c.verify
@@ -5,9 +5,9 @@ tests/cn/partial_init_bytes.error.c:5:9: warning: experimental keyword 'to_bytes
 tests/cn/partial_init_bytes.error.c:9:9: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
     /*@ from_bytes RW<int>(p); @*/
         ^~~~~~~~~~ 
-tests/cn/partial_init_bytes.error.c:7:9: warning: focus: index added, no effect on existing resources (yet).
+tests/cn/partial_init_bytes.error.c:7:8: warning: focus: index added, no effect on existing resources (yet).
     /*@ focus W<char>, 2u64; @*/
-        ^~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: main -- fail
 tests/cn/partial_init_bytes.error.c:8:5: error: Missing resource for writing
     p_char[2] = 0xff;

--- a/tests/cn/swap.c.verify
+++ b/tests/cn/swap.c.verify
@@ -11,10 +11,10 @@ tests/cn/swap.c:11:38: warning: 'focus' prefers a 'u64', but '0'i32' has type 'i
 tests/cn/swap.c:12:38: warning: 'focus' prefers a 'u64', but '1'i32' has type 'i32'.
     /*@ focus RW<unsigned long int>, 1i32; @*/
                                      ^
-tests/cn/swap.c:13:9: warning: nothing instantiated
+tests/cn/swap.c:13:8: warning: nothing instantiated
     /*@ instantiate good<unsigned long int>, 0i32; @*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-tests/cn/swap.c:14:9: warning: nothing instantiated
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+tests/cn/swap.c:14:8: warning: nothing instantiated
     /*@ instantiate good<unsigned long int>, 1i32; @*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: swap_pair -- pass

--- a/tests/cn/swap_pair.c.verify
+++ b/tests/cn/swap_pair.c.verify
@@ -11,10 +11,10 @@ tests/cn/swap_pair.c:11:38: warning: 'focus' prefers a 'u64', but '0'i32' has ty
 tests/cn/swap_pair.c:13:38: warning: 'focus' prefers a 'u64', but '1'i32' has type 'i32'.
     /*@ focus RW<unsigned long int>, 1i32; @*/
                                      ^
-tests/cn/swap_pair.c:14:9: warning: nothing instantiated
+tests/cn/swap_pair.c:14:8: warning: nothing instantiated
     /*@ instantiate good<unsigned long int>, 0i32; @*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-tests/cn/swap_pair.c:16:9: warning: nothing instantiated
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+tests/cn/swap_pair.c:16:8: warning: nothing instantiated
     /*@ instantiate good<unsigned long int>, 1i32; @*/
-        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 [1/1]: swap_pair -- pass

--- a/tests/cn/to_bytes.error.c.verify
+++ b/tests/cn/to_bytes.error.c.verify
@@ -3,6 +3,6 @@ tests/cn/to_bytes.error.c:5:9: warning: experimental keyword 'to_bytes' (use of 
     /*@ to_bytes Alloc(p); @*/
         ^~~~~~~~ 
 [1/1]: main -- fail
-tests/cn/to_bytes.error.c:5:9: error: byte conversion only supports W/RW
+tests/cn/to_bytes.error.c:5:8: error: byte conversion only supports W/RW
     /*@ to_bytes Alloc(p); @*/
-        ^~~~~~~~~~~~~~~~~~ 
+       ^~~~~~~~~~~~~~~~~~~~~ 


### PR DESCRIPTION
Cnprog does not need to carry around locations which can always be found elsewhere.