### PR TITLE
Clean up Bennet alloc and ownership bookkeeping

### DIFF
--- a/runtime/libcn/include/bennet-exp/alloc.h
+++ b/runtime/libcn/include/bennet-exp/alloc.h
@@ -15,22 +15,16 @@ uint8_t get_null_in_every(void);
 void set_null_in_every(uint8_t n);
 
 void bennet_alloc_reset(void);
-void* bennet_alloc_save(void);
-void bennet_alloc_restore(void* ptr);
-
-void bennet_ownership_reset(void);
-
-void* bennet_ownership_save(void);
-
-void bennet_ownership_restore(void* ptr);
-
+size_t bennet_alloc_save(void);
+void bennet_alloc_restore(size_t size);
+int bennet_alloc_check(void* p, size_t sz);
 cn_pointer* bennet_alloc(bennet_domain(uintptr_t) * cs);
 
-int bennet_alloc_check(void* p, size_t sz);
-
-void bennet_ownership_update(void* p, size_t sz);
-
+void bennet_ownership_reset(void);
+size_t bennet_ownership_save(void);
+void bennet_ownership_restore(size_t size);
 int bennet_ownership_check(void* p, size_t sz);
+void bennet_ownership_update(void* p, size_t sz);
 
 #ifdef __cplusplus
 }

--- a/runtime/libcn/include/bennet-exp/checkpoint.h
+++ b/runtime/libcn/include/bennet-exp/checkpoint.h
@@ -7,8 +7,8 @@
 
 typedef struct {
   cn_bump_frame_id frame_id;
-  void* alloc;
-  void* ownership;
+  size_t alloc;
+  size_t ownership;
 } bennet_checkpoint;
 
 static inline bennet_checkpoint bennet_checkpoint_save(void) {

--- a/runtime/libcn/include/bennet-exp/dsl.h
+++ b/runtime/libcn/include/bennet-exp/dsl.h
@@ -235,17 +235,13 @@
   }                                                                                      \
   tmp##_num_choices /= 2;                                                                \
   struct bennet_int_urn* tmp##_urn = urn_from_array(tmp##_choices, tmp##_num_choices);   \
