### PR TITLE
Bennet destruct product arguments

### DIFF
--- a/bin/test.ml
+++ b/bin/test.ml
@@ -56,6 +56,7 @@ let run_tests
       output_tyche
       inline_everything
       experimental_struct_asgn_destruction
+      experimental_product_arg_destruction
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
@@ -101,6 +102,7 @@ let run_tests
           sanitizers;
           inline_everything;
           experimental_struct_asgn_destruction;
+          experimental_product_arg_destruction;
           print_seed;
           input_timeout;
           null_in_every;
@@ -436,6 +438,11 @@ module Flags = struct
   let experimental_struct_asgn_destruction =
     let doc = "Destructs struct assignments" in
     Arg.(value & flag & info [ "experimental-struct-asgn-destruction" ] ~doc)
+
+
+  let experimental_product_arg_destruction =
+    let doc = "Destructs all records and structs arguments" in
+    Arg.(value & flag & info [ "experimental-product-arg-destruction" ] ~doc)
 end
 
 let cmd =
@@ -491,6 +498,7 @@ let cmd =
     $ Flags.output_tyche
     $ Flags.inline_everything
     $ Flags.experimental_struct_asgn_destruction
+    $ Flags.experimental_product_arg_destruction
   in
   let doc =
     "Generates tests for all functions in [FILE] with CN specifications.\n\

