### PR TITLE
[CN-exec] Remove iteration over entire ownership ghost state

### DIFF
--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -3820,16 +3820,16 @@ let cn_to_ail_loop_inv
     let (_, (cond_bs, cond_ss)), (_, loop_bs_and_ss) =
       cn_to_ail_loop_inv_aux filename dts globals preds (Some Loop) loop
     in
-    let cn_stack_depth_incr_call =
+    (* let cn_stack_depth_incr_call =
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_stack_depth_incr_sym), [])))
-    in
+    in *)
     let cn_loop_put_call =
       A.AilSexpr
         (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_put_back_ownership_sym), [])))
     in
-    let cn_stack_depth_decr_call =
+    (* let cn_stack_depth_decr_call =
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_stack_depth_decr_sym), [])))
-    in
+    in *)
     let dummy_expr_as_stat =
       A.(
         AilSexpr
@@ -3842,10 +3842,10 @@ let cn_to_ail_loop_inv
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_leak_check_sym), [])))
     in
     let stats =
-      (bump_alloc_start_stat_ :: cn_stack_depth_incr_call :: cond_ss)
+      (bump_alloc_start_stat_ :: (* cn_stack_depth_incr_call :: *) cond_ss)
       @ (if with_loop_leak_checks then [ cn_ownership_leak_check_call ] else [])
       @ [ cn_loop_put_call;
-          cn_stack_depth_decr_call;
+          (* cn_stack_depth_decr_call; *)
           bump_alloc_end_stat_;
           dummy_expr_as_stat
         ]

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -774,9 +774,11 @@ let generate_get_or_put_ownership_function ~without_ownership_checking ctype
       ([ generic_c_ptr_binding ], [ generic_c_ptr_assign_stat_ ]))
   in
   let param2_sym = spec_mode_sym in
+  let param3_sym = loop_ownership_sym in
   let param1 = (param1_sym, bt_to_ail_ctype BT.(Loc ())) in
   let param2 = (param2_sym, spec_mode_enum_type) in
-  let param_syms, param_types = List.split [ param1; param2 ] in
+  let param3 = (param3_sym, loop_ownership_struct_ptr_ctype) in
+  let param_syms, param_types = List.split [ param1; param2; param3 ] in
   let param_types = List.map (fun t -> (C.no_qualifiers, t, false)) param_types in
   let ownership_fcall_maybe =
     if without_ownership_checking then