-  cn_bump_frame_id tmp##_checkpoint = cn_bump_get_frame_id();                            \
-  void* tmp##_alloc_checkpoint = bennet_alloc_save();                                    \
-  void* tmp##_ownership_checkpoint = bennet_ownership_save();                            \
+  bennet_checkpoint tmp##_checkpoint = bennet_checkpoint_save();                         \
   bennet_label_##tmp##_gen :;                                                            \
   cn_bits_u64* tmp = convert_to_cn_bits_u64(urn_remove(tmp##_urn));                      \
   if (0) {                                                                               \
     bennet_label_##tmp##_backtrack :;                                                    \
     BENNET_CHECK_TIMEOUT();                                                              \
-    cn_bump_free_after(tmp##_checkpoint);                                                \
-    bennet_alloc_restore(tmp##_alloc_checkpoint);                                        \
-    bennet_ownership_restore(tmp##_ownership_checkpoint);                                \
+    bennet_checkpoint_restore(&tmp##_checkpoint);                                        \
     bennet_failure_mark_old();                                                           \
     if ((bennet_failure_get_failure_type() == BENNET_FAILURE_ASSERT ||                   \
             bennet_failure_get_failure_type() == BENNET_FAILURE_DEPTH) &&                \
@@ -275,9 +271,7 @@
 #define BENNET_SPLIT_BEGIN(tmp, ...)                                                     \
   void* tmp = malloc(1);                                                                 \
   int tmp##_backtracks = bennet_get_size_split_backtracks_allowed();                     \
-  cn_bump_frame_id tmp##_checkpoint = cn_bump_get_frame_id();                            \
-  void* tmp##_alloc_checkpoint = bennet_alloc_save();                                    \
-  void* tmp##_ownership_checkpoint = bennet_ownership_save();                            \
+  bennet_checkpoint tmp##_checkpoint = bennet_checkpoint_save();                         \
   bennet_label_##tmp##_gen : {                                                           \
     size_t* vars[] = {__VA_ARGS__};                                                      \
     int count = 0;                                                                       \
@@ -301,9 +295,7 @@
     bennet_label_##tmp##_backtrack :;                                                    \
     BENNET_CHECK_TIMEOUT();                                                              \
     if (bennet_failure_is_blamed(tmp)) {                                                 \
-      cn_bump_free_after(tmp##_checkpoint);                                              \
-      bennet_alloc_restore(tmp##_alloc_checkpoint);                                      \
-      bennet_ownership_restore(tmp##_ownership_checkpoint);                              \
+      bennet_checkpoint_restore(&tmp##_checkpoint);                                      \
       bennet_failure_remove_blame(tmp);                                                  \
       free(tmp);                                                                         \
                                                                                          \

--- a/runtime/libcn/include/bennet-exp/prelude.h
+++ b/runtime/libcn/include/bennet-exp/prelude.h
@@ -16,6 +16,7 @@
 #include <bennet-exp/size.h>
 #include <bennet-exp/uniform.h>
 #include <bennet-exp/urn.h>
+#include <bennet-exp/vector.h>
 
 void bennet_reset(void);
 

--- a/runtime/libcn/src/bennet-exp/alloc.c
+++ b/runtime/libcn/src/bennet-exp/alloc.c
@@ -4,72 +4,62 @@
 #include <bennet-exp/prelude.h>
 #include <cn-executable/utils.h>
 
-#define MEM_SIZE (1024 * 1024 * 256)
-static char alloc_buf[MEM_SIZE];
-static void* alloc_curr = alloc_buf;
-
-void bennet_alloc_reset(void) {
-  alloc_curr = alloc_buf;
-}
-
-void* bennet_alloc_save(void) {
-  return alloc_curr;
-}
-
-void bennet_alloc_restore(void* ptr) {
-  if (alloc_buf <= (char*)ptr && (char*)ptr < alloc_buf + MEM_SIZE) {
-    alloc_curr = ptr;
-    return;
-  }
-
-  fprintf(stderr, "Error: Tried to set allocation data pointer out of range (%p)\n", ptr);
-  exit(1);
-}
-
-static char ownership_buf[MEM_SIZE];
-static void* ownership_curr = ownership_buf;
-
-void bennet_ownership_reset(void) {
-  ownership_curr = ownership_buf;
-}
-
-void* bennet_ownership_save(void) {
-  return ownership_curr;
-}
-
-void bennet_ownership_restore(void* ptr) {
-  if (ownership_buf <= (char*)ptr && (char*)ptr < ownership_buf + MEM_SIZE) {
-    ownership_curr = ptr;
-    return;
-  }
-
-  fprintf(stderr, "Error: Tried to set ownership data pointer out of range (%p)\n", ptr);
-  exit(1);
-}
-
-struct pointer_data {
+// Define the pointer_data structure
+typedef struct {
   void* ptr;
   size_t sz;
-};
+} pointer_data;
 
-static void update_alloc(void* ptr, size_t sz) {
-  if ((uintptr_t)alloc_curr - (uintptr_t)alloc_buf + sizeof(struct pointer_data) >
-      MEM_SIZE) {
-    printf("Out of space for allocation metadata!\n");
-    exit(1);
-  }
-  *(struct pointer_data*)alloc_curr = (struct pointer_data){.ptr = ptr, .sz = sz};
-  alloc_curr = (char*)alloc_curr + sizeof(struct pointer_data);
+// Declare vector types for pointer_data
+BENNET_VECTOR_DECL(pointer_data)
+BENNET_VECTOR_IMPL(pointer_data)
+
+// Global vectors for tracking allocations and ownership
+static bennet_vector(pointer_data) alloc_vector;
+static bennet_vector(pointer_data) ownership_vector;
+
+void bennet_alloc_reset(void) {
+  bennet_vector_free(pointer_data)(&alloc_vector);
+  bennet_vector_init(pointer_data)(&alloc_vector);
 }
 
-static void update_ownership(void* ptr, size_t sz) {
-  if ((uintptr_t)ownership_curr - (uintptr_t)ownership_buf + sizeof(struct pointer_data) >
-      MEM_SIZE) {
-    printf("Out of space for ownership metadata!\n");
-    exit(1);
+size_t bennet_alloc_save(void) {
+  return bennet_vector_size(pointer_data)(&alloc_vector);
+}
+
+void bennet_alloc_restore(size_t size) {
+  if (size <= bennet_vector_size(pointer_data)(&alloc_vector)) {
+    // Truncate the vector to the saved size
+    while (bennet_vector_size(pointer_data)(&alloc_vector) > size) {
+      bennet_vector_pop(pointer_data)(&alloc_vector);
+    }
+    return;
   }
-  *(struct pointer_data*)ownership_curr = (struct pointer_data){.ptr = ptr, .sz = sz};
-  ownership_curr = (char*)ownership_curr + sizeof(struct pointer_data);
+
+  fprintf(stderr, "Error: Tried to grow allocation data\n");
+  exit(1);
+}
+
+void bennet_ownership_reset(void) {
+  bennet_vector_free(pointer_data)(&ownership_vector);
+  bennet_vector_init(pointer_data)(&ownership_vector);
+}
+
+size_t bennet_ownership_save(void) {
+  return bennet_vector_size(pointer_data)(&ownership_vector);
+}
+
+void bennet_ownership_restore(size_t size) {
+  if (size <= bennet_vector_size(pointer_data)(&ownership_vector)) {
+    // Truncate the vector to the saved size
+    while (bennet_vector_size(pointer_data)(&ownership_vector) > size) {
+      bennet_vector_pop(pointer_data)(&ownership_vector);
+    }
+    return;
+  }
+
+  fprintf(stderr, "Error: Tried to grow ownership data\n");
+  exit(1);
 }
 
 cn_pointer* bennet_alloc(bennet_domain(uintptr_t) * cs) {
@@ -82,20 +72,23 @@ cn_pointer* bennet_alloc(bennet_domain(uintptr_t) * cs) {
   // Much faster than `bennet_rand_alloc_bounded`
 
   void* p = bennet_rand_alloc_bounded(cs);
-  update_alloc(p, bytes);
+
+  pointer_data data = {.ptr = p, .sz = bytes};
+  bennet_vector_push(pointer_data)(&alloc_vector, data);
+
   return convert_to_cn_pointer(p + cs->lower_offset_bound);
 }
 
 int bennet_alloc_check(void* p, size_t sz) {
-  if (alloc_curr == alloc_buf) {
+  if (bennet_vector_size(pointer_data)(&alloc_vector) == 0) {
     return 0;
   }
 
   int bytes = sz;
 
-  struct pointer_data* q =
-      (struct pointer_data*)((uintptr_t)alloc_curr - sizeof(struct pointer_data));
-  for (; (uintptr_t)q >= (uintptr_t)alloc_buf; q--) {
+  // Iterate through all allocation records
+  for (size_t i = 0; i < bennet_vector_size(pointer_data)(&alloc_vector); i++) {
+    pointer_data* q = bennet_vector_get(pointer_data)(&alloc_vector, i);
     uintptr_t lb = (uintptr_t)q->ptr;
     uintptr_t ub = (uintptr_t)q->ptr + q->sz;
     if (lb < (uintptr_t)p) {
@@ -116,18 +109,19 @@ int bennet_alloc_check(void* p, size_t sz) {
   return (bytes == 0);
 }
 
-void bennet_ownership_update(void* p, size_t sz) {
-  update_ownership(p, sz);
+void bennet_ownership_update(void* ptr, size_t sz) {
+  pointer_data data = {.ptr = ptr, .sz = sz};
+  bennet_vector_push(pointer_data)(&ownership_vector, data);
 }
 
 int bennet_ownership_check(void* p, size_t sz) {
-  if (ownership_curr == ownership_buf) {
+  if (bennet_vector_size(pointer_data)(&ownership_vector) == 0) {
     return 1;
   }
 
-  struct pointer_data* q =
-      (struct pointer_data*)((uintptr_t)ownership_curr - sizeof(struct pointer_data));
-  for (; (uintptr_t)q >= (uintptr_t)ownership_buf; q--) {
+  // Iterate through all ownership records
+  for (size_t i = 0; i < bennet_vector_size(pointer_data)(&ownership_vector); i++) {
+    pointer_data* q = bennet_vector_get(pointer_data)(&ownership_vector, i);
     uintptr_t lb = (uintptr_t)q->ptr;
     uintptr_t ub = (uintptr_t)q->ptr + q->sz;
     if (lb < (uintptr_t)p) {


### PR DESCRIPTION
In anticipation of adding more...

Closes https://github.com/rems-project/cerberus/issues/890, though not the way that was expected (used a vector instead of a hashtable)