### PR TITLE
use up-to-date cvc5 and z3 in github CI

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: System dependencies (Ubuntu)
       run: |
-        sudo apt-get install build-essential libgmp-dev z3 opam
+        sudo apt-get install build-essential libgmp-dev opam
 
     - name: Restore OPAM cache
       id: cache-opam-restore
@@ -49,7 +49,7 @@ jobs:
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam install --deps-only --yes ./cn.opam z3
+        opam install --deps-only --yes ./cn.opam
 
     - name: Save OPAM cache
       uses: actions/cache/save@v4
@@ -58,11 +58,26 @@ jobs:
         path: ~/.opam
         key: ${{ matrix.version }}
 
+    - name: Download z3 release
+      uses: robinraju/release-downloader@v1
+      with:
+        repository: z3prover/z3
+        tag: z3-4.15.2
+        fileName: z3-4.15.2-x64-glibc-2.39.zip
+
+
+    - name: Unzip and install z34
+      run: |
+        unzip z3-4.15.2-x64-glibc-2.39.zip
+        chmod +x z3-4.15.2-x64-glibc-2.39/bin/z3
+        sudo cp z3-4.15.2-x64-glibc-2.39/bin/z3 /usr/local/bin/
+
+
     - name: Download cvc5 release
       uses: robinraju/release-downloader@v1
       with:
         repository: cvc5/cvc5
-        tag: cvc5-1.2.0
+        tag: cvc5-1.3.0
         fileName: cvc5-Linux-x86_64-static.zip
 
     - name: Unzip and install cvc5

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup OPAM
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |
-        opam init --no-setup --yes --shell=sh --compiler=${{ matrix.version }}
+        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
         opam install --deps-only --yes ./cn.opam

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup OPAM
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |
-        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
+        opam init --yes --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
         opam install --deps-only --yes ./cn.opam z3

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: System dependencies (Ubuntu)
       run: |
-        sudo apt-get install build-essential libgmp-dev opam z3
+        sudo apt-get install build-essential libgmp-dev z3 opam
 
     - name: Restore OPAM cache
       id: cache-opam-restore

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: System dependencies (Ubuntu)
       run: |
-        sudo apt-get install build-essential libgmp-dev opam
+        sudo apt-get install build-essential libgmp-dev opam z3
 
     - name: Restore OPAM cache
       id: cache-opam-restore
@@ -46,10 +46,10 @@ jobs:
     - name: Setup OPAM
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |
-        opam init --yes --shell=sh --compiler=${{ matrix.version }}
+        opam init --no-setup --yes --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam install --deps-only --yes ./cn.opam z3
+        opam install --deps-only --yes ./cn.opam
 
     - name: Save OPAM cache
       uses: actions/cache/save@v4

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -49,7 +49,7 @@ jobs:
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam install --deps-only --yes ./cn.opam
+        opam install --deps-only --yes ./cn.opam z3
 
     - name: Save OPAM cache
       uses: actions/cache/save@v4

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -49,7 +49,7 @@ jobs:
         opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
         eval $(opam env --switch=${{ matrix.version }})
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
-        opam install --deps-only --yes ./cn.opam
+        opam install --deps-only --yes ./cn.opam z3
 
     - name: Save OPAM cache
       uses: actions/cache/save@v4
@@ -58,19 +58,19 @@ jobs:
         path: ~/.opam
         key: ${{ matrix.version }}
 
-    - name: Download z3 release
-      uses: robinraju/release-downloader@v1
-      with:
-        repository: z3prover/z3
-        tag: z3-4.15.2
-        fileName: z3-4.15.2-x64-glibc-2.39.zip
+    # - name: Download z3 release
+    #   uses: robinraju/release-downloader@v1
+    #   with:
+    #     repository: z3prover/z3
+    #     tag: z3-4.15.2
+    #     fileName: z3-4.15.2-x64-glibc-2.39.zip
 
 
-    - name: Unzip and install z34
-      run: |
-        unzip z3-4.15.2-x64-glibc-2.39.zip
-        chmod +x z3-4.15.2-x64-glibc-2.39/bin/z3
-        sudo cp z3-4.15.2-x64-glibc-2.39/bin/z3 /usr/local/bin/
+    # - name: Unzip and install z3
+    #   run: |
+    #     unzip z3-4.15.2-x64-glibc-2.39.zip
+    #     chmod +x z3-4.15.2-x64-glibc-2.39/bin/z3
+    #     sudo cp z3-4.15.2-x64-glibc-2.39/bin/z3 /usr/local/bin/
 
 
     - name: Download cvc5 release

--- a/lib/simple_smt.ml
+++ b/lib/simple_smt.ml
@@ -901,7 +901,7 @@ let cvc5 : solver_config =
   { exe = "cvc5";
     (* opts = [ "--incremental"; "--sets-ext"; "--force-logic=QF_AUFBVDTLIA" ]; *)
     (* NOTE cvc5 1.2.1 renamed --sets-ext to --sets-exp *)
-    opts = [ "--incremental"; "--sets-ext"; "--force-logic=QF_ALL" ];
+    opts = [ "--incremental"; "--sets-exp"; "--force-logic=QF_ALL" ];
     setup = [];
     exts = CVC5;
     log = quiet_log


### PR DESCRIPTION
This was meant to update both cvc5 and z3, but now it's only cvc5: I didn't get the z3 package from github to work.