### PR TITLE
Fix spec for memcmp

### DIFF
--- a/tests/cn_vip_testsuite/cn_lemmas.h
+++ b/tests/cn_vip_testsuite/cn_lemmas.h
@@ -1,13 +1,19 @@
 [[cerb::byte]] typedef unsigned char byte;
 
 /*@
-function [rec] (boolean) array_bits_eq(map<u64, byte> arr1, map<u64, byte> arr2, u64 end) {
+function [rec] (boolean) byte_array_init(map<u64, byte> arr1, map<u64, byte> arr2, u64 end) {
+    let end1 = end - 1u64;
+    let b1 = arr1[end1];
+    let b2 = arr2[end1];
+    end == 0u64 || is_some(b1) && is_some(b1) && byte_array_bits_eq(arr1, arr2, end1)
+}
+
+function [rec] (boolean) byte_array_bits_eq(map<u64, byte> arr1, map<u64, byte> arr2, u64 end) {
     let end1 = end - 1u64;
     let b1 = arr1[end1];
     let b2 = arr2[end1];
     end == 0u64 ||
-        is_some(b1) && is_some(b1) &&
-        ((u8) get_opt(b1)) == ((u8) get_opt(b2)) && array_bits_eq(arr1, arr2, end1)
+        ((u8) get_opt(b1)) == ((u8) get_opt(b2)) && byte_array_bits_eq(arr1, arr2, end1)
 }
 @*/
 
@@ -37,12 +43,13 @@ requires
     (u64) dest <= (u64) dest + n;
     take Src = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift(src, i)) };
     take Dest = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift(dest, i)) };
+    byte_array_init(Src, Dest, n);
 
 ensures
     take SrcR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift(src, i)) };
     take DestR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift(dest, i)) };
     Src == SrcR; Dest == DestR;
-    let bits_eq = array_bits_eq(Src, Dest, n);
+    let bits_eq = byte_array_bits_eq(Src, Dest, n);
     (return == 0i32 implies bits_eq) && (return != 0i32 implies !bits_eq);
 @*/
 
@@ -55,7 +62,7 @@ ensures
 @*/
 
 /*@
-lemma array_bits_eq_8(pointer dest, pointer src, u64 n)
+lemma byte_array_init_8(pointer dest, pointer src, u64 n)
 requires
     n == sizeof<int*>;
     take Src = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(src, i)) };
@@ -64,9 +71,20 @@ ensures
     take SrcR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(src, i)) };
     take DestR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(dest, i)) };
     Src == SrcR; Dest == DestR;
-    let arr_eq = array_bits_eq(Src, Dest, n);
-    let each_eq = each (u64 i: 0,7;
-        is_some(Src[i]) && is_some(Dest[i]) &&
-        (u8) get_opt(Src[i]) == (u8) get_opt(Dest[i]) );
+    let all_init = byte_array_init(Src, Dest, n);
+    let each_init = each (u64 i: 0,7; is_some(Src[i]) && is_some(Dest[i]));
+    (all_init implies each_init) && (each_init implies all_init);
+
+lemma byte_array_bits_eq_8(pointer dest, pointer src, u64 n)
+requires
+    n == sizeof<int*>;
+    take Src = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(src, i)) };
+    take Dest = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(dest, i)) };
+ensures
+    take SrcR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(src, i)) };
+    take DestR = each (u64 i; 0u64 <= i && i < n ) { RW(array_shift<byte>(dest, i)) };
+    Src == SrcR; Dest == DestR;
+    let arr_eq = byte_array_bits_eq(Src, Dest, n);
+    let each_eq = each (u64 i: 0,7; (u8) get_opt(Src[i]) == (u8) get_opt(Dest[i]) );
     (arr_eq implies each_eq) && (each_eq implies arr_eq);
 @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c
@@ -15,8 +15,9 @@ int main()
   uintptr_t j = (uintptr_t)q;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
-  /*CN_VIP*//*@ apply array_bits_eq_8(&p, &q, sizeof<int*>); @*/
+  /*CN_VIP*//*@ apply byte_array_bits_eq_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/
   if (result == 0) {

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:28:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:29:5: error: Missing resource for writing
     *r=11;  // is this free of UB?
     ~~^~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c
@@ -15,6 +15,7 @@ int main()
   uintptr_t j = (uintptr_t)q;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c.no_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:19:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c
@@ -15,8 +15,9 @@ int main()
   uintptr_t j = (uintptr_t)q;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
-  /*CN_VIP*//*@ apply array_bits_eq_8(&p, &q, sizeof<int*>); @*/
+  /*CN_VIP*//*@ apply byte_array_bits_eq_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/
   if (result == 0) {

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:28:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:29:5: error: Missing resource for writing
     *r=11;  // CN VIP UB if ¬ANNOT
     ~~^~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.with_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:29:7: error: `&copy_alloc_id((u64)&&x[1'u64], value)[(u64)(0'i32 - 1'i32)]` out of bounds
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:30:7: error: `&copy_alloc_id((u64)&&x[1'u64], value)[(u64)(0'i32 - 1'i32)]` out of bounds
     r=r-1;  // CN VIP UB if  ANNOT
       ~^~ 
 (UB missing short message): UB_CERB004_unspecified__pointer_add

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
@@ -20,6 +20,7 @@ int main() {
   int *q = &y;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:24:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:27:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:28:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:24:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
@@ -20,6 +20,7 @@ int main() {
   int *q = &y;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:24:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:27:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:28:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:24:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
@@ -22,6 +22,7 @@ int main()
   int *q = &y;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:29:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:30:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
@@ -22,6 +22,7 @@ int main()
   int *q = &y;
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:29:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:30:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c
+++ b/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c
@@ -9,6 +9,7 @@ int main() {
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:10:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:13:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:14:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:16:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:17:5: error: Missing resource for writing
     *p = 11;  // CN VIP UB
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c
+++ b/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c
@@ -11,6 +11,7 @@ int main()
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:12:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:15:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:16:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:18:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:19:5: error: Missing resource for writing
     *p = 11;  // CN_VIP UB
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
@@ -24,6 +24,7 @@ int main() {
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:31:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:32:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
@@ -24,6 +24,7 @@ int main()
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&p, (byte*)&q, sizeof(p));
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ from_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:31:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:32:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
@@ -23,6 +23,7 @@ int main()
   //CN_VIP printf("Addresses: p=%p\n",(void*)p);
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i4); @*/
+  /*CN_VIP*//*@ apply byte_array_init_8(&i1, &i4, sizeof<int*>); @*/
   /*CN_VIP*/int result = _memcmp((byte*)&i1, (byte*)&i4, sizeof(i1));
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i1); @*/
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i4); @*/

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.no_annot
@@ -2,11 +2,11 @@ return code: 1
 tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:30:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:31:5: error: Missing resource for writing
     *q = 11;  // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.with_annot
@@ -2,7 +2,7 @@ return code: 0
 tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass


### PR DESCRIPTION
From a verification perspective, memcmp only really makes sense when its argument arrays are initialised in the compared regions, and so this commit adjusts the precondition to require that, and updates the tests with an extra lemma due to the lack of automatic unfolding for pure functions.