### PR TITLE
Add `-Werror=shadow` to LibCN CI

### DIFF
--- a/runtime/libcn/include/cn-testing/result.h
+++ b/runtime/libcn/include/cn-testing/result.h
@@ -7,8 +7,6 @@
 extern "C" {
 #endif
 
-typedef uint64_t seed;
-
 enum cn_test_result {
   CN_TEST_PASS,
   CN_TEST_FAIL,

--- a/runtime/libcn/lib/compile.sh
+++ b/runtime/libcn/lib/compile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FLAGS="-O2 "
+FLAGS="-O2 -Werror=shadow "
 if [[ -n "${GITHUB_ACTIONS+isset}" ]]; then
     FLAGS+="-Werror -Wall"
 fi

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -323,14 +323,10 @@ int cn_test_main(int argc, char* argv[]) {
             cn_printf(CN_LOGGING_ERROR, "\n");
 
             cn_test_reproduce(&repros[i]);
-            struct cn_test_input test_input = {.replay = true,
-                .progress_level = CN_TEST_GEN_PROGRESS_NONE,
-                .sizing_strategy = sizing_strategy,
-                .trap = trap,
-                .replicas = replicas,
-                .output_tyche = output_tyche,
-                .tyche_output_stream = tyche_output_stream,
-                .begin_time = begin_time};
+            test_input.replay = true;
+            test_input.progress_level = CN_TEST_GEN_PROGRESS_NONE;
+            test_input.trap = trap;
+            test_input.replicas = replicas;
             enum cn_test_result replay_result = test_case->func(test_input);
 
             if (replay_result != CN_TEST_FAIL) {


### PR DESCRIPTION
Add `-Werror=shadow` when building the libraries.

This would've caught some bugs that I spent a while trying to find...