### PR TITLE
fix 'too many open files' issue in solver

### DIFF
--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1329,6 +1329,9 @@ let model_evaluator, reset_model_evaluator_state =
     !model_id
   in
   let reset_model_evaluator_state () =
+    match !model_evaluator_solver with
+    | None -> ()
+    | Some e -> SMT.(e.stop ());
     currently_loaded_model := 0;
     model_evaluator_solver := None;
     model_id := 0
@@ -1445,6 +1448,7 @@ let provableWithUnknown ~loc ~solver ~assumptions ~simp_ctxt lc =
   let _ = loc in
   let set_model smt_solver qs =
     let defs = SMT.get_model smt_solver in
+    reset_model_evaluator_state ();
     let model = model_evaluator solver defs in
     model_state := Model (model, qs)
   in

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1331,10 +1331,11 @@ let model_evaluator, reset_model_evaluator_state =
   let reset_model_evaluator_state () =
     match !model_evaluator_solver with
     | None -> ()
-    | Some e -> SMT.(e.stop ());
-    currently_loaded_model := 0;
-    model_evaluator_solver := None;
-    model_id := 0
+    | Some e ->
+      SMT.(e.stop ());
+      currently_loaded_model := 0;
+      model_evaluator_solver := None;
+      model_id := 0
   in
   let model_evaluator solver mo =
     match SMT.to_list mo with


### PR DESCRIPTION
- reset model evaluator solver state when setting new model
- make that stop the solver instance used as the evaluator for the previous model