### PR TITLE
Fix integer-to-u64 cast failure in SMT translation

### DIFF
--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -846,8 +846,8 @@ module WIT = struct
         let@ () = WCT.is_ct loc ct in
         let@ base = check loc (Loc ()) base in
         let@ index = infer index in
-        let index = cast_ Memory.uintptr_bt index loc in
         let@ () = ensure_bits_type loc (IT.get_bt index) in
+        let index = cast_ Memory.uintptr_bt index loc in
         return (IT (ArrayShift { base; ct; index }, BT.Loc (), loc))
       | CopyAllocId { addr; loc = ptr } ->
         let@ addr = check loc Memory.uintptr_bt addr in

--- a/tests/cn/issue_113.error.c
+++ b/tests/cn/issue_113.error.c
@@ -1,0 +1,7 @@
+// regression test: see https://github.com/rems-project/cn/issues/113#issuecomment-2967000854
+void f(char *p, unsigned x)
+/*@
+requires is_null(array_shift<unsigned char>(array_shift<unsigned char>(p, x), 1));
+@*/
+{
+}

--- a/tests/cn/issue_113.error.c.verify
+++ b/tests/cn/issue_113.error.c.verify
@@ -1,0 +1,5 @@
+return code: 1
+tests/cn/issue_113.error.c:4:18: error: Mismatched types.
+requires is_null(array_shift<unsigned char>(array_shift<unsigned char>(p, x), 1));
+                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+Expected value of type 'bitvector' but found value of type 'integer'


### PR DESCRIPTION
I've encountered the array_shift casting issue again, as noted in https://github.com/rems-project/cn/issues/113#issuecomment-2967000854. Here is the patch to address this issue.