### PR TITLE
disable debug_constraint_failure_diagnostics because it (AIUI) also

### DIFF
--- a/lib/indexTerms.ml
+++ b/lib/indexTerms.ml
@@ -34,18 +34,18 @@ let pp_with_typf f it = Pp.typ (pp it) (f (get_bt it))
 
 let pp_with_typ = pp_with_typf BT.pp
 
-let pp_with_eval eval_f =
-  let open Cerb_pp_prelude in
-  let pp_v tm std_pp =
-    match eval_f tm with
-    | None -> !^"/* NO_EVAL */" ^^ std_pp
-    | Some (IT (_, BT.Struct _, _))
-    | Some (IT (_, BT.Record _, _))
-    | Some (IT (_, BT.Map (_, _), _)) ->
-      std_pp
-    | Some v -> !^"/*" ^^^ pp v ^^^ !^"*/" ^^ std_pp
-  in
-  pp ~f:pp_v
+(* let pp_with_eval eval_f = *)
+(*   let open Cerb_pp_prelude in *)
+(*   let pp_v tm std_pp = *)
+(*     match eval_f tm with *)
+(*     | None -> !^"/* NO_EVAL */" ^^ std_pp *)
+(*     | Some (IT (_, BT.Struct _, _)) *)
+(*     | Some (IT (_, BT.Record _, _)) *)
+(*     | Some (IT (_, BT.Map (_, _), _)) -> *)
+(*       std_pp *)
+(*     | Some v -> !^"/*" ^^^ pp v ^^^ !^"*/" ^^ std_pp *)
+(*   in *)
+(*   pp ~f:pp_v *)
 
 
 let rec bound_by_pattern (Pat (pat_, bt, _)) =

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -4,36 +4,37 @@ module Req = Request
 open Typing
 
 let debug_constraint_failure_diagnostics
-      lvl
-      (model_with_q : Solver.model_with_q)
-      simp_ctxt
-      c
+      _lvl
+      (_model_with_q : Solver.model_with_q)
+      _simp_ctxt
+      _c
   =
-  let model = fst model_with_q in
-  if !Pp.print_level == 0 then
-    ()
-  else (
-    let pp_f = IT.pp_with_eval (Solver.eval model) in
-    let diag msg c =
-      match (c, model_with_q) with
-      | LC.T tm, _ ->
-        Pp.debug lvl (lazy (Pp.item msg (IT.pp tm)));
-        Pp.debug lvl (lazy (pp_f tm))
-      | LC.Forall ((sym, _bt), tm), (_, [ (sym', _bt') ]) ->
-        let tm' = IT.subst (IT.make_rename ~from:sym ~to_:sym') tm in
-        Pp.debug lvl (lazy (Pp.item ("quantified " ^ msg) (IT.pp tm)));
-        Pp.debug lvl (lazy (pp_f tm'))
-      | _ ->
-        Pp.warn
-          (Locations.other __LOC__)
-          (Pp.bold "unexpected quantifier count with model")
-    in
-    diag "counterexample, expanding" c;
-    let c2 = Simplify.LogicalConstraints.simp simp_ctxt c in
-    if LC.equal c c2 then
-      ()
-    else
-      diag "simplified variant" c2)
+  ()
+  (* let model = fst model_with_q in *)
+  (* if !Pp.print_level == 0 then *)
+  (*   () *)
+  (* else ( *)
+  (*   let pp_f = IT.pp_with_eval (Solver.eval model) in *)
+  (*   let diag msg c = *)
+  (*     match (c, model_with_q) with *)
+  (*     | LC.T tm, _ -> *)
+  (*       Pp.debug lvl (lazy (Pp.item msg (IT.pp tm))); *)
+  (*       Pp.debug lvl (lazy (pp_f tm)) *)
+  (*     | LC.Forall ((sym, _bt), tm), (_, [ (sym', _bt') ]) -> *)
+  (*       let tm' = IT.subst (IT.make_rename ~from:sym ~to_:sym') tm in *)
+  (*       Pp.debug lvl (lazy (Pp.item ("quantified " ^ msg) (IT.pp tm))); *)
+  (*       Pp.debug lvl (lazy (pp_f tm')) *)
+  (*     | _ -> *)
+  (*       Pp.warn *)
+  (*         (Locations.other __LOC__) *)
+  (*         (Pp.bold "unexpected quantifier count with model") *)
+  (*   in *)
+  (*   diag "counterexample, expanding" c; *)
+  (*   let c2 = Simplify.LogicalConstraints.simp simp_ctxt c in *)
+  (*   if LC.equal c c2 then *)
+  (*     () *)
+  (*   else *)
+  (*     diag "simplified variant" c2) *)
 
 
 module General = struct


### PR DESCRIPTION
breaks variable scoping in its solver interaction, leading to solver crashes.