### PR TITLE
Fix #177: remmove dep. of TypeErrors from Parse

### DIFF
--- a/bin/common.ml
+++ b/bin/common.ml
@@ -458,5 +458,5 @@ module Flags = struct
       "Alloc function specifications and loop invariants to be split across multiple \
        magic comments"
     in
-    Arg.(value & flag & info [ "allow_split_magic_comments" ] ~doc)
+    Arg.(value & flag & info [ "allow-split-magic-comments" ] ~doc)
 end

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -68,6 +68,20 @@ module Translate = struct
   let statement x1 x2 x3 x4 = lift (statement x1 x2 x3 x4)
 end
 
+module Parse = struct
+  include Parse
+
+  let lift x =
+    Result.map_error (fun { loc; msg } -> TypeErrors.{ loc; msg = Parse msg }) x
+
+
+  let function_spec attrs = lift (function_spec attrs)
+
+  let loop_spec attrs = lift (loop_spec attrs)
+
+  let cn_statements annots = lift (cn_statements annots)
+end
+
 open CF.Core
 open Pp
 

--- a/lib/typeErrors.mli
+++ b/lib/typeErrors.mli
@@ -33,6 +33,7 @@ type message =
   | Compile of Compile.message
   | Global of Global.message
   | WellTyped of WellTyped.message
+  | Parse of Parse.message
   | Missing_resource of
       { requests : RequestChain.t;
         situation : Error_common.situation;
@@ -116,7 +117,6 @@ type message =
         ctxt : Context.t * Explain.log
       } [@deprecated "Please add a specific constructor"] (** TODO delete this too *)
   | Unsupported of Pp.document (** TODO add source location *)
-  | Parser of Cerb_frontend.Errors.cparser_cause
   | Empty_provenance
   | Inconsistent_assumptions of string * (Context.t * Explain.log)
   (** TODO replace string with an actual type *)
@@ -125,11 +125,6 @@ type message =
       { fname : Sym.t;
         orig_loc : Locations.t
       }
-  | Spec_split_across_multiple_magic_comments of
-      { loc1 : Locations.t;
-        loc2 : Locations.t
-      }
-  | Requires_after_ensures of { ens_loc : Locations.t }
   | Unsupported_byte_conv_ct of Sctypes.ctype
   | Number_spec_args of
       { spec : int;

--- a/tests/cn-test-gen/run-single-test.sh
+++ b/tests/cn-test-gen/run-single-test.sh
@@ -26,7 +26,7 @@ BASE_CONFIG="-I${OPAM_SWITCH_PREFIX}/lib/cerberus-lib/runtime/libc/include/posix
   --input-timeout=1000 \
   --progress-level=function \
   --sanitize=undefined \
-  --allow_split_magic_comments \
+  --allow-split-magic-comments \
   --print-seed"
 if [[ $(basename $TEST) == "mkm.pass.c" ]]; then
   BASE_CONFIG="$BASE_CONFIG --max-array-length=1024"


### PR DESCRIPTION
Commit 363aea6 removed the dependency of `TypeErrors` on `parse.ml`, in preparation of removing the dependency of the same in `Core_to_mucore` (I want to invert the dependency structure so that each pass defines its own errors and embeds them into `TypeErrors` as needed).

Commit b0f96b3 reintroduced this dependency, to use `TypeErrors.Spec_split_across_multiple_magic_comments`.

This commits instead adds an extra constructor to the commented out `msg` type that was already there and then rebinding the parse module `Core_to_mucore` to lift the error.