@@ -787,7 +789,8 @@ let generate_get_or_put_ownership_function ~without_ownership_checking ctype
         A.
           [ AilEident param2_sym;
             AilEident generic_c_ptr_sym;
-            AilEsizeof (C.no_qualifiers, ctype)
+            AilEsizeof (C.no_qualifiers, ctype);
+            AilEident param3_sym
           ]
       in
       [ A.(
@@ -2899,6 +2902,7 @@ let cn_to_ail_resource
       dts
       globals
       (preds : (Sym.t * Definition.Predicate.t) list)
+      loop_ownership_sym_opt
       spec_mode_opt
         (* used to check whether spec_mode enum should be pretty-printed or whether it's an inner call with the spec_mode enum parameter *)
       loc
@@ -2965,9 +2969,16 @@ let cn_to_ail_resource
         let owned_fn_name = generate_owned_fn_name sct in
         (* Hack with enum as sym *)
         let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let loop_ownership_arg =
+          match loop_ownership_sym_opt with
+          | Some loop_ownership_sym ->
+            IT.(IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+          | None -> IT.(IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown))
+        in
         let fn_call_it =
           IT.IT
-            ( Apply (Sym.fresh owned_fn_name, [ p.pointer; enum_val_get ]),
+            ( Apply
+                (Sym.fresh owned_fn_name, [ p.pointer; enum_val_get; loop_ownership_arg ]),
               BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct,
               Cerb_location.unknown )
         in
@@ -3060,9 +3071,16 @@ let cn_to_ail_resource
         let ptr_add_it = IT.(IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
         (* Hack with enum as sym *)
         let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let loop_ownership_arg =
+          match loop_ownership_sym_opt with
+          | Some loop_ownership_sym ->
+            IT.(IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+          | None -> IT.(IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown))
+        in
         let fn_call_it =
           IT.IT
-            ( Apply (Sym.fresh owned_fn_name, [ ptr_add_it; enum_val_get ]),
+            ( Apply
+                (Sym.fresh owned_fn_name, [ ptr_add_it; enum_val_get; loop_ownership_arg ]),
               BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct,
               Cerb_location.unknown )
         in
@@ -3412,7 +3430,7 @@ let rec cn_to_ail_lat filename dts pred_sym_opt globals preds spec_mode_opt = fu
     let upd_s = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
     let pop_s = generate_cn_pop_msg_info in
     let b1, s1 =
-      cn_to_ail_resource filename name dts globals preds spec_mode_opt loc ret
+      cn_to_ail_resource filename name dts globals preds None spec_mode_opt loc ret
     in
     let b2, s2 =
       cn_to_ail_lat filename dts pred_sym_opt globals preds spec_mode_opt lat
@@ -3574,7 +3592,7 @@ let rec cn_to_ail_post_aux filename dts globals preds spec_mode_opt = function
     let upd_s = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
     let pop_s = generate_cn_pop_msg_info in
     let b1, s1 =
-      cn_to_ail_resource filename new_name dts globals preds spec_mode_opt loc re
+      cn_to_ail_resource filename new_name dts globals preds None spec_mode_opt loc re
     in
     let new_lrt = LogicalReturnTypes.subst (ESE.sym_subst (name, bt, new_name)) t in
     let b2, s2 = cn_to_ail_post_aux filename dts globals preds spec_mode_opt new_lrt in
@@ -3704,24 +3722,54 @@ let cn_to_ail_statements filename dts globals spec_mode_opt (loc, cn_progs) =
   (loc, (List.concat bs, upd_s @ List.concat ss @ pop_s))
 
 
-let rec cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt = function
+let rec cn_to_ail_lat_internal_loop
+          filename
+          dts
+          globals
+          preds
+          loop_ownership_sym
+          spec_mode_opt
+  = function
   | LAT.Define ((name, it), _info, lat) ->
     let ctype = bt_to_ail_ctype (IT.get_bt it) in
     let binding = create_binding name ctype in
     let decl = A.(AilSdeclaration [ (name, None) ]) in
     let b1, s1 = cn_to_ail_expr filename dts globals spec_mode_opt it (AssignVar name) in
     let b2, s2 =
-      cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt lat
+      cn_to_ail_lat_internal_loop
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_sym
+        spec_mode_opt
+        lat
     in
     (b1 @ b2 @ [ binding ], (decl :: s1) @ s2)
   | LAT.Resource ((name, (ret, _bt)), (loc, _str_opt), lat) ->
     let upd_s = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
     let pop_s = generate_cn_pop_msg_info in
     let b1, s1 =
-      cn_to_ail_resource filename name dts globals preds spec_mode_opt loc ret
+      cn_to_ail_resource
+        filename
+        name
+        dts
+        globals
+        preds
+        (Some loop_ownership_sym)
+        spec_mode_opt
+        loc
+        ret
     in
     let b2, s2 =
-      cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt lat
+      cn_to_ail_lat_internal_loop
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_sym
+        spec_mode_opt
+        lat
     in
     (b1 @ b2, upd_s @ s1 @ pop_s @ s2)
   | LAT.Constraint (lc, (loc, _str_opt), lat) ->
@@ -3737,7 +3785,14 @@ let rec cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt = f
       | None -> s
     in
     let b2, s2 =
-      cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt lat
+      cn_to_ail_lat_internal_loop
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_sym
+        spec_mode_opt
+        lat
     in
     (b1 @ b2, ss @ s2)
   | LAT.I ss ->
@@ -3757,6 +3812,7 @@ let rec cn_to_ail_loop_inv_aux
           dts
           globals
           preds
+          loop_ownership_sym
           spec_mode_opt
           (contains_user_spec, cond_loc, loop_loc, at)
   =
@@ -3769,7 +3825,14 @@ let rec cn_to_ail_loop_inv_aux
         (contains_user_spec, cond_loc, loop_loc, at')
     in
     let (_, (cond_bs, cond_ss)), (_, (loop_bs, loop_ss)) =
-      cn_to_ail_loop_inv_aux filename dts globals preds spec_mode_opt subst_loop
+      cn_to_ail_loop_inv_aux
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_sym
+        spec_mode_opt
+        subst_loop
     in
     ((cond_loc, (cond_bs, cond_ss)), (loop_loc, (loop_bs, loop_ss)))
   | AT.Ghost _ -> failwith "TODO Fulminate: Ghost arguments not yet supported at runtime"
@@ -3806,27 +3869,48 @@ let rec cn_to_ail_loop_inv_aux
          | _ -> modify_decls_for_loop decls (modified_stats @ [ s ]) ss)
     in
     let bs, ss =
-      cn_to_ail_lat_internal_loop filename dts globals preds spec_mode_opt lat
+      cn_to_ail_lat_internal_loop
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_sym
+        spec_mode_opt
+        lat
     in
     let decls, modified_stats = modify_decls_for_loop [] [] ss in
-    let loop_local_ownership_sym = Sym.fresh_anon () in
-    let loop_ownership_binding =
-      create_binding loop_local_ownership_sym loop_ownership_struct_ptr_ctype
-    in
-    let loop_ownership_init_fn_call =
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh "initialise_loop_ownership_state")), []))
-    in
-    let loop_ownership_decl = A.(AilSdeclaration [ (loop_local_ownership_sym, None) ]) in
-    let loop_ownership_assign =
-      A.(
-        AilSexpr
-          (mk_expr
-             (AilEassign
-                ( mk_expr (AilEident loop_local_ownership_sym),
-                  mk_expr loop_ownership_init_fn_call ))))
-    in
-    ( (cond_loc, (loop_ownership_binding :: bs, loop_ownership_assign :: modified_stats)),
-      (loop_loc, (loop_ownership_binding :: bs, loop_ownership_decl :: decls)) )
+    ((cond_loc, (bs, modified_stats)), (loop_loc, (bs, decls)))
+
+
+type loop_ownership =
+  { sym : Sym.t;
+    binding : A.bindings;
+    decl : CF.GenTypes.genTypeCategory A.statement_;
+    assign : CF.GenTypes.genTypeCategory A.statement_
+  }
+
+let get_loop_ownership_bs_and_ss () =
+  let loop_local_ownership_sym = Sym.fresh_anon () in
+  let loop_ownership_binding =
+    create_binding loop_local_ownership_sym loop_ownership_struct_ptr_ctype
+  in
+  let loop_ownership_init_fn_call =
+    A.(AilEcall (mk_expr (AilEident (Sym.fresh "initialise_loop_ownership_state")), []))
+  in
+  let loop_ownership_decl = A.(AilSdeclaration [ (loop_local_ownership_sym, None) ]) in
+  let loop_ownership_assign =
+    A.(
+      AilSexpr
+        (mk_expr
+           (AilEassign
+              ( mk_expr (AilEident loop_local_ownership_sym),
+                mk_expr loop_ownership_init_fn_call ))))
+  in
+  { sym = loop_local_ownership_sym;
+    binding = [ loop_ownership_binding ];
+    decl = loop_ownership_decl;
+    assign = loop_ownership_assign
+  }
 
 
 let cn_to_ail_loop_inv
@@ -3838,12 +3922,23 @@ let cn_to_ail_loop_inv
       ((contains_user_spec, cond_loc, loop_loc, _) as loop)
   =
   if contains_user_spec then (
-    let (_, (cond_bs, cond_ss)), (_, loop_bs_and_ss) =
-      cn_to_ail_loop_inv_aux filename dts globals preds (Some Loop) loop
+    let loop_ownership_state = get_loop_ownership_bs_and_ss () in
+    let (_, (cond_bs, cond_ss)), (_, (loop_bs, loop_ss)) =
+      cn_to_ail_loop_inv_aux
+        filename
+        dts
+        globals
+        preds
+        loop_ownership_state.sym
+        (Some Loop)
+        loop
     in
     let cn_loop_put_call =
       A.AilSexpr
-        (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_put_back_ownership_sym), [])))
+        (mk_expr
+           (AilEcall
+              ( mk_expr (AilEident OE.cn_loop_put_back_ownership_sym),
+                [ mk_expr (AilEident loop_ownership_state.sym) ] )))
     in
     let dummy_expr_as_stat =
       A.(
@@ -3857,7 +3952,7 @@ let cn_to_ail_loop_inv
       A.AilSexpr (mk_expr (AilEcall (mk_expr (AilEident OE.cn_loop_leak_check_sym), [])))
     in
     let stats =
-      (bump_alloc_start_stat_ :: cond_ss)
+      (bump_alloc_start_stat_ :: loop_ownership_state.assign :: cond_ss)
       @ (if with_loop_leak_checks then [ cn_ownership_leak_check_call ] else [])
       @ [ cn_loop_put_call; bump_alloc_end_stat_; dummy_expr_as_stat ]
     in
@@ -3865,7 +3960,11 @@ let cn_to_ail_loop_inv
       A.(AilEgcc_statement ([ bump_alloc_binding ], List.map mk_stmt stats))
     in
     let ail_stat_as_expr_stat = A.(AilSexpr (mk_expr ail_gcc_stat_as_expr)) in
-    Some ((cond_loc, (cond_bs, [ ail_stat_as_expr_stat ])), (loop_loc, loop_bs_and_ss)))
+    Some
+      ( (cond_loc, (cond_bs, [ ail_stat_as_expr_stat ])),
+        ( loop_loc,
+          (loop_ownership_state.binding @ loop_bs, loop_ownership_state.decl :: loop_ss)
+        ) ))
   else
     (* Produce no runtime loop invariant statements if the user has not written any spec for this loop*)
     None
