### PR TITLE
Map Byte to Option MemByte

### DIFF
--- a/coq/Cn/BaseTypes.v
+++ b/coq/Cn/BaseTypes.v
@@ -37,7 +37,8 @@ Inductive t_gen (A:Type) : Type :=
   | Map : t_gen A -> t_gen A -> t_gen A
   | List : t_gen A -> t_gen A
   | Tuple : list (t_gen A) -> t_gen A
-  | TSet : t_gen A -> t_gen A.
+  | TSet : t_gen A -> t_gen A
+  | Option : t_gen A -> t_gen A.
 Set Elimination Schemes.
 
 Inductive Forall_type {A : Type} (P : A -> Type) : list A -> Type :=
@@ -65,11 +66,12 @@ Theorem t_gen_ind_set (A : Type) (P : t_gen A -> Type):
   (forall t : t_gen A, P t -> forall t0 : t_gen A, P t0 -> P (Map A t t0)) ->
   (forall t : t_gen A, P t -> P (List A t)) ->
   (forall l : list (t_gen A), (Forall_type P l) -> P (Tuple A l))  ->
-  (forall t : t_gen A, P t -> P (TSet A t))
+  (forall t : t_gen A, P t -> P (TSet A t)) ->
+  (forall t : t_gen A, P t -> P (Option A t))
 
   -> forall t : t_gen A, P t.
 Proof.
-  intros HUnit HBool HInteger HMemByte HBits HReal HAlloc HLoc HCType HStruct HDatatype HTRecord HMap HList HTuple HTSet.
+  intros HUnit HBool HInteger HMemByte HBits HReal HAlloc HLoc HCType HStruct HDatatype HTRecord HMap HList HTuple HTSet HOption.
   fix IH 1.
   intros t.
   destruct t; simpl.
@@ -114,6 +116,8 @@ Proof.
     + constructor; auto.
   - (* TSet *)
     apply HTSet; apply IH.
+  - (* Option *)
+    apply HOption; apply IH.
 Defined.
 
 
@@ -297,6 +301,15 @@ Module BasetTypes_t_as_MiniDecidableType <: MiniDecidableType.
             intros C.
             inversion C.
             congruence.
+    -
+      specialize (H y).
+      destruct H.
+      + subst. left. reflexivity.
+      +
+        right.
+        intros C.
+        inversion C.
+        congruence.
     -
       specialize (H y).
       destruct H.

--- a/lib/baseTypes.ml
+++ b/lib/baseTypes.ml
@@ -140,7 +140,7 @@ let rec of_sct loc is_signed size_of = function
     Map (uintptr_bt loc is_signed size_of, of_sct loc is_signed size_of sct)
   | Pointer sct -> Loc (loc sct)
   | Struct tag -> Struct tag
-  | Byte -> MemByte
+  | Byte -> Option MemByte
   | Function _ -> Cerb_debug.error "todo: function types"
 
 

--- a/lib/builtins.ml
+++ b/lib/builtins.ml
@@ -195,6 +195,12 @@ let rem_def = ("rem", Sym.fresh "rem", mk_arg2 IT.rem_)
 
 let mod_def = ("mod", Sym.fresh "mod", mk_arg2 IT.mod_)
 
+let is_some_def = ("is_some", Sym.fresh "is_some", mk_arg1 IT.isSome_)
+
+let is_none_def = ("is_none", Sym.fresh "is_none", mk_arg1 IT.isNone_)
+
+let get_opt_def = ("get_opt", Sym.fresh "get_opt", mk_arg1 IT.getOpt_)
+
 let builtin_funs =
   [ mul_uf_def;
     div_uf_def;
@@ -213,7 +219,10 @@ let builtin_funs =
     power_def;
     rem_def;
     mod_def;
-    has_alloc_id_def
+    has_alloc_id_def;
+    is_some_def;
+    is_none_def;
+    get_opt_def
   ]
 
 

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1218,6 +1218,10 @@ let add_trace_information _labels annots =
   return ()
 
 
+let bytes_pred ct pointer init : Req.Predicate.t =
+  { name = Owned (ct, init); pointer; iargs = [] }
+
+
 let bytes_qpred sym size pointer init : Req.QPredicate.t =
   let here = Locations.other __LOC__ in
   let bt' = WellTyped.default_quantifier_bt in
