### PR TITLE
[CN-exec] dynamic allocation of loop ownership state

### DIFF
--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -148,11 +148,6 @@ typedef struct cn_alloc_id {
 
 typedef hash_table cn_map;
 
-struct loop_ownership {
-  uintptr_t *owned_loop_addrs;
-  signed long arr_size;
-};
-
 void initialise_ownership_ghost_state(void);
 void free_ownership_ghost_state(void);
 void initialise_ghost_stack_depth(void);


### PR DESCRIPTION
Tracks addresses as a list of segments, and opportunistically coalesces blocks which are extended piecewise.

Future work: coalesce better.

Fixes #321