@@ -3920,7 +4019,7 @@ let rec cn_to_ail_lat_2
     let pop_s = generate_cn_pop_msg_info in
     let new_name = generate_sym_with_suffix ~suffix:"_cn" name in
     let b1, s1 =
-      cn_to_ail_resource filename new_name dts globals preds spec_mode_opt loc ret
+      cn_to_ail_resource filename new_name dts globals preds None spec_mode_opt loc ret
     in
     let new_lat = ESE.fn_largs_and_body_subst (ESE.sym_subst (name, bt, new_name)) lat in
     let ail_executable_spec =

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -30,7 +30,7 @@ let cn_stack_depth_decr_sym = Sym.fresh "ghost_stack_depth_decr"
 
 let cn_postcondition_leak_check_sym = Sym.fresh "cn_postcondition_leak_check"
 
-let cn_loop_put_back_ownership_sym = Sym.fresh "cn_loop_put_back_ownership_new"
+let cn_loop_put_back_ownership_sym = Sym.fresh "cn_loop_put_back_ownership"
 
 let cn_loop_leak_check_sym = Sym.fresh "cn_loop_leak_check"
 

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -30,7 +30,7 @@ let cn_stack_depth_decr_sym = Sym.fresh "ghost_stack_depth_decr"
 
 let cn_postcondition_leak_check_sym = Sym.fresh "cn_postcondition_leak_check"
 
