### PR TITLE
[CN-exec] Add `no_debug_info` flag

### DIFF
--- a/runtime/libcn/libexec/cn-runtime-single-file.sh
+++ b/runtime/libcn/libexec/cn-runtime-single-file.sh
@@ -47,7 +47,7 @@ RUNTIME_PREFIX="$OPAM_SWITCH_PREFIX/lib/cn/runtime"
 
 # Instrument code with CN
 if cn instrument "${INPUT_FN}" \
-    --run --tmp --print-steps \
+    --run --no-debug-info --tmp --print-steps \
     --output="${INPUT_BASENAME}.exec.c" \
     ${NO_CHECK_OWNERSHIP}; then
   [ "${QUIET}" ] || echo "Success!"


### PR DESCRIPTION
This PR makes compiling with the `-g` flag the default behaviour when running `cn instrument --run <your-source>.c`, to make gdb/lldb usable on the executable. I've added a flag for disabling collection of debug information called `no_debug_info`. I'd argue this is better than having to manually enable the collection of debug information every time the user runs Fulminate.