### PR TITLE
[CN-exec] Add `-O2` to runtime library compile script

### DIFF
--- a/runtime/libcn/lib/compile.sh
+++ b/runtime/libcn/lib/compile.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-FLAGS=""
+FLAGS="-O2 "
 if [[ -n "${GITHUB_ACTIONS+isset}" ]]; then
-    FLAGS="-Werror -Wall"
+    FLAGS+="-Werror -Wall"
 fi
 
 cc ${FLAGS} -I ../../include/ -c -g "$@"


### PR DESCRIPTION
@pqwy's suggestion