-let cn_loop_put_back_ownership_sym = Sym.fresh "cn_loop_put_back_ownership"
+let cn_loop_put_back_ownership_sym = Sym.fresh "cn_loop_put_back_ownership_new"
 
 let cn_loop_leak_check_sym = Sym.fresh "cn_loop_leak_check"
 

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -547,8 +547,6 @@ void ownership_ghost_state_set(int64_t *address_key, int stack_depth_val);
 void ownership_ghost_state_remove(int64_t *address_key);
 
 /* CN ownership checking */
-void cn_get_ownership(void *generic_c_ptr, size_t size, char *check_msg);
-void cn_put_ownership(void *generic_c_ptr, size_t size);
 void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun);
 void cn_get_or_put_ownership(enum spec_mode spec_mode, void *generic_c_ptr, size_t size);
 

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -160,11 +160,10 @@ signed long get_cn_stack_depth(void);
 void ghost_stack_depth_incr(void);
 void ghost_stack_depth_decr(void);
 void cn_postcondition_leak_check(void);
-void cn_loop_put_back_ownership(void);
-void cn_loop_leak_check(void);
 
 struct loop_ownership *initialise_loop_ownership_state(void);
-void cn_loop_put_back_ownership_new(struct loop_ownership *loop_ownership);
+void cn_loop_leak_check(void);
+void cn_loop_put_back_ownership(struct loop_ownership *loop_ownership);
 
 /* malloc, free */
 void *cn_aligned_alloc(size_t align, size_t size);

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -148,6 +148,11 @@ typedef struct cn_alloc_id {
 
 typedef hash_table cn_map;
 
+struct loop_ownership {
+  uintptr_t *owned_loop_addrs;
+  signed long arr_size;
+};
+
 void initialise_ownership_ghost_state(void);
 void free_ownership_ghost_state(void);
 void initialise_ghost_stack_depth(void);
@@ -157,6 +162,9 @@ void ghost_stack_depth_decr(void);
 void cn_postcondition_leak_check(void);
 void cn_loop_put_back_ownership(void);
 void cn_loop_leak_check(void);
+
+struct loop_ownership *initialise_loop_ownership_state(void);
+void cn_loop_put_back_ownership_new(struct loop_ownership *loop_ownership);
 
 /* malloc, free */
 void *cn_aligned_alloc(size_t align, size_t size);
@@ -548,7 +556,10 @@ void ownership_ghost_state_remove(int64_t *address_key);
 
 /* CN ownership checking */
 void cn_assume_ownership(void *generic_c_ptr, unsigned long size, char *fun);
-void cn_get_or_put_ownership(enum spec_mode spec_mode, void *generic_c_ptr, size_t size);
+void cn_get_or_put_ownership(enum spec_mode spec_mode,
+    void *generic_c_ptr,
+    size_t size,
+    struct loop_ownership *loop_ownership);
 
 /* C ownership checking */
 void c_add_to_ghost_state(void *ptr_to_local, size_t size, signed long stack_depth);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -364,7 +364,8 @@ void cn_loop_get_ownership(
     cn_printf(CN_LOGGING_ERROR, "******** FULMINATE ERROR *********\n");
     cn_printf(CN_LOGGING_ERROR, "No loop ownership state found.\n");
     cn_printf(CN_LOGGING_ERROR,
-        "Please open a pull request at https://github.com/rems-project/cn\n") exit(1);
+        "Please open a pull request at https://github.com/rems-project/cn\n");
+    exit(1);
   }
 }
 

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -20,8 +20,8 @@ signed long cn_stack_depth;
 
 signed long nr_owned_predicates;
 
