### PR TITLE
Update Docker test CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,4 +107,4 @@ jobs:
     - name: Run CI tests
       run: |
         docker pull ${{env.CN_IMAGE_ID}}:release-${{ matrix.os }}
-        docker run -v $PWD:/work -w /work ${{env.CN_IMAGE_ID}}:release-${{ matrix.os }} bash tests/run-cn.sh
+        docker run -v $PWD:/work -w /work ${{env.CN_IMAGE_ID}}:release-${{ matrix.os }} tests/diff-prog.py cn tests/cn/verify.json

--- a/tests/run-cn.sh
+++ b/tests/run-cn.sh
@@ -38,7 +38,10 @@ function exits_with_code() {
   local -a expected_exit_codes=$3
 
   printf "[%s]...\n" "$file"
-  timeout 60 "${action}" "$file"
+  # ${action} can be either "cn verify" or "make -C"
+  # both must be split as words intentionally
+  # shellcheck disable=SC2086
+  timeout 60 ${action} "$file"
   local result=$?
 
   for code in "${expected_exit_codes[@]}"; do


### PR DESCRIPTION
The docker test CI used to use a deprecated script; this commit changes it to use diff-prog like the other CI. It also updates the deprecated script to intentionally split the ${action} word.