### PR TITLE
Stats for unsatisfied constraints in gen discards

### DIFF
--- a/bin/test.ml
+++ b/bin/test.ml
@@ -61,6 +61,7 @@ let run_tests
       smt_pruning
       print_size_info
       print_backtrack_info
+      print_satisfaction_info
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
@@ -130,7 +131,8 @@ let run_tests
           no_replicas;
           output_tyche;
           print_size_info;
-          print_backtrack_info
+          print_backtrack_info;
+          print_satisfaction_info
         }
       in
       TestGeneration.set_config config;
@@ -477,6 +479,11 @@ module Flags = struct
   let print_backtrack_info =
     let doc = "(Experimental) Print backtracking info" in
     Arg.(value & flag & info [ "print-backtrack-info" ] ~doc)
+
+
+  let print_satisfaction_info =
+    let doc = "(Experimental) Print satisfaction info" in
+    Arg.(value & flag & info [ "print-satisfaction-info" ] ~doc)
 end
 
 let cmd =
@@ -537,6 +544,7 @@ let cmd =
     $ Flags.smt_pruning
     $ Flags.print_size_info
     $ Flags.print_backtrack_info
+    $ Flags.print_satisfaction_info
   in
   let doc =
     "Generates tests for all functions in [FILE] with CN specifications.\n\

--- a/lib/testGeneration/buildScripts/bash.ml
+++ b/lib/testGeneration/buildScripts/bash.ml
@@ -194,8 +194,15 @@ let run () =
           | Some file -> [ "--output-tyche"; file ]
           | None -> [])
        @ (if Config.will_print_size_info () then [ "--print-size-info" ] else [])
-       @ if Config.will_print_backtrack_info () then [ "--print-backtrack-info" ] else []
-      )
+       @ (if Config.will_print_backtrack_info () then
+            [ "--print-backtrack-info" ]
+          else
+            [])
+       @
+       if Config.will_print_satisfaction_info () then
+         [ "--print-satisfaction-info" ]
+       else
+         [])
   in
   !^"# Run"
   ^^ hardline

--- a/lib/testGeneration/buildScripts/make.ml
+++ b/lib/testGeneration/buildScripts/make.ml
@@ -98,7 +98,15 @@ let define_test_flags () =
        | Some file -> [ "--output-tyche"; file ]
        | None -> [])
     @ (if Config.will_print_size_info () then [ "--print-size-info" ] else [])
-    @ if Config.will_print_backtrack_info () then [ "--print-backtrack-info" ] else []
+    @ (if Config.will_print_backtrack_info () then
+         [ "--print-backtrack-info" ]
+       else
+         [])
+    @
+    if Config.will_print_satisfaction_info () then
+      [ "--print-satisfaction-info" ]
+    else
+      []
   in
   !^"TEST_FLAGS := " ^^ separate_map space string flags ^^ hardline
 

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -58,7 +58,8 @@ type t =
     no_replicas : bool;
     output_tyche : string option;
     print_size_info : bool;
-    print_backtrack_info : bool
+    print_backtrack_info : bool;
+    print_satisfaction_info : bool
   }
 
 let default =
@@ -95,7 +96,8 @@ let default =
     no_replicas = false;
     output_tyche = Option.None;
     print_size_info = false;
-    print_backtrack_info = false
+    print_backtrack_info = false;
+    print_satisfaction_info = false
   }
 
 
@@ -237,3 +239,5 @@ let get_output_tyche () = (Option.get !instance).output_tyche
 let will_print_size_info () = (Option.get !instance).print_size_info
 
 let will_print_backtrack_info () = (Option.get !instance).print_backtrack_info
+
+let will_print_satisfaction_info () = (Option.get !instance).print_satisfaction_info

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -58,7 +58,8 @@ type t =
     no_replicas : bool;
     output_tyche : string option;
     print_size_info : bool;
-    print_backtrack_info : bool
+    print_backtrack_info : bool;
+    print_satisfaction_info : bool
   }
 
 val default : t
@@ -152,3 +153,5 @@ val get_output_tyche : unit -> string option
 val will_print_size_info : unit -> bool
 
 val will_print_backtrack_info : unit -> bool
+
+val will_print_satisfaction_info : unit -> bool

--- a/runtime/libcn/include/bennet-exp/dsl.h
+++ b/runtime/libcn/include/bennet-exp/dsl.h
@@ -71,8 +71,11 @@
     const void* vars[] = {__VA_ARGS__};                                                  \
     if (bennet_assign(id, ptr, addr, &value_redir, sizeof(addr_ty), vars)) {             \
       bennet_info_backtracks_log(__FUNCTION__, __FILE__, __LINE__);                      \
+      bennet_info_unsatisfied_log(__FILE__, __LINE__, true);                             \
       goto bennet_label_##last_var##_backtrack;                                          \
     }                                                                                    \
+                                                                                         \
+    bennet_info_unsatisfied_log(__FILE__, __LINE__, false);                              \
   }
 
 #define BENNET_LET_ARBITRARY(backtracks, cn_ty, c_ty, var, last_var)                     \

--- a/runtime/libcn/include/bennet-exp/dsl/assert.h
+++ b/runtime/libcn/include/bennet-exp/dsl/assert.h
@@ -11,11 +11,15 @@
 #define BENNET_ASSERT(cond, last_var, ...)                                               \
   if (!convert_from_cn_bool(cond)) {                                                     \
     bennet_info_backtracks_log(__FUNCTION__, __FILE__, __LINE__);                        \
+    bennet_info_unsatisfied_log(__FILE__, __LINE__, true);                               \
+                                                                                         \
     bennet_failure_set_failure_type(BENNET_FAILURE_ASSERT);                              \
     const void* vars[] = {__VA_ARGS__};                                                  \
     bennet_failure_blame_many(vars);                                                     \
     goto bennet_label_##last_var##_backtrack;                                            \
-  }
+  }                                                                                      \
+                                                                                         \
+  bennet_info_unsatisfied_log(__FILE__, __LINE__, false);
 
 ////////////
 // Domain //
@@ -125,8 +129,11 @@ BENNET_ASSERT_DOMAIN_IMPL(cn_bits_i64, int64_t, INT64_MIN, INT64_MAX)
     const void* vars[] = {__VA_ARGS__};                                                  \
     if (bennet_assert_domain(cn_ty)(sym, lbi, lbe, ubi, ube, m, vars)) {                 \
       bennet_info_backtracks_log(__FUNCTION__, __FILE__, __LINE__);                      \
+      bennet_info_unsatisfied_log(__FILE__, __LINE__, true);                             \
       goto bennet_label_##last_var##_backtrack;                                          \
     }                                                                                    \
+                                                                                         \
+    bennet_info_unsatisfied_log(__FILE__, __LINE__, false);                              \
   }
 
 #define bennet_assert_domain_cast(cn_ty, cast_cn_ty)                                     \
@@ -254,8 +261,11 @@ BENNET_ASSERT_CAST_IMPL(
     if (bennet_assert_domain_cast(cn_ty, cast_cn_ty)(                                    \
             sym, lbi, lbe, ubi, ube, m, vars)) {                                         \
       bennet_info_backtracks_log(__FUNCTION__, __FILE__, __LINE__);                      \
+      bennet_info_unsatisfied_log(__FILE__, __LINE__, true);                             \
       goto bennet_label_##last_var##_backtrack;                                          \
     }                                                                                    \
+                                                                                         \
+    bennet_info_unsatisfied_log(__FILE__, __LINE__, false);                              \
   }
 
 #endif  // BENNET_EXP_ASSERT_H

--- a/runtime/libcn/include/bennet-exp/info/unsatisfied.h
+++ b/runtime/libcn/include/bennet-exp/info/unsatisfied.h
@@ -1,0 +1,48 @@
+#ifndef BENNET_EXP_UNSATISFIED_H
+#define BENNET_EXP_UNSATISFIED_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialize satisfaction info */
+void bennet_info_unsatisfied_init(void);
+
+/**
+ * Sets the current function under test
+ * @param function_name The name of the function currently being tested
+ */
+void bennet_info_unsatisfied_set_function_under_test(const char* function_name);
+
+/**
+ * Logs whether the constraint was unsatisfied for a specific location
+ * @param filename The source file where the unsatisfied constraint was
+ * @param line_number The line number where the unsatisfied constraint was
+ * @param unsatisfied True if the constraint was unsatisfied in this evaluation, false otherwise
+ */
+void bennet_info_unsatisfied_log(const char* filename, int line_number, bool unsatisfied);
+
+/**
+ * Prints satisfaction statistics for all functions under test
+ */
+void bennet_info_unsatisfied_print_info(void);
+
+/**
+ * @brief Begin a new run by initializing temporary hash tables for tracking satisfaction statistics.
+ * This function should be called at the start of each run to prepare the temporary storage.
+ */
+void bennet_info_unsatisfied_begin_run(void);
+
+/**
+ * @brief End a run by merging temporary satisfaction statistics into permanent storage.
+ * @param record If false, the temporary statistics are discarded. If true, they are merged into permanent storage.
+ */
+void bennet_info_unsatisfied_end_run(bool record);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // BENNET_EXP_UNSATISFIED_H

--- a/runtime/libcn/include/bennet-exp/prelude.h
+++ b/runtime/libcn/include/bennet-exp/prelude.h
@@ -6,6 +6,7 @@
 #include <bennet-exp/info/backtracks.h>
 #include <bennet-exp/info/sizes.h>
 #include <bennet-exp/info/tyche.h>
+#include <bennet-exp/info/unsatisfied.h>
 #include <bennet-exp/internals/domain.h>
 #include <bennet-exp/internals/rand.h>
 #include <bennet-exp/internals/size.h>

--- a/runtime/libcn/include/bennet/compat.h
+++ b/runtime/libcn/include/bennet/compat.h
@@ -9,4 +9,10 @@ void bennet_info_sizes_set_function_under_test(const char*);
 void bennet_info_sizes_print_info(void);
 void bennet_info_sizes_log(void);
 
+void bennet_info_unsatisfied_init(void);
+void bennet_info_unsatisfied_set_function_under_test(const char* function_name);
+void bennet_info_unsatisfied_print_info(void);
+void bennet_info_unsatisfied_begin_run(void);
+void bennet_info_unsatisfied_end_run(bool);
+
 int is_bennet_experimental(void);

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -139,6 +139,7 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
         recentDiscards++;                                                                \
                                                                                          \
         bennet_info_backtracks_end_run(true);                                            \
+        bennet_info_unsatisfied_end_run(true);                                           \
                                                                                          \
         if (test_input.output_tyche) {                                                   \
           int64_t runtime = timediff_timeval(&start_time, &end_time);                    \
@@ -184,6 +185,7 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
       }                                                                                  \
                                                                                          \
       bennet_info_backtracks_begin_run();                                                \
+      bennet_info_unsatisfied_begin_run();                                               \
       successful_gen = false;                                                            \
       bennet_##FuncName##_record* res = bennet_##FuncName();                             \
       if (bennet_failure_get_failure_type() != BENNET_BACKTRACK_NONE) {                  \
@@ -196,6 +198,7 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
         recentDiscards++;                                                                \
                                                                                          \
         bennet_info_backtracks_end_run(true);                                            \
+        bennet_info_unsatisfied_end_run(true);                                           \
                                                                                          \
         if (test_input.output_tyche) {                                                   \
           int64_t runtime = timediff_timeval(&start_time, &end_time);                    \
@@ -218,6 +221,7 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
       successful_gen = true;                                                             \
       bennet_info_sizes_log();                                                           \
       bennet_info_backtracks_end_run(test_input.log_all_backtracks);                     \
+      bennet_info_unsatisfied_end_run(test_input.log_all_backtracks);                    \
                                                                                          \
       assume_##FuncName(__VA_ARGS__);                                                    \
       (void)Init(res);                                                                   \

--- a/runtime/libcn/include/dune
+++ b/runtime/libcn/include/dune
@@ -41,6 +41,9 @@
   (bennet-exp/info/backtracks.h
    as
    runtime/include/bennet-exp/info/backtracks.h)
+  (bennet-exp/info/unsatisfied.h
+   as
+   runtime/include/bennet-exp/info/unsatisfied.h)
   (bennet-exp/info/sizes.h as runtime/include/bennet-exp/info/sizes.h)
   (bennet-exp/info/tyche.h as runtime/include/bennet-exp/info/tyche.h)
   (bennet-exp/internals/domain.h

--- a/runtime/libcn/lib/dune
+++ b/runtime/libcn/lib/dune
@@ -73,6 +73,7 @@
     bennet-exp/prelude.o
     bennet-exp/rand.o
     bennet-exp/rand_alloc.o
+    bennet-exp/unsatisfied.o
     bennet-exp/size.o
     bennet-exp/sizes.o
     bennet-exp/tyche.o

--- a/runtime/libcn/src/bennet-exp/info/unsatisfied.c
+++ b/runtime/libcn/src/bennet-exp/info/unsatisfied.c
@@ -1,0 +1,288 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bennet-exp/utils/hash_table.h>
+
+// String hash and equality functions
+static size_t string_hash(const char* str) {
+  size_t hash = 5381;
+  int c;
+  while ((c = *str++)) {
+    hash = ((hash << 5) + hash) + c;  // hash * 33 + c
+  }
+  return hash;
+}
+
+static bool string_equal(const char* a, const char* b) {
+  return strcmp(a, b) == 0;
+}
+
+// Structure to represent a location (filename + line number)
+typedef struct {
+  const char* filename;
+  int line_number;
+} location_key_t;
+
+// Hash and equality functions for location_key_t
+static size_t location_hash(location_key_t key) {
+  size_t hash = string_hash(key.filename);
+  hash = ((hash << 5) + hash) + (size_t)key.line_number;
+  return hash;
+}
+
+static bool location_equal(location_key_t a, location_key_t b) {
+  return string_equal(a.filename, b.filename) && a.line_number == b.line_number;
+}
+
+typedef const char* const_str;
+typedef bool boolean;
+typedef void* pointer;
+
+// Struct to hold both unsatisfied and satisfied counters
+typedef struct {
+  uint32_t unsatisfied;
+  uint32_t satisfied;
+} satisfaction_counters_t;
+// Hash table type: location key -> satisfaction_counters_t
+#define bennet_info_unsatisfied_locations_count                                          \
+  bennet_hash_table(location_key_t, satisfaction_counters_t)
+
+BENNET_OPTIONAL_DECL(satisfaction_counters_t);
+BENNET_HASH_TABLE_DECL(location_key_t, satisfaction_counters_t);
+BENNET_HASH_TABLE_IMPL(location_key_t, satisfaction_counters_t);
+
+// Struct to hold pointer to location table and a per-function run counter
+typedef struct {
+  bennet_info_unsatisfied_locations_count* loc_table;
+  uint32_t run_count;
+} function_unsatisfied_entry_t;
+
+// Hash table type: function name -> function_unsatisfied_entry_t
+#define bennet_info_unsatisfied_functions                                                \
+  bennet_hash_table(const_str, function_unsatisfied_entry_t)
+
+// Hash table type: location key -> bool
+#define bennet_info_unsatisfied_locations bennet_hash_table(location_key_t, boolean)
+
+BENNET_OPTIONAL_DECL(pointer);
+BENNET_OPTIONAL_DECL(boolean);
+BENNET_OPTIONAL_DECL(function_unsatisfied_entry_t);
+BENNET_OPTIONAL_UNWRAP_OR_IMPL(pointer);
+BENNET_OPTIONAL_UNWRAP_OR_IMPL(boolean);
+BENNET_OPTIONAL_UNWRAP_OR_IMPL(satisfaction_counters_t);
+BENNET_OPTIONAL_UNWRAP_OR_IMPL(function_unsatisfied_entry_t);
+BENNET_HASH_TABLE_DECL(const_str, pointer);
+BENNET_HASH_TABLE_DECL(location_key_t, boolean);
+BENNET_HASH_TABLE_DECL(const_str, function_unsatisfied_entry_t);
+BENNET_HASH_TABLE_IMPL(const_str, pointer);
+BENNET_HASH_TABLE_IMPL(location_key_t, boolean);
+BENNET_HASH_TABLE_IMPL(const_str, function_unsatisfied_entry_t);
+
+// Global state
+static bool initialized = false;
+static const char* current_function = NULL;
+static bennet_info_unsatisfied_functions function_to_unsatisfied;
+static bennet_hash_table_const_str_pointer function_to_unsatisfied_tmp;
+
+void bennet_info_unsatisfied_init(void) {
+  if (!initialized) {
+    bennet_hash_table_init(const_str, function_unsatisfied_entry_t)(
+        &function_to_unsatisfied, string_hash, string_equal);
+    initialized = true;
+  }
+}
+
+void bennet_info_unsatisfied_set_function_under_test(const char* function_name) {
+  if (!initialized) {
+    return;
+  }
+  assert(function_name);
+  current_function = function_name;
+}
+
+void bennet_info_unsatisfied_begin_run(void) {
+  if (!initialized) {
+    return;
+  }
+  bennet_hash_table_init(const_str, pointer)(
+      &function_to_unsatisfied_tmp, string_hash, string_equal);
+  // Insert an entry into function_to_unsatisfied if current_function doesn't exist
+  if (current_function && initialized) {
+    bennet_optional(function_unsatisfied_entry_t) entry_opt =
+        bennet_hash_table_get(const_str, function_unsatisfied_entry_t)(
+            &function_to_unsatisfied, current_function);
+    if (bennet_optional_is_none(entry_opt)) {
+      bennet_info_unsatisfied_locations_count* loc_table =
+          malloc(sizeof(bennet_info_unsatisfied_locations_count));
+      bennet_hash_table_init(location_key_t, satisfaction_counters_t)(
+          loc_table, location_hash, location_equal);
+      function_unsatisfied_entry_t entry = {.loc_table = loc_table, .run_count = 0};
+      bennet_hash_table_set(const_str, function_unsatisfied_entry_t)(
+          &function_to_unsatisfied, current_function, entry);
+    }
+  }
+}
+
+void bennet_info_unsatisfied_end_run(bool record) {
+  if (!initialized) {
+    return;
+  }
+
+  if (!record) {
+    bennet_hash_table_free(const_str, pointer)(&function_to_unsatisfied_tmp);
+    return;
+  }
+
+  // Merge function_to_unsatisfied_tmp into function_to_unsatisfied
+  for (size_t i = 0; i < function_to_unsatisfied_tmp.capacity; ++i) {
+    if (function_to_unsatisfied_tmp.entries[i].occupied) {
+      const char* function_name = function_to_unsatisfied_tmp.entries[i].key;
+      bennet_info_unsatisfied_locations* tmp_loc_table =
+          (bennet_info_unsatisfied_locations*)function_to_unsatisfied_tmp.entries[i]
+              .value;
+      // Get or create entry for this function in the permanent table
+      bennet_optional(function_unsatisfied_entry_t) entry_opt =
+          bennet_hash_table_get(const_str, function_unsatisfied_entry_t)(
+              &function_to_unsatisfied, function_name);
+      function_unsatisfied_entry_t entry;
+      if (bennet_optional_is_none(entry_opt)) {
+        entry.loc_table = malloc(sizeof(bennet_info_unsatisfied_locations_count));
+        bennet_hash_table_init(location_key_t, satisfaction_counters_t)(
+            entry.loc_table, location_hash, location_equal);
+        entry.run_count = 0;
+        bennet_hash_table_set(const_str, function_unsatisfied_entry_t)(
+            &function_to_unsatisfied, function_name, entry);
+      } else {
+        entry = entry_opt.body;
+      }
+      // Increment the per-function run counter
+      entry.run_count++;
+      // For each location in tmp_loc_table, increment the appropriate counter
+      for (size_t j = 0; j < tmp_loc_table->capacity; ++j) {
+        if (tmp_loc_table->entries[j].occupied) {
+          location_key_t loc_key = tmp_loc_table->entries[j].key;
+          boolean tmp_val = tmp_loc_table->entries[j].value;
+          bennet_optional(satisfaction_counters_t) counters_opt = bennet_hash_table_get(
+              location_key_t, satisfaction_counters_t)(entry.loc_table, loc_key);
+          satisfaction_counters_t counters = bennet_optional_unwrap_or(
+              satisfaction_counters_t)(&counters_opt, (satisfaction_counters_t){0, 0});
+          if (tmp_val) {
+            counters.unsatisfied++;
+          } else {
+            counters.satisfied++;
+          }
+          bennet_hash_table_set(location_key_t, satisfaction_counters_t)(
+              entry.loc_table, loc_key, counters);
+        }
+      }
+      // Update the entry in the hash table
+      bennet_hash_table_set(const_str, function_unsatisfied_entry_t)(
+          &function_to_unsatisfied, function_name, entry);
+    }
+  }
+  bennet_hash_table_free(const_str, pointer)(&function_to_unsatisfied_tmp);
+}
+
+void bennet_info_unsatisfied_log(
+    const char* filename, int line_number, bool unsatisfied) {
+  if (!initialized || !current_function || !filename) {
+    return;
+  }
+
+  // Get or create location table for current function in the TMP table
+  bennet_optional(pointer) loc_table_opt = bennet_hash_table_get(const_str, pointer)(
+      &function_to_unsatisfied_tmp, current_function);
+  bennet_info_unsatisfied_locations* loc_table;
+  if (bennet_optional_is_none(loc_table_opt)) {
+    loc_table = malloc(sizeof(bennet_info_unsatisfied_locations));
+    bennet_hash_table_init(location_key_t, boolean)(
+        loc_table, location_hash, location_equal);
+    bennet_hash_table_set(const_str, pointer)(
+        &function_to_unsatisfied_tmp, current_function, loc_table);
+  } else {
+    loc_table = (bennet_info_unsatisfied_locations*)bennet_optional_unwrap(loc_table_opt);
+  }
+
+  // Set or update the bool for this location
+  location_key_t loc_key;
+  loc_key.filename = strdup(filename);
+  loc_key.line_number = line_number;
+  bennet_optional(boolean) satisfied_opt =
+      bennet_hash_table_get(location_key_t, boolean)(loc_table, loc_key);
+  boolean current = bennet_optional_unwrap_or(boolean)(&satisfied_opt, true);
+  boolean new_value = current && unsatisfied;
+  bennet_hash_table_set(location_key_t, boolean)(loc_table, loc_key, new_value);
+}
+
+// Comparison function for qsort of location_key_t
+static int cmp_locations(const void* a, const void* b) {
+  const location_key_t* la = (const location_key_t*)a;
+  const location_key_t* lb = (const location_key_t*)b;
+  int cmp = strcmp(la->filename, lb->filename);
+  if (cmp != 0)
+    return cmp;
+  return (la->line_number - lb->line_number);
+}
+
+void bennet_info_unsatisfied_print_info(void) {
+  if (!initialized) {
+    return;
+  }
+  printf("=== SATISFACTION STATISTICS ===\n\n");
+  printf("====================\n");
+  printf("FUNCTIONS UNDER TEST\n");
+  printf("====================\n\n");
+  for (size_t i = 0; i < function_to_unsatisfied.capacity; ++i) {
+    if (function_to_unsatisfied.entries[i].occupied) {
+      const char* function_name = function_to_unsatisfied.entries[i].key;
+      function_unsatisfied_entry_t entry = function_to_unsatisfied.entries[i].value;
+      bennet_info_unsatisfied_locations_count* loc_table = entry.loc_table;
+      printf("%s (%u runs):\n", function_name, entry.run_count);
+
+      // Collect locations into an array for sorting
+      size_t loc_count = 0;
+      for (size_t j = 0; j < loc_table->capacity; ++j) {
+        if (loc_table->entries[j].occupied) {
+          loc_count++;
+        }
+      }
+      location_key_t* locs = malloc(loc_count * sizeof(location_key_t));
+      satisfaction_counters_t* counters =
+          malloc(loc_count * sizeof(satisfaction_counters_t));
+      size_t idx = 0;
+      for (size_t j = 0; j < loc_table->capacity; ++j) {
+        if (loc_table->entries[j].occupied) {
+          locs[idx] = loc_table->entries[j].key;
+          counters[idx] = loc_table->entries[j].value;
+          idx++;
+        }
+      }
+      // Sort locations
+      qsort(locs, loc_count, sizeof(location_key_t), cmp_locations);
+      // Print in sorted order
+      for (size_t k = 0; k < loc_count; ++k) {
+        // Find the corresponding counters (since we sorted locs, need to find value)
+        // But since we built counters[] in the same order, we can just look up in the hash table
+        satisfaction_counters_t c = bennet_optional_unwrap(bennet_hash_table_get(
+            location_key_t, satisfaction_counters_t)(loc_table, locs[k]));
+        uint32_t total = c.unsatisfied + c.satisfied;
+        assert(total > 0);
+        double sat_percentage = (double)(c.satisfied * 100) / (double)total;
+        assert(entry.run_count > 0);
+        double hit_percentage = (double)(total * 100) / (double)entry.run_count;
+        printf("  %s::%d: %.1f%% satisfied, %.1f%% hit\n",
+            locs[k].filename,
+            locs[k].line_number,
+            sat_percentage,
+            hit_percentage);
+      }
+      free(locs);
+      free(counters);
+      printf("\n");
+    }
+  }
+}

--- a/runtime/libcn/src/bennet/compat.c
+++ b/runtime/libcn/src/bennet/compat.c
@@ -3,21 +3,21 @@
 #include <stdio.h>
 
 void bennet_info_backtracks_init(void) {}
-
 void bennet_info_backtracks_print_backtrack_info(void) {}
-
 void bennet_info_backtracks_set_function_under_test(const char* fut) {}
-
 void bennet_info_backtracks_begin_run(void) {}
 void bennet_info_backtracks_end_run(bool record) {}
 
 void bennet_info_sizes_init(void) {}
-
 void bennet_info_sizes_print_info(void) {}
-
 void bennet_info_sizes_set_function_under_test(const char* fut) {}
-
 void bennet_info_sizes_log(void) {}
+
+void bennet_info_unsatisfied_init(void) {}
+void bennet_info_unsatisfied_set_function_under_test(const char* function_name) {}
+void bennet_info_unsatisfied_print_info(void) {}
+void bennet_info_unsatisfied_begin_run(void) {}
+void bennet_info_unsatisfied_end_run(bool record) {}
 
 int is_bennet_experimental(void) {
   return 0;

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -163,6 +163,7 @@ int cn_test_main(int argc, char* argv[]) {
   FILE* tyche_output_stream = NULL;
   bool print_size_info = false;
   bool print_backtrack_info = false;
+  bool print_satisfaction_info = false;
 
   for (int i = 0; i < argc; i++) {
     char* arg = argv[i];
@@ -268,6 +269,12 @@ int cn_test_main(int argc, char* argv[]) {
       }
 
       print_backtrack_info = true;
+    } else if (strcmp("--print-satisfaction-info", arg) == 0) {
+      if (!is_bennet_experimental()) {
+        printf("UNSUPPORTED SATISFACTION INFO ON BASE RUNTIME");
+        assert(is_bennet_experimental());
+      }
+      print_satisfaction_info = true;
     } else if (strcmp("--print-size-info", arg) == 0) {
       if (!is_bennet_experimental()) {
         printf("UNSUPPORTED SIZE INFO ON BASE RUNTIME");
@@ -283,6 +290,10 @@ int cn_test_main(int argc, char* argv[]) {
 
   if (output_tyche || print_backtrack_info) {
     bennet_info_backtracks_init();
+  }
+
+  if (print_satisfaction_info) {
+    bennet_info_unsatisfied_init();
   }
 
   if (timeout != 0) {
@@ -314,6 +325,10 @@ int cn_test_main(int argc, char* argv[]) {
 
       if (output_tyche || print_backtrack_info) {
         bennet_info_backtracks_set_function_under_test(test_cases[i].name);
+      }
+
+      if (output_tyche || print_satisfaction_info) {
+        bennet_info_unsatisfied_set_function_under_test(test_cases[i].name);
       }
 
       struct cn_test_case* test_case = &test_cases[i];
@@ -440,6 +455,12 @@ outside_loop:;
     printf("\n");
 
     bennet_info_backtracks_print_backtrack_info();
+  }
+
+  if (print_satisfaction_info) {
+    printf("\n");
+
+    bennet_info_unsatisfied_print_info();
   }
 
   return !(failed == 0 && errored == 0);


### PR DESCRIPTION
Printout for `cn test bounds.pass.c --experimental-runtime --print-satisfaction-stats`:
```
=== SATISFACTION STATISTICS ===

====================
FUNCTIONS UNDER TEST
====================

bounds1 (110 runs):
  ./bounds.pass.gen.h::94: 100.0% satisfied, 100.0% hit
  ./bounds.pass.gen.h::100: 96.4% satisfied, 100.0% hit

bounds2 (94 runs):
  ./bounds.pass.gen.h::74: 100.0% satisfied, 100.0% hit
  ./bounds.pass.gen.h::80: 98.9% satisfied, 100.0% hit

bounds3 (1 runs):
  ./bounds.pass.gen.h::54: 100.0% satisfied, 100.0% hit
  ./bounds.pass.gen.h::60: 0.0% satisfied, 100.0% hit

bounds4 (0 runs):
```