-static signed long UNMAPPED_VAL = INT_MIN + 1;
-static signed long WILDCARD_DEPTH = INT_MIN + 2;
+static signed long UNMAPPED_VAL = -1;
+static signed long WILDCARD_DEPTH = INT_MIN + 1;
 
 static allocator bump_alloc = (allocator){
     .malloc = &cn_bump_malloc, .calloc = &cn_bump_calloc, .free = &cn_bump_free};

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -346,7 +346,12 @@ void cn_loop_get_ownership(
   c_ownership_check(
       "Loop invariant ownership check", generic_c_ptr, (int)size, cn_stack_depth);
   c_add_to_ghost_state(generic_c_ptr, size, cn_stack_depth - 1);
-  cn_add_to_loop_ownership_state(generic_c_ptr, size, loop_ownership);
+  if (loop_ownership) {
+    cn_add_to_loop_ownership_state(generic_c_ptr, size, loop_ownership);
+  } else {
+    // TODO: Change to error
+    printf("No loop ownership state found\n");
+  }
 }
 
 void cn_put_ownership(void* generic_c_ptr, size_t size) {

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -1,3 +1,5 @@
+#include <_inttypes.h>
+
 #include <inttypes.h>
 #include <limits.h>
 #include <signal.h>  // for SIGABRT
@@ -18,9 +20,8 @@ signed long cn_stack_depth;
 
 signed long nr_owned_predicates;
 
-static signed long WILDCARD_DEPTH = INT_MAX - 1;
-
 static signed long UNMAPPED_VAL = INT_MIN + 1;
+static signed long WILDCARD_DEPTH = INT_MIN + 2;
 
 static allocator bump_alloc = (allocator){
     .malloc = &cn_bump_malloc, .calloc = &cn_bump_calloc, .free = &cn_bump_free};
@@ -219,6 +220,37 @@ void ghost_stack_depth_decr(void) {
   // cn_printf(CN_LOGGING_INFO, "\n");
 }
 
+/* TODO: DAVID
+1. Uncomment + add max value lookups to first 2 functions
+2. Delete the 2 functions after that (old implementations)
+*/
+
+// void cn_postcondition_leak_check(void) {
+//   signed long max_depth_in_ghost_state =
+//       /* get_max_value(cn_ownership_global_ghost_state) */ INT_MAX - 1;  // TODO: Change
+//   if (max_depth_in_ghost_state > cn_stack_depth) {
+//     print_error_msg_info(error_msg_info);
+//     // XXX: This appears to print the *hashed* pointer?
+//     cn_printf(CN_LOGGING_ERROR,
+//         "Postcondition leak check failed, ownership leaked for pointer " FMT_PTR "\n",
+//         (uintptr_t)*key);
+//     cn_failure(CN_FAILURE_OWNERSHIP_LEAK, POST);
+//   }
+// }
+//
+// void cn_loop_leak_check(void) {
+//   signed long max_depth_in_ghost_state =
+//       /* get_max_value(cn_ownership_global_ghost_state) */ INT_MAX - 1;  // TODO: Change
+//   if (max_depth_in_ghost_state == cn_stack_depth) {
+//     print_error_msg_info(error_msg_info);
+//     // XXX: This appears to print the *hashed* pointer?
+//     cn_printf(CN_LOGGING_ERROR,
+//         "Loop invariant leak check failed, ownership leaked for pointer " FMT_PTR "\n",
+//         (uintptr_t)*key);
+//     cn_failure(CN_FAILURE_OWNERSHIP_LEAK, LOOP);
+//   }
+// }
+
 void cn_postcondition_leak_check(void) {
   // leak checking
   hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
@@ -256,6 +288,8 @@ void cn_loop_leak_check(void) {
     }
   }
 }
