### PR TITLE
[CN-exec] Change bump allocator block size and count

### DIFF
--- a/runtime/libcn/src/cn-executable/bump_alloc.c
+++ b/runtime/libcn/src/cn-executable/bump_alloc.c
@@ -12,8 +12,8 @@
 #include <cn-executable/bump_alloc.h>
 #include <cn-executable/utils.h>
 
-#define BUMP_BLOCK_SIZE  (1024 * 1024)
-#define BUMP_BLOCK_COUNT 1024
+#define BUMP_BLOCK_SIZE  (1024 * 1024 * 16)
+#define BUMP_BLOCK_COUNT (1024 / 16)
 static char* bump_blocks[BUMP_BLOCK_COUNT];
 static uint16_t bump_curr_block;
 static char* bump_curr;

--- a/runtime/libcn/src/cn-executable/bump_alloc.c
+++ b/runtime/libcn/src/cn-executable/bump_alloc.c
@@ -12,8 +12,8 @@
 #include <cn-executable/bump_alloc.h>
 #include <cn-executable/utils.h>
 
-#define BUMP_BLOCK_SIZE  (1024 * 1024 * 16)
-#define BUMP_BLOCK_COUNT (1024 / 16)
+#define BUMP_BLOCK_SIZE  (1024 * 1024 * 8)
+#define BUMP_BLOCK_COUNT (1024 / 8)
 static char* bump_blocks[BUMP_BLOCK_COUNT];
 static uint16_t bump_curr_block;
 static char* bump_curr;


### PR DESCRIPTION
Now that CN maps are allocated using the bump allocator and not the free-list allocator/`malloc`, it was exceeding `BUMP_BLOCK_SIZE` quite easily. We keep the maximum space in the bump allocator as 1GB but make the size of each block 8x bigger and the number of blocks 8x smaller.