### PR TITLE
[CN-exec] Make loop leak check more explicit when enabled

### DIFF
--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3810,14 +3810,9 @@ let cn_to_ail_loop_inv
     let cn_stack_depth_incr_call =
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_stack_depth_incr_sym), [])))
     in
-    let cn_ownership_put_sym =
-      if with_loop_leak_checks then
-        OE.cn_loop_leak_check_and_put_back_ownership_sym
-      else
-        OE.cn_loop_put_back_ownership_sym
-    in
     let cn_loop_put_call =
-      A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident cn_ownership_put_sym), [])))
+      A.AilSexpr
+        (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_put_back_ownership_sym), [])))
     in
     let cn_stack_depth_decr_call =
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_stack_depth_decr_sym), [])))
@@ -3830,8 +3825,12 @@ let cn_to_ail_loop_inv
     let bump_alloc_binding, bump_alloc_start_stat_, bump_alloc_end_stat_ =
       gen_bump_alloc_bs_and_ss ()
     in
+    let cn_ownership_leak_check_call =
+      A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_leak_check_sym), [])))
+    in
     let stats =
       (bump_alloc_start_stat_ :: cn_stack_depth_incr_call :: cond_ss)
+      @ (if with_loop_leak_checks then [ cn_ownership_leak_check_call ] else [])
       @ [ cn_loop_put_call;
           cn_stack_depth_decr_call;
           bump_alloc_end_stat_;

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -32,9 +32,7 @@ let cn_postcondition_leak_check_sym = Sym.fresh "cn_postcondition_leak_check"
 
 let cn_loop_put_back_ownership_sym = Sym.fresh "cn_loop_put_back_ownership"
 
-let cn_loop_leak_check_and_put_back_ownership_sym =
-  Sym.fresh "cn_loop_leak_check_and_put_back_ownership"
-
+let cn_loop_leak_check_sym = Sym.fresh "cn_loop_leak_check"
 
 let c_add_ownership_fn_sym = Sym.fresh "c_add_to_ghost_state"
 

--- a/lib/fulminate/ownership.mli
+++ b/lib/fulminate/ownership.mli
@@ -25,7 +25,7 @@ val cn_postcondition_leak_check_sym : Sym.t
 
 val cn_loop_put_back_ownership_sym : Sym.t
 
-val cn_loop_leak_check_and_put_back_ownership_sym : Sym.t
+val cn_loop_leak_check_sym : Sym.t
 
 val get_ownership_global_init_stats
   :  unit ->

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -156,7 +156,7 @@ void ghost_stack_depth_incr(void);
 void ghost_stack_depth_decr(void);
 void cn_postcondition_leak_check(void);
 void cn_loop_put_back_ownership(void);
-void cn_loop_leak_check_and_put_back_ownership(void);
+void cn_loop_leak_check(void);
 
 /* malloc, free */
 void *cn_aligned_alloc(size_t align, size_t size);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -278,11 +278,6 @@ void cn_loop_put_back_ownership(void) {
   }
 }
 
-void cn_loop_leak_check_and_put_back_ownership(void) {
-  cn_loop_leak_check();
-  cn_loop_put_back_ownership();
-}
-
 int ownership_ghost_state_get(int64_t* address_key) {
   int* curr_depth_maybe = (int*)ht_get(cn_ownership_global_ghost_state, address_key);
   return curr_depth_maybe ? *curr_depth_maybe : -1;


### PR DESCRIPTION
Print a separate call to `cn_loop_leak_check` when `--with-loop-leak-checks` enabled to make the difference in output when flag disabled more clear.