+
+/* / TODO: DAVID */
 
 struct loop_ownership* initialise_loop_ownership_state(void) {
   struct loop_ownership* loop_ownership =

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -1,5 +1,3 @@
-#include <_inttypes.h>
-
 #include <inttypes.h>
 #include <limits.h>
 #include <signal.h>  // for SIGABRT

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -265,19 +265,6 @@ void cn_loop_leak_check(void) {
   }
 }
 
-void cn_loop_put_back_ownership(void) {
-  hash_table_iterator it = ht_iterator(cn_ownership_global_ghost_state);
-
-  while (ht_next(&it)) {
-    int64_t* key = it.key;
-    int* depth = it.value;
-    /* Bump down everything that was bumped up in loop invariant */
-    if (*depth == cn_stack_depth - 1) {
-      ownership_ghost_state_set(key, cn_stack_depth);
-    }
-  }
-}
-
 struct loop_ownership* initialise_loop_ownership_state(void) {
   struct loop_ownership* loop_ownership =
       bump_alloc.malloc(sizeof(struct loop_ownership));
@@ -295,7 +282,7 @@ void cn_add_to_loop_ownership_state(
   }
 }
 
-void cn_loop_put_back_ownership_new(struct loop_ownership* loop_ownership) {
+void cn_loop_put_back_ownership(struct loop_ownership* loop_ownership) {
   for (int i = 0; i < loop_ownership->arr_size; i++) {
     int64_t address_key = loop_ownership->owned_loop_addrs[i];
     ownership_ghost_state_set(&address_key, cn_stack_depth);


### PR DESCRIPTION
We remove all instances in Fulminate's runtime library of iterating over the entire global ownership ghost state. This involved changing the logic of ownership checking at loop invariants, where we now track the addresses we take ownership for in a loop-local ghost array so we can put back ownership for them manually at the end of the loop invariant. We also no longer bump the global ghost stack depth at the start/end of loop invariants, changing the implementation of dynamic `Owned` for loops.

This should make Fulminate amenable to @pqwy 's more efficient data structure, which can do fast max value lookups.