### PR TITLE
Fix build for updated frontend

### DIFF
--- a/cn.opam
+++ b/cn.opam
@@ -23,7 +23,7 @@ depends: [
   "zarith" {>= "1.13"}
 ]
 pin-depends: [
-  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#f11e6b3"]
+  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#73b0949"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/cStatements.ml
+++ b/lib/cStatements.ml
@@ -88,7 +88,7 @@ let add_map_stmt (stmt : 'a statement) m =
   let rec f stmts m =
     match stmts with
     | [] -> m
-    | { loc = l; is_forloop = _; attrs = _; node = x } :: ss ->
+    | { loc = l; desug_info = _; attrs = _; node = x } :: ss ->
       let m = map l m l in
       (match x with
        | AilSblock (_, ss2) -> f (ss2 @ ss) m

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -1703,7 +1703,7 @@ let rec cn_to_ail_expr_aux
                  in
                  A.
                    { loc = Cerb_location.unknown;
-                     is_forloop = false;
+                     desug_info = Desug_none;
                      attrs = CF.Annot.Attrs [ attribute ];
                      node = ail_case
                    }
@@ -2104,7 +2104,7 @@ let generate_datatype_equality_function (filename : string) (cn_datatype : _ cn_
     in
     A.
       { loc = Cerb_location.unknown;
-        is_forloop = false;
+        desug_info = Desug_none;
         attrs = CF.Annot.Attrs [ attribute ];
         node = ail_case
       }
@@ -2207,7 +2207,7 @@ let generate_datatype_default_function (cn_datatype : _ cn_datatype) =
   let res_tag_assign_stat =
     A.
       { loc = Cerb_location.unknown;
-        is_forloop = false;
+        desug_info = Desug_none;
         attrs = CF.Annot.Attrs [ attribute ];
         node = res_tag_assign
       }

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -189,7 +189,7 @@ let get_c_local_ownership_checking params =
 
 let rec collect_visibles bindings = function
   | [] -> []
-  | A.{ loc = _; is_forloop = _; attrs = _; node = AilSdeclaration decls } :: ss ->
+  | A.{ loc = _; desug_info = _; attrs = _; node = AilSdeclaration decls } :: ss ->
     let decl_syms_and_ctypes =
       List.map (fun (sym, _) -> (sym, find_ctype_from_bindings bindings sym)) decls
     in
@@ -211,7 +211,7 @@ let rec get_c_control_flow_block_unmaps_aux
           continue_vars
           return_vars
           bindings
-          A.{ loc; is_forloop = _; attrs = _; node = s_ }
+          A.{ loc; desug_info = _; attrs = _; node = s_ }
   : ownership_injection list
   =
   match s_ with
@@ -285,7 +285,7 @@ let get_c_control_flow_block_unmaps stat =
 
 
 (* Ghost state tracking for block declarations *)
-let rec get_c_block_entry_exit_injs_aux bindings A.{ loc; is_forloop; node = s_; _ } =
+let rec get_c_block_entry_exit_injs_aux bindings A.{ loc; desug_info; node = s_; _ } =
   let gen_standard_block_injs bs ss =
     let exit_injs =
       List.map
@@ -298,6 +298,7 @@ let rec get_c_block_entry_exit_injs_aux bindings A.{ loc; is_forloop; node = s_;
     let stat_injs = List.map (fun s -> get_c_block_entry_exit_injs_aux bs s) ss in
     List.concat stat_injs @ exit_injs'
   in
+  let is_forloop = match desug_info with Desug_forloop -> true | _ -> false in
   match s_ with
   | A.(AilSdeclaration decls) ->
     generate_c_local_ownership_entry_inj ~is_forloop loc decls bindings
@@ -353,7 +354,7 @@ let rec remove_duplicates ds = function
 
 
 let get_c_block_local_ownership_checking_injs
-      A.({ loc = _; is_forloop = _; attrs = _; node = fn_block } as statement)
+      A.({ loc = _; desug_info = _; attrs = _; node = fn_block } as statement)
   =
   match fn_block with
   | A.(AilSblock _) ->

--- a/lib/fulminate/utils.ml
+++ b/lib/fulminate/utils.ml
@@ -42,7 +42,7 @@ let[@warning "-32" (* unused-value-declaration *)] rm_cn_expr (Cn.CNExpr (_, cn_
 let mk_stmt stmt_ =
   A.
     { loc = Cerb_location.unknown;
-      is_forloop = false;
+      desug_info = Desug_none;
       attrs = CF.Annot.Attrs [];
       node = stmt_
     }
@@ -51,7 +51,7 @@ let mk_stmt stmt_ =
 let rm_expr (A.AnnotatedExpression (_, _, _, expr_)) = expr_
 
 let[@warning "-32" (* unused-value-declaration *)] rm_stmt = function
-  | A.{ loc = _; is_forloop = _; attrs = _; node = stmt_ } -> stmt_
+  | A.{ loc = _; desug_info = _; attrs = _; node = stmt_ } -> stmt_
 
 
 let empty_ail_str = "empty_ail"


### PR DESCRIPTION
In particular https://github.com/rems-project/cerberus/commit/4c18ad5bb24c67c28cb72c608cdb8e2190093b8d:
(Ail) replacing is_forloop with more general desug_info now also used for CabsScontinue

May want to create an issue to finish the update for more general desug_info