### PR TITLE
Rename variables to be unique before SMT pruning

### DIFF
--- a/lib/testGeneration/bennet/stage2/stage2.ml
+++ b/lib/testGeneration/bennet/stage2/stage2.ml
@@ -21,9 +21,9 @@ let transform (prog5 : unit Mucore.file) (paused : _ Typing.pause) (ctx : Stage1
   |> Reorder.transform
   |> SpecializeEquality.transform
   |> SimplifyGen.transform prog5
+  |> SimplifyNames.transform
   |> (if TestGenConfig.has_smt_pruning () then
         SmtPruning.transform paused
       else
         fun ctx -> ctx)
   |> SimplifyGen.transform prog5
-  |> SimplifyNames.transform


### PR DESCRIPTION
Need to make the string identifiers unique before using the SMT solver, similar to our need to do it before translating to C.