### PR TITLE
bind logical return types directly, rather than via a return record

### DIFF
--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -166,19 +166,15 @@ end
 
 val lift : 'a Or_TypeError.t -> 'a m
 
-val make_return_record
-  :  Locations.t ->
-  string ->
-  BaseTypes.member_types ->
-  (IndexTerms.t * IndexTerms.t list) m
+(* val make_return_record *)
+(*   :  Locations.t -> *)
+(*   string -> *)
+(*   BaseTypes.member_types -> *)
+(*   (IndexTerms.t * IndexTerms.t list) m *)
 
-val bind_logical_return
-  :  Locations.t ->
-  IndexTerms.t list ->
-  LogicalReturnTypes.t ->
-  unit m
+val bind_logical_return : Locations.t -> string -> LogicalReturnTypes.t -> unit m
 
-val bind_return : Locations.t -> IndexTerms.t list -> ReturnTypes.t -> IndexTerms.t m
+(* val bind_return : Locations.t -> IndexTerms.t list -> ReturnTypes.t -> IndexTerms.t m *)
 
 val add_movable_index
   :  Locations.t ->

--- a/tests/cn/int_to_ptr.error.c.verify
+++ b/tests/cn/int_to_ptr.error.c.verify
@@ -4,5 +4,5 @@ return code: 1
 tests/cn/int_to_ptr.error.c:16:12: error: Missing resource for reading
     return *p == 0;
            ^~ 
-Resource needed: RW<signed int>(call_cast0.return)
+Resource needed: RW<signed int>(call_cast0_return)
 State file: file:///tmp/state__int_to_ptr.error.c__main.html


### PR DESCRIPTION
Disabling return records for now (this fixes a problem that those return records were not type correct, because not sorted by member names, and simplifies the code. We may decide to bring back return records later, though maybe with simpler code.