### PR TITLE
Use casting in `Simplify` for `array_shift`

### DIFF
--- a/lib/baseTypes.ml
+++ b/lib/baseTypes.ml
@@ -263,7 +263,7 @@ module Surface = struct
 
   let of_sct = of_sct Option.some
 
-  let unintptr_bt = uintptr_bt Option.some
+  let uintptr_bt = uintptr_bt Option.some
 
   let intptr_bt = intptr_bt Option.some
 

--- a/lib/indexTerms.ml
+++ b/lib/indexTerms.ml
@@ -698,6 +698,20 @@ let cast_ bt' it loc =
   if BT.equal bt' (get_bt it) then it else IT (Cast (bt', it), bt', loc)
 
 
+let arith_binop_cast op (it1, it2) loc =
+  let it1, it2 =
+    match (get_bt it1, get_bt it2) with
+    | BT.Bits (sgn1, sz1), BT.Bits (sgn2, sz2) ->
+      let sgn = if BT.equal_sign sgn1 sgn2 then sgn1 else Unsigned in
+      let cast = fun it -> cast_ (BT.Bits (sgn, max sz1 sz2)) it (get_loc it) in
+      (cast it1, cast it2)
+    | bt1, bt2 ->
+      assert (BT.equal bt1 bt2);
+      (it1, it2)
+  in
+  arith_binop op (it1, it2) loc
+
+
 let uintptr_const_ n loc = num_lit_ n Memory.uintptr_bt loc
 
 let uintptr_int_ n loc = uintptr_const_ (Z.of_int n) loc

--- a/lib/simplify.ml
+++ b/lib/simplify.ml
@@ -543,7 +543,7 @@ module IndexTerms = struct
           match base with
           | IT (ArrayShift { base = base2; ct = ct2; index = i2 }, _, _)
             when Sctypes.equal ct ct2 ->
-            (base2, IT.add_ (index, i2) the_loc)
+            (base2, IT.arith_binop_cast Add (index, i2) the_loc)
           | _ -> (base, index)
         in
         let index = aux index in

--- a/tests/cn-test-gen/src/array_shift.pass.c
+++ b/tests/cn-test-gen/src/array_shift.pass.c
@@ -1,0 +1,14 @@
+void f(int *p, int len)
+/*@
+    requires
+        take x_1 = Owned<int>(p);
+        len > 0i32;
+        let offset = array_shift(array_shift(p, (u64)mod(x_1, len)), 5u32);
+        take x_2 = Owned(offset);
+    ensures
+        take x_1_after = Owned<int>(p);
+        take x_2_after = Owned(offset);
+        x_1 == x_1_after;
+        x_2 == x_2_after;
+@*/
+{}


### PR DESCRIPTION
#131 added casting for offsets in `array_shift` during typechecking, but it seems morally, testing should use `ArgumentTypes` rather than `Mucore`. As such, the issue with `Simplify` remains.

This adds a new smart constructor `arith_binop_cast` that inserts casts to make bitvectors' sizes match. It then uses this in `Simplify`.

Closes #182, though I don't love this solution.