--- a/lib/testGeneration/bennet/stage1/destructProducts.ml
+++ b/lib/testGeneration/bennet/stage1/destructProducts.ml
@@ -1,0 +1,165 @@
+module BT = BaseTypes
+module IT = IndexTerms
+
+type destruct_tree =
+  | Struct of Sym.t * (Id.t * destruct_tree) list
+  | Record of (Id.t * destruct_tree) list
+  | Tuple of destruct_tree list
+  | Leaf of Sym.t * BT.t (** New Name *)
+
+let rec flatten_tree (t : destruct_tree) : (Sym.t * BT.t) list =
+  match t with
+  | Struct (_, xts) | Record xts ->
+    xts |> List.map snd |> List.map flatten_tree |> List.flatten
+  | Tuple ts -> ts |> List.map flatten_tree |> List.flatten
+  | Leaf (x, bt) -> [ (x, bt) ]
+
+
+let transform_iarg (prog5 : unit Mucore.file) (arg : Sym.t * BT.t) : destruct_tree =
+  let rec aux ((arg_sym, arg_bt) : Sym.t * BT.t) : destruct_tree =
+    match arg_bt with
+    | BT.Struct tag ->
+      (match Pmap.find tag prog5.tagDefs with
+       | StructDef pieces ->
+         let members =
+           pieces
+           |> List.filter_map (fun ({ member_or_padding; _ } : Memory.struct_piece) ->
+             member_or_padding)
+           (* |> List.sort (fun (id1, _) (id2, _) -> Id.compare id1 id2) *)
+           |> List.map (fun (member, sct) ->
+             ( member,
+               ( Sym.fresh Pp.(plain (Sym.pp arg_sym ^^ underscore ^^ Id.pp member)),
+                 Memory.bt_of_sct sct ) ))
+           |> List.map_snd aux
+         in
+         Struct (tag, members)
+       | _ -> failwith ("no struct " ^ Sym.pp_string tag ^ " found"))
+    | BT.Record members ->
+      let members =
+        members
+        (* |> List.sort (fun (id1, _) (id2, _) -> Id.compare id1 id2) *)
+        |> List.map (fun (member, bt) ->
+          ( member,
+            (Sym.fresh Pp.(plain (Sym.pp arg_sym ^^ underscore ^^ Id.pp member)), bt) ))
+        |> List.map_snd aux
+      in
+      Record members
+    | BT.Tuple items ->
+      let items =
+        items
+        |> List.mapi (fun i bt ->
+          (Sym.fresh Pp.(plain (Sym.pp arg_sym ^^ underscore ^^ int i)), bt))
+        |> List.map aux
+      in
+      Tuple items
+    | _ -> Leaf (arg_sym, arg_bt)
+  in
+  aux arg
+
+
+let transform_iargs (prog5 : unit Mucore.file) (args : (Sym.t * BT.t) list)
+  : (Sym.t * destruct_tree) list
+  =
+  (* TODO: Ensure uniqueness of names *)
+  (* let assert_uniqueness args' =
+    let uniq = args' |> List.map fst |> Sym.Set.of_list in
+    assert (Sym.Set.cardinal uniq = List.length args');
+    args'
+  in *)
+  args |> List.map (fun (sym, bt) -> (sym, transform_iarg prog5 (sym, bt)))
+
+
+let transform_it (prog5 : unit Mucore.file) ((it, bt) : IT.t * BT.t) : IT.t list =
+  let rec aux ((it, bt) : IT.t * BT.t) : IT.t list =
+    match bt with
+    | BT.Struct tag ->
+      (match Pmap.find tag prog5.tagDefs with
+       | StructDef pieces ->
+         pieces
+         |> List.filter_map (fun ({ member_or_padding; _ } : Memory.struct_piece) ->
+           member_or_padding)
+         (* |> List.sort (fun (id1, _) (id2, _) -> Id.compare id1 id2) *)
+         |> List.map (fun (member, sct) ->
+           let loc = Locations.other __LOC__ in
+           let member_bt = Memory.bt_of_sct sct in
+           (IT.member_ ~member_bt (it, member) loc, member_bt))
+         |> List.map aux
+         |> List.flatten
+       | _ -> failwith ("no struct " ^ Sym.pp_string tag ^ " found"))
+    | BT.Record members ->
+      members
+      (* |> List.sort (fun (id1, _) (id2, _) -> Id.compare id1 id2) *)
+      |> List.map (fun (member, member_bt) ->
+        let loc = Locations.other __LOC__ in
+        (IT.recordMember_ ~member_bt (it, member) loc, member_bt))
+      |> List.map aux
+      |> List.flatten
+    | Tuple members ->
+      members
+      |> List.mapi (fun i item_bt ->
+        let loc = Locations.other __LOC__ in
+        (IT.nthTuple_ ~item_bt (i, it) loc, item_bt))
+      |> List.map aux
+      |> List.flatten
+    | _ -> [ it ]
+  in
+  aux (it, bt)
+
+
+let transform_its (prog5 : unit Mucore.file) (its : (IT.t * BT.t) list) : IT.t list =
+  its |> List.map (transform_it prog5) |> List.flatten
+
+
+let transform_gt (prog5 : unit Mucore.file) (ctx : Ctx.t) (gt : Term.t) : Term.t =
+  let aux (gt : Term.t) : Term.t =
+    let (GT (gt_, bt, loc)) = gt in
+    match gt_ with
+    | Call (fsym, xits) ->
+      let gd = List.assoc Sym.equal fsym ctx in
+      let xs =
+        gd.iargs
+        |> transform_iargs prog5
+        |> List.map snd
+        |> List.map flatten_tree
+        |> List.flatten
+        |> List.map fst
+      in
+      let its =
+        gd.iargs
+        |> List.map snd
+        |> List.combine (List.map snd xits)
+        |> transform_its prog5
+      in
+      let xits' = List.combine xs its in
+      Term.call_ (fsym, xits') bt loc
+    | _ -> gt
+  in
+  Term.map_gen_pre aux gt
+
+
+let transform_gd (prog5 : unit Mucore.file) (ctx : Ctx.t) (gd : Def.t) : Def.t =
+  let t = transform_iargs prog5 gd.iargs in
+  let iargs = t |> List.map snd |> List.map flatten_tree |> List.flatten in
+  let rec assemble_product (t : destruct_tree) : IT.t =
+    match t with
+    | Struct (tag, members) ->
+      IT.struct_ (tag, List.map_snd assemble_product members) (Locations.other __LOC__)
+    | Record members ->
+      IT.record_ (List.map_snd assemble_product members) (Locations.other __LOC__)
+    | Tuple items -> IT.tuple_ (List.map assemble_product items) (Locations.other __LOC__)
+    | Leaf (x, bt) -> IT.sym_ (x, bt, Locations.other __LOC__)
+  in
+  let body =
+    List.fold_left
+      (fun gt_rest (sym, t) ->
+         Term.let_star_
+           ((sym, Term.return_ (assemble_product t) (Locations.other __LOC__)), gt_rest)
+           (Locations.other __LOC__))
+      (transform_gt prog5 ctx gd.body)
+      t
+  in
+  { gd with iargs; body }
+
+
+let transform (prog5 : unit Mucore.file) (ctx : Ctx.t) : Ctx.t =
+  List.map_snd (transform_gd prog5 ctx) ctx

--- a/lib/testGeneration/bennet/stage1/stage1.ml
+++ b/lib/testGeneration/bennet/stage1/stage1.ml
@@ -8,3 +8,8 @@ let transform filename (prog5 : unit Mucore.file) (tests : Test.t list)
   tests
   |> Convert.transform filename prog5.resource_predicates
   |> DestructArbitrary.transform prog5
+  |>
+  if TestGenConfig.is_experimental_product_arg_destruction () then
+    DestructProducts.transform prog5
+  else
+    fun ctx -> ctx

--- a/lib/testGeneration/bennet/stage2/simplifyGen/memberIndirection.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/memberIndirection.ml
@@ -131,6 +131,7 @@ let transform_gt (gt : Term.t) : Term.t =
                    |> List.map (fun (y, z) ->
                      let it = List.assoc Id.equal y xits in
                      (y, IT.sym_ (z, IT.get_bt it, IT.get_loc it)))
+                   |> List.sort (fun (id1, _) (id2, _) -> Id.compare id1 id2)
                  in
                  match k with
                  | Struct tag -> IT.struct_ (tag, members) loc_it
@@ -150,3 +151,8 @@ let transform_gt (gt : Term.t) : Term.t =
     | _ -> gt
   in
   Term.map_gen_post aux gt
+
+
+let transform_gd (gd : Def.t) : Def.t = { gd with body = transform_gt gd.body }
+
+let transform (ctx : Ctx.t) = List.map_snd transform_gd ctx

--- a/lib/testGeneration/bennet/stage2/simplifyGen/memberIndirection.mli
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/memberIndirection.mli
@@ -1,1 +1,3 @@
 val transform_gt : Term.t -> Term.t
+
+val transform : Ctx.t -> Ctx.t

--- a/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.ml
@@ -13,7 +13,11 @@ let transform_gt prog5 gt =
         |> InlineTerm.transform_gt
         |> PushPull.transform_gt
         |> PartialEvaluation.transform_gt prog5
-        |> MemberIndirection.transform_gt
+        |>
+        if TestGenConfig.is_experimental_product_arg_destruction () then
+          fun ctx -> ctx
+        else
+          MemberIndirection.transform_gt
       in
       if Term.equal old_gt new_gt then new_gt else aux new_gt (fuel - 1))
   in

--- a/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.ml
@@ -1,3 +1,5 @@
+module MemberIndirection = MemberIndirection
+
 let transform_gt prog5 gt =
   let rec aux gt fuel =
     if fuel <= 0 then

--- a/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.mli
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/simplifyGen.mli
@@ -1,1 +1,3 @@
+module MemberIndirection = MemberIndirection
+
 val transform : unit Mucore.file -> Ctx.t -> Ctx.t

--- a/lib/testGeneration/bennet/stage2/stage2.ml
+++ b/lib/testGeneration/bennet/stage2/stage2.ml
@@ -5,6 +5,7 @@ module Ctx = Ctx
 let transform (prog5 : unit Mucore.file) (ctx : Stage1.Ctx.t) : Ctx.t =
   ctx
   |> Convert.transform
+  |> SimplifyGen.MemberIndirection.transform
   |> SimplifyGen.transform prog5
   |> (fun ctx ->
   if TestGenConfig.has_inline_everything () then

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -32,6 +32,7 @@ type t =
     sanitizers : string option * string option;
     inline_everything : bool;
     experimental_struct_asgn_destruction : bool;
+    experimental_product_arg_destruction : bool;
     (* Run time *)
     print_seed : bool;
     input_timeout : int option;
@@ -65,6 +66,7 @@ let default =
     sanitizers = (None, None);
     inline_everything = false;
     experimental_struct_asgn_destruction = false;
+    experimental_product_arg_destruction = false;
     print_seed = false;
     input_timeout = None;
     null_in_every = None;
@@ -154,6 +156,10 @@ let has_sanitizers () = !instance.sanitizers
 
 let is_experimental_struct_asgn_destruction () =
   !instance.experimental_struct_asgn_destruction
+
+
+let is_experimental_product_arg_destruction () =
+  !instance.experimental_product_arg_destruction
 
 
 let has_inline_everything () = !instance.inline_everything

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -32,6 +32,7 @@ type t =
     sanitizers : string option * string option;
     inline_everything : bool;
     experimental_struct_asgn_destruction : bool;
+    experimental_product_arg_destruction : bool;
     (* Run time *)
     print_seed : bool;
     input_timeout : int option;
@@ -89,6 +90,8 @@ val has_sanitizers : unit -> string option * string option
 val has_inline_everything : unit -> bool
 
 val is_experimental_struct_asgn_destruction : unit -> bool
+
+val is_experimental_product_arg_destruction : unit -> bool
 
 val has_input_timeout : unit -> int option
 


### PR DESCRIPTION
Since our backtracking uses variable names, when there was a failure, if the argument was a struct, we lost information about which specific member was the issue.

Rewriting generators that take structs to instead take an argument for each member solves this issue.

Also added an option to break apart assignments, but we'd need to improve initial allocation sizes to avoid a performance degradation.