### PR TITLE
resource unfolding

### DIFF
--- a/cn.opam
+++ b/cn.opam
@@ -23,7 +23,7 @@ depends: [
   "zarith" {>= "1.13"}
 ]
 pin-depends: [
-  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#73b0949"]
+  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#61700b3"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/error_common.ml
+++ b/lib/error_common.ml
@@ -17,3 +17,4 @@ type call_situation =
 type situation =
   | Access of access
   | Call of call_situation
+  | Unpacking

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -91,12 +91,11 @@ let packing_ft ~permit_recursive loc global provable ret =
        let at = LAT.of_lrt lrt (LAT.I (IT.struct_ (tag, value) loc)) in
        Some at
      | PName pn ->
-        let def = Sym.Map.find pn global.resource_predicates in
-        (match def.clauses with
-        | Some (_ :: _ :: _) when (not permit_recursive) ->
-           None
+       let def = Sym.Map.find pn global.resource_predicates in
+       (match def.clauses with
+        | Some (_ :: _ :: _) when not permit_recursive -> None
         | _ ->
-           (match Predicate.identify_right_clause provable def ret.pointer ret.iargs with
+          (match Predicate.identify_right_clause provable def ret.pointer ret.iargs with
            | None -> None
            | Some right_clause -> Some right_clause.packing_ft)))
   | Q _ -> None

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2035,6 +2035,7 @@ let pp_situation (s : Error_common.situation) =
   match s with
   | Error_common.Access a -> pp_constructor "ErrorCommon.Access" [ pp_access a ]
   | Error_common.Call c -> pp_constructor "ErrorCommon.Call" [ pp_call_situation c ]
+  | Error_common.Unpacking -> failwith "todo: pp_situation Unpacking"
 
 
 let pp_init = function

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -229,7 +229,9 @@ module General = struct
       match needed with
       | false -> return (Some ((requested, oarg), []))
       | true ->
-        (match Pack.packing_ft ~permit_recursive:true here global provable (P requested) with
+        (match
+           Pack.packing_ft ~permit_recursive:true here global provable (P requested)
+         with
          | Some packing_ft ->
            let ft_pp =
              lazy (LogicalArgumentTypes.pp (fun _ -> Pp.string "resource") packing_ft)

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -229,7 +229,7 @@ module General = struct
       match needed with
       | false -> return (Some ((requested, oarg), []))
       | true ->
-        (match Pack.packing_ft here global provable (P requested) with
+        (match Pack.packing_ft ~permit_recursive:true here global provable (P requested) with
          | Some packing_ft ->
            let ft_pp =
              lazy (LogicalArgumentTypes.pp (fun _ -> Pp.string "resource") packing_ft)

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -25,6 +25,7 @@ let call_situation = function
 let checking_situation = function
   | Access _ -> !^"checking access"
   | Call s -> call_situation s
+  | Unpacking -> !^"unpacking"
 
 
 let for_access = function
@@ -39,6 +40,7 @@ let for_access = function
 
 let for_situation = function
   | Access access -> for_access access
+  | Unpacking -> !^"for unpacking"
   | Call s ->
     (match s with
      | FunctionCall fsym -> !^"for calling function" ^^^ Sym.pp fsym

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -558,7 +558,9 @@ let do_unfold_resources loc =
       let keep, unpack, extract =
         List.fold_right
           (fun re (keep, unpack, extract) ->
-             match Pack.unpack ~permit_recursive:!unfold_rec_preds loc s.global provable_f re with
+             match
+               Pack.unpack ~permit_recursive:!unfold_rec_preds loc s.global provable_f re
+             with
              | Some unpackable -> (keep, (re, unpackable) :: unpack, extract)
              | None ->
                let re_reduced, extracted =

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -5,6 +5,8 @@ module LC = LogicalConstraints
 module Loc = Locations
 module IT = IndexTerms
 
+let unfold_rec_preds = ref true
+
 type solver = Solver.solver
 
 type s =
@@ -556,7 +558,7 @@ let do_unfold_resources loc =
       let keep, unpack, extract =
         List.fold_right
           (fun re (keep, unpack, extract) ->
-             match Pack.unpack loc s.global provable_f re with
+             match Pack.unpack ~permit_recursive:!unfold_rec_preds loc s.global provable_f re with
              | Some unpackable -> (keep, (re, unpackable) :: unpack, extract)
              | None ->
                let re_reduced, extracted =

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2569,6 +2569,8 @@ let logical_constraint = WLC.welltyped
 
 let oarg_bt_of_pred = WRS.oarg_bt_of_pred
 
+let request = WReq.welltyped
+
 let default_quantifier_bt = quantifier_bt
 
 let infer_term = WIT.infer
@@ -2641,6 +2643,8 @@ module Lift (M : ErrorReader) : WellTyped_intf.S with type 'a t := 'a M.t = stru
   let function_type = lift3 function_type
 
   let logical_constraint = lift2 logical_constraint
+
+  let request = lift2 request
 
   let oarg_bt_of_pred = lift2 oarg_bt_of_pred
 

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -28,6 +28,8 @@ module type S = sig
 
   val oarg_bt_of_pred : Locations.t -> Request.name -> BaseTypes.t t
 
+  val request : Locations.t -> Request.t -> Request.t t
+
   val logical_constraint : Locations.t -> LogicalConstraints.t -> LogicalConstraints.t t
 
   val function_type


### PR DESCRIPTION
- reinstate manual unfolding of resource predicates

- make typing monad's unfolding of recursive predicates conditional on ref, switched to true to (for the moment) maintain previous behaviour