@@ -1254,6 +1258,150 @@ let rec cn_prog_sub_let f = function
     let subbed = Cnprog.subst f (IT.make_subst [ (sym, value) ]) cn_prog in
     cn_prog_sub_let f subbed
   | Pure (loc, x) -> return (loc, x)
+
+
+let bytes_constraints
+      loc
+      (to_from : CF.Cn.to_from)
+      ~(value : IT.t)
+      ~(byte_arr : IT.t)
+      (ct : Sctypes.t)
+  : IT.t t
+  =
+  (* FIXME this hard codes big endianness but this should be switchable *)
+  let here = Locations.other __LOC__ in
+  match ct with
+  | Sctypes.Void | Array (_, _) | Struct _ | Function (_, _, _) | Byte ->
+    fail (fun _ -> { loc; msg = Unsupported_byte_conv_ct ct })
+  | Integer it ->
+    let bt = IT.get_bt value in
+    let lhs = value in
+    let bytes =
+      List.init (Memory.size_of_integer_type it) (fun i ->
+        let index = int_lit_ i WellTyped.default_quantifier_bt here in
+        map_get_ byte_arr index here)
+    in
+    let all_some = and_ (List.map (fun byte -> isSome_ byte here) bytes) here in
+    let rhs =
+      let shifted =
+        List.mapi
+          (fun i byte ->
+             let casted = cast_ bt (getOpt_ byte here) here in
+             let shift_amt = int_lit_ (i * 8) bt here in
+             IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
+          bytes
+      in
+      List.fold_left (fun x y -> IT.add_ (x, y) here) (List.hd shifted) (List.tl shifted)
+    in
+    (match to_from with
+     | To -> return (and2_ (all_some, eq_ (lhs, rhs) here) here)
+     | From ->
+       let lc = LC.T all_some in
+       let@ provable = provable loc in
+       (match provable lc with
+        | `True -> return (eq_ (lhs, rhs) here)
+        | `False ->
+          let@ model = model () in
+          fail (fun ctxt ->
+            { loc;
+              msg =
+                Unproven_constraint
+                  { constr = lc; info = (loc, None); requests = []; ctxt; model }
+            })))
+  | Pointer _ ->
+    let bt = Memory.uintptr_bt in
+    let value_prov = cast_ BT.Alloc_id value here in
+    let value_addr = cast_ bt value here in
+    let bytes =
+      List.init Memory.size_of_pointer (fun i ->
+        let index = int_lit_ i WellTyped.default_quantifier_bt here in
+        map_get_ byte_arr index here)
+    in
+    let bytes_addr =
+      let shifted =
+        List.mapi
+          (fun i byte ->
+             let casted = cast_ bt (getOpt_ byte here) here in
+             let shift_amt = int_lit_ (i * 8) bt here in
+             IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
+          bytes
+      in
+      List.fold_left (fun x y -> IT.add_ (x, y) here) (List.hd shifted) (List.tl shifted)
+    in
+    let all_some = and_ (List.map (fun byte -> isSome_ byte here) bytes) here in
+    let bytes_prov =
+      List.map (fun byte -> cast_ (BT.Option Alloc_id) (getOpt_ byte here) here) bytes
+    in
+    (match to_from with
+     | From ->
+       let lc = LC.T all_some in
+       let@ provable = provable loc in
+       (match provable lc with
+        | `False ->
+          let@ model = model () in
+          fail (fun ctxt ->
+            { loc;
+              msg =
+                Unproven_constraint
+                  { constr = lc; info = (loc, None); requests = []; ctxt; model }
+            })
+        | `True ->
+          (* if two byte provenances are not CN_None, they should be equal *)
+          let bytes_prov_eq =
+            let pairwise prov1 prov2 =
+              or_
+                [ isNone_ prov1 here;
+                  isNone_ prov2 here;
+                  eq_ (getOpt_ prov1 here, getOpt_ prov2 here) here
+                ]
+                here
+            in
+            let _, _, pairwise_opt_eq =
+              List.fold_right
+                (fun prov1 (prov2, rest, constr) ->
+                   ( prov1,
+                     prov2 :: rest,
+                     List.map (pairwise prov1) (prov2 :: rest) @ constr ))
+                bytes_prov
+                (none_ Alloc_id here, [], [])
+            in
+            and_ pairwise_opt_eq here
+          in
+          let combined_prov_sym, combined_prov =
+            IT.fresh_named (BT.Option Alloc_id) "combined_prov" here
+          in
+          (* evaluate to the first non-CN_None provenance... *)
+          let first_some_prov =
+            List.fold_right
+              (fun rest prov -> ite_ (isSome_ prov here, prov, rest) here)
+              bytes_prov
+              (none_ Alloc_id here)
+          in
+          (* ...and name it for easy reference *)
+          let@ () =
+            add_a
+              combined_prov_sym
+              (BT.Option Alloc_id)
+              (here, lazy (Pp.string "combined provenance"))
+          in
+          let@ () = add_c here (LC.T (IT.eq_ (combined_prov, first_some_prov) here)) in
+          (* this constraint implements the combine_provenance function *)
+          let prov_constr =
+            impl_
+              ( and2_ (bytes_prov_eq, isSome_ combined_prov here) here,
+                eq_ (value_prov, getOpt_ combined_prov here) here )
+              here
+          in
+          return (and_ [ prov_constr; eq_ (value_addr, bytes_addr) here ] here))
+     | To ->
+       let bytes_prov_eq =
+         and_
+           (List.map
+              (fun byte_prov -> eq_ (byte_prov, some_ value_prov here) here)
+              bytes_prov)
+           here
+       in
+       return (and_ [ all_some; bytes_prov_eq; eq_ (value_addr, bytes_addr) here ] here))
 
 
 let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
@@ -1755,129 +1903,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
     in
     aux es []
   | CN_progs (_, cn_progs) ->
-    let bytes_pred ct pointer init : Req.Predicate.t =
-      { name = Owned (ct, init); pointer; iargs = [] }
-    in
-    let bytes_constraints
-          (to_from : CF.Cn.to_from)
-          ~(value : IT.t)
-          ~(byte_arr : IT.t)
-          (ct : Sctypes.t)
-      : IT.t t
-      =
-      (* FIXME this hard codes big endianness but this should be switchable *)
-      let here = Locations.other __LOC__ in
-      match ct with
-      | Sctypes.Void | Array (_, _) | Struct _ | Function (_, _, _) | Byte ->
-        fail (fun _ -> { loc; msg = Unsupported_byte_conv_ct ct })
-      | Integer it ->
-        let bt = IT.get_bt value in
-        let lhs = value in
-        let bytes =
-          List.init (Memory.size_of_integer_type it) (fun i ->
-            let index = int_lit_ i WellTyped.default_quantifier_bt here in
-            map_get_ byte_arr index here)
-        in
-        let all_some = and_ (List.map (fun byte -> isSome_ byte here) bytes) here in
-        let rhs =
-          let shifted =
-            List.mapi
-              (fun i byte ->
-                 let casted = cast_ bt (getOpt_ byte here) here in
-                 let shift_amt = int_lit_ (i * 8) bt here in
-                 IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
-              bytes
-          in
-          List.fold_left
-            (fun x y -> IT.add_ (x, y) here)
-            (List.hd shifted)
-            (List.tl shifted)
-        in
-        return (and2_ (all_some, eq_ (lhs, rhs) here) here)
-      | Pointer _ ->
-        let bt = Memory.uintptr_bt in
-        let value_prov = cast_ BT.Alloc_id value here in
-        let value_addr = cast_ bt value here in
-        let bytes =
-          List.init Memory.size_of_pointer (fun i ->
-            let index = int_lit_ i WellTyped.default_quantifier_bt here in
-            map_get_ byte_arr index here)
-        in
-        let bytes_addr =
-          let shifted =
-            List.mapi
-              (fun i byte ->
-                 let casted = cast_ bt (getOpt_ byte here) here in
-                 let shift_amt = int_lit_ (i * 8) bt here in
-                 IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
-              bytes
-          in
-          List.fold_left
-            (fun x y -> IT.add_ (x, y) here)
-            (List.hd shifted)
-            (List.tl shifted)
-        in
-        let all_some = and_ (List.map (fun byte -> isSome_ byte here) bytes) here in
-        let bytes_prov =
-          List.map (fun byte -> cast_ (BT.Option Alloc_id) (getOpt_ byte here) here) bytes
-        in
-        (match to_from with
-         | From ->
-           (* if two byte provenances are not CN_None, they should be equal *)
-           let bytes_prov_eq =
-             let _, pairwise_opt_eq =
-               List.fold_right
-                 (fun prov1 (prov2, rest) ->
-                    ( prov1,
-                      or_
-                        [ isNone_ prov1 here;
-                          isNone_ prov2 here;
-                          eq_ (getOpt_ prov1 here, getOpt_ prov2 here) here
-                        ]
-                        here
-                      :: rest ))
-                 bytes_prov
-                 (none_ Alloc_id here, [])
-             in
-             and_ pairwise_opt_eq here
-           in
-           let combined_prov_sym, combined_prov =
-             IT.fresh_named (BT.Option Alloc_id) "combined_prov" here
-           in
-           (* evaluate to the first non-CN_None provenance... *)
-           let first_some_prov =
-             List.fold_right
-               (fun rest prov -> ite_ (isSome_ prov here, prov, rest) here)
-               bytes_prov
-               (none_ Alloc_id here)
-           in
-           (* ...and name it for easy reference *)
-           let@ () =
-             add_a
-               combined_prov_sym
-               (BT.Option Alloc_id)
-               (here, lazy (Pp.string "combined provenance"))
-           in
-           let@ () = add_c here (LC.T (IT.eq_ (combined_prov, first_some_prov) here)) in
-           (* this constraint implements the combine_provenance function *)
-           let prov_constr =
-             impl_
-               ( and2_ (bytes_prov_eq, isSome_ combined_prov here) here,
-                 eq_ (value_prov, getOpt_ combined_prov here) here )
-               here
-           in
-           return (and_ [ all_some; prov_constr; eq_ (value_addr, bytes_addr) here ] here)
-         | To ->
-           let bytes_prov_eq =
-             and_
-               (List.map
-                  (fun byte_prov -> eq_ (byte_prov, some_ value_prov here) here)
-                  bytes_prov)
-               here
-           in
-           return
-             (and_ [ all_some; bytes_prov_eq; eq_ (value_addr, bytes_addr) here ] here))
-    in
     let@ () = WellTyped.ensure_base_type loc ~expect Unit in
     let do_unpack (req, o) =
       let@ provable = provable loc in
@@ -1955,7 +1980,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
         (match init with
          | Uninit -> add_c loc (LC.T (IT.eq_ (byte_arr, default_ map_bt here) here))
          | Init ->
-           let@ constr = bytes_constraints To ~value ~byte_arr ct in
+           let@ constr = bytes_constraints loc To ~value ~byte_arr ct in
            add_c loc (LC.T constr))
       | To_from_bytes (From, { name = Owned (ct, init); pointer; _ }) ->
         let ctxt = match init with Init -> `RW | Uninit -> `W in
@@ -1979,7 +2004,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
         (match init with
          | Uninit -> add_c loc (LC.T (IT.eq_ (value, default_ value_bt here) here))
          | Init ->
-           let@ constr = bytes_constraints From ~value ~byte_arr ct in
+           let@ constr = bytes_constraints loc From ~value ~byte_arr ct in
            add_c loc (LC.T constr))
       | Have lc ->
         let@ _lc = WellTyped.logical_constraint loc lc in

--- a/lib/coreTypeChecks.ml
+++ b/lib/coreTypeChecks.ml
@@ -35,7 +35,7 @@ let check_against_core_bt core_bt cn_bt =
   let rec check_object_type = function
     | OTy_integer, BT.Integer -> return ()
     | OTy_integer, BT.Bits _ -> return ()
-    | OTy_integer, BT.MemByte -> return ()
+    | OTy_integer, BT.Option MemByte -> return ()
     | OTy_pointer, BT.Loc () -> return ()
     | OTy_array t, BT.Map (param_t, t2) ->
       let@ () = check_object_type (OTy_integer, param_t) in

--- a/lib/indexTerms.ml
+++ b/lib/indexTerms.ml
@@ -854,6 +854,8 @@ let map_def_ (s, abt) body loc =
   IT (MapDef ((s, abt), body), BT.Map (abt, get_bt body), loc)
 
 
+let none_ bt loc = IT (CN_None bt, BT.Option bt, loc)
+
 let some_ t loc = IT (CN_Some t, BT.Option (get_bt t), loc)
 
 let isNone_ t loc =

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -571,10 +571,10 @@ let rec pp_basetype pp_loc = function
   | BaseTypes.List t -> pp_constructor "BaseTypes.List" [ !^"unit"; pp_basetype pp_loc t ]
   | BaseTypes.Tuple ts ->
     pp_constructor "BaseTypes.Tuple" [ !^"unit"; pp_list (pp_basetype pp_loc) ts ]
-  | BaseTypes.Set t -> pp_constructor "BaseTypes.Set" [ !^"unit"; pp_basetype pp_loc t ]
+  | BaseTypes.Set t -> pp_constructor "BaseTypes.TSet" [ !^"unit"; pp_basetype pp_loc t ]
   | BaseTypes.Loc x -> pp_constructor "BaseTypes.Loc" [ !^"unit"; pp_unit x ]
   | BaseTypes.Option t ->
-    pp_constructor "BaseTypes.Set" [ !^"unit"; pp_basetype pp_loc t ]
+    pp_constructor "BaseTypes.Option" [ !^"unit"; pp_basetype pp_loc t ]
 
 
 let pp_integer_base_type = function

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1046,7 +1046,7 @@ module WIT = struct
         return (IT (Match (e, cases), rbt, loc))
       | CN_None bt ->
         let@ bt = WBT.is_bt loc bt in
-        return (IT (CN_None bt, bt, loc))
+        return (IT (CN_None bt, Option bt, loc))
       | CN_Some t ->
         let@ t = infer t in
         let bt = IT.get_bt t in

--- a/tests/cn/to_from_bytes_struct.error.c.verify
+++ b/tests/cn/to_from_bytes_struct.error.c.verify
@@ -3,6 +3,6 @@ tests/cn/to_from_bytes_struct.error.c:30:7: warning: experimental keyword 'to_by
   /*@ to_bytes RW<s>(p); @*/
       ^~~~~~~~ 
 [1/1]: untransmute_to_blob -- fail
-tests/cn/to_from_bytes_struct.error.c:30:6: error: Cannot (yet) convert value of struct s to/from bytes
+tests/cn/to_from_bytes_struct.error.c:30:7: error: Cannot (yet) convert value of struct s to/from bytes
   /*@ to_bytes RW<s>(p); @*/
-     ^~~~~~~~~~~~~~~~~~~~~ 
+      ^~~~~~~~~~~~~~~~~~ 

--- a/tests/cn_vip_testsuite/cn_lemmas.h
+++ b/tests/cn_vip_testsuite/cn_lemmas.h
@@ -3,8 +3,11 @@
 /*@
 function [rec] (boolean) array_bits_eq(map<u64, byte> arr1, map<u64, byte> arr2, u64 end) {
     let end1 = end - 1u64;
+    let b1 = arr1[end1];
+    let b2 = arr2[end1];
     end == 0u64 ||
-        ((u8) arr1[end1]) == ((u8) arr2[end1]) && array_bits_eq(arr1, arr2, end1)
+        is_some(b1) && is_some(b1) &&
+        ((u8) get_opt(b1)) == ((u8) get_opt(b2)) && array_bits_eq(arr1, arr2, end1)
 }
 @*/
 
@@ -62,6 +65,8 @@ ensures
     take DestR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(dest, i)) };
     Src == SrcR; Dest == DestR;
     let arr_eq = array_bits_eq(Src, Dest, n);
-    let each_eq = each (u64 i: 0,7; (u8) Src[i] == (u8) Dest[i] );
+    let each_eq = each (u64 i: 0,7;
+        is_some(Src[i]) && is_some(Dest[i]) &&
+        (u8) get_opt(Src[i]) == (u8) get_opt(Dest[i]) );
     (arr_eq implies each_eq) && (each_eq implies arr_eq);
 @*/


### PR DESCRIPTION
This commit changes the mapping of the Byte C type to Option MemByte from MemByte and updates all the associated constraints with it.