### PR TITLE
make variable declarations in the SMT solver when they happen in CN

### DIFF
--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -26,6 +26,8 @@ val make : Global.t -> solver
 (* Incrementally (and imperatively) add an assumption to the solver state *)
 val add_assumption : solver -> Global.t -> LogicalConstraints.t -> unit
 
+val declare_variable : solver -> Sym.t -> BaseTypes.t -> unit
+
 (* Save / restore solver state, to support backtracking *)
 val push : solver -> unit
 


### PR DESCRIPTION
... not lazily. This disables resource simplification in Explain, which breaks this, and temporarily disables checkPredicates, before we bring this up-to-date wrt this change.

Also, do not use `pure` in the typing rule for load.