### PR TITLE
[CN-exec] Introduce mode for switching between source/output locations 

### DIFF
--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -95,6 +95,7 @@ let generate_executable_specs
       with_testing
       run
       no_debug_info
+      exec_c_locs_mode
       experimental_ownership_stack_mode
       mktemp
       print_steps
@@ -136,7 +137,8 @@ let generate_executable_specs
     ~magic_comment_char_dollar
     ~allow_split_magic_comments (* Callbacks *)
     ~save_cpp:(Some pp_file)
-    ~disable_linemarkers:true
+    ~disable_linemarkers:exec_c_locs_mode
+      (* If output locations requested, disable linemarkers in preproc step *)
     ~skip_label_inlining:true
     ~handle_error
     ~f:(fun ~cabs_tunit ~prog5 ~ail_prog ~statement_locs:_ ~paused:_ ->
@@ -156,6 +158,7 @@ let generate_executable_specs
                 ~without_ownership_checking
                 ~without_loop_invariants
                 ~with_loop_leak_checks
+                ~exec_c_locs_mode
                 ~experimental_ownership_stack_mode
                 ~with_testing
                 ~skip_and_only:(skip, only)
@@ -265,6 +268,14 @@ module Flags = struct
     Arg.(value & flag & info [ "no-debug-info" ] ~doc)
 
 
+  let exec_c_locs_mode =
+    let doc =
+      "At errors, report the location in the Fulminated output, not the source. This \
+       flag needs to be enabled for lldb to be usable on the instrumented binary."
+    in
+    Arg.(value & flag & info [ "exec-c-locs-mode" ] ~doc)
+
+
   let experimental_ownership_stack_mode =
     let doc =
       "(experimental) Record (and report, in case of ownership error) the source \
@@ -307,6 +318,7 @@ let cmd =
         (Term.product Flags.with_test_gen Flags.with_testing)
     $ Flags.run
     $ Flags.no_debug_info
+    $ Flags.exec_c_locs_mode
     $ Flags.experimental_ownership_stack_mode
     $ Flags.mktemp
     $ Flags.print_steps

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -18,7 +18,8 @@ let run_seq_tests
       allow_split_magic_comments
       (* Executable spec *)
         without_ownership_checking
-      (* without_loop_invariants *)
+      exec_c_locs_mode
+      experimental_ownership_stack_mode
       (* Test Generation *)
         output_dir
       print_steps
@@ -70,6 +71,8 @@ let run_seq_tests
              ~without_ownership_checking
              ~without_loop_invariants:true
              ~with_loop_leak_checks:false
+             ~exec_c_locs_mode
+             ~experimental_ownership_stack_mode
              ~with_testing:true
              ~skip_and_only:([], [])
              filename
@@ -149,6 +152,8 @@ let cmd =
     $ Common.Flags.magic_comment_char_dollar
     $ Common.Flags.allow_split_magic_comments
     $ Instrument.Flags.without_ownership_checking
+    $ Instrument.Flags.exec_c_locs_mode
+    $ Instrument.Flags.experimental_ownership_stack_mode
     $ Flags.output_dir
     $ Flags.print_steps
     $ Flags.gen_num_calls

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -18,6 +18,8 @@ let run_tests
       allow_split_magic_comments
       (* Executable spec *)
         without_ownership_checking
+      exec_c_locs_mode
+      experimental_ownership_stack_mode
       (* without_loop_invariants *)
       (* Test Generation *)
         print_steps
@@ -169,6 +171,8 @@ let run_tests
            ~without_ownership_checking
            ~without_loop_invariants:true
            ~with_loop_leak_checks:false
+           ~exec_c_locs_mode
+           ~experimental_ownership_stack_mode
            ~with_testing:true
            ~skip_and_only:(skip_fulminate, only_fulminate)
            filename
@@ -593,6 +597,8 @@ let cmd =
     $ Common.Flags.magic_comment_char_dollar
     $ Common.Flags.allow_split_magic_comments
     $ Instrument.Flags.without_ownership_checking
+    $ Instrument.Flags.exec_c_locs_mode
+    $ Instrument.Flags.experimental_ownership_stack_mode
     $ Flags.print_steps
     $ Flags.output_dir
     $ Flags.only

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -298,12 +298,12 @@ let get_instrumented_filename filename =
 let get_filename_with_prefix output_dir filename = Filename.concat output_dir filename
 
 let main
-      ?(without_ownership_checking = false)
-      ?(without_loop_invariants = false)
-      ?(with_loop_leak_checks = false)
-      ?(exec_c_locs_mode = false)
-      ?(experimental_ownership_stack_mode = false)
-      ?(with_testing = false)
+      ~without_ownership_checking
+      ~without_loop_invariants
+      ~with_loop_leak_checks
+      ~exec_c_locs_mode
+      ~experimental_ownership_stack_mode
+      ~with_testing
       ~skip_and_only
       filename
       cc

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -301,6 +301,7 @@ let main
       ?(without_ownership_checking = false)
       ?(without_loop_invariants = false)
       ?(with_loop_leak_checks = false)
+      ?(exec_c_locs_mode = false)
       ?(experimental_ownership_stack_mode = false)
       ?(with_testing = false)
       ~skip_and_only
@@ -476,7 +477,11 @@ let main
       (* XXX: ONLY IF THERE IS A MAIN *)
       (* Inject ownership init function calls and mapping and unmapping of globals into provided main function *)
       let global_ownership_init_pair =
-        generate_global_assignments ~experimental_ownership_stack_mode sigm prog5
+        generate_global_assignments
+          ~exec_c_locs_mode
+          ~experimental_ownership_stack_mode
+          sigm
+          prog5
       in
       global_ownership_init_pair @ executable_spec.pre_post)
   in

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -9,12 +9,12 @@ module Utils = Utils
 val get_instrumented_filename : string -> string
 
 val main
-  :  ?without_ownership_checking:bool ->
-  ?without_loop_invariants:bool ->
-  ?with_loop_leak_checks:bool ->
-  ?exec_c_locs_mode:bool ->
-  ?experimental_ownership_stack_mode:bool ->
-  ?with_testing:bool ->
+  :  without_ownership_checking:bool ->
+  without_loop_invariants:bool ->
+  with_loop_leak_checks:bool ->
+  exec_c_locs_mode:bool ->
+  experimental_ownership_stack_mode:bool ->
+  with_testing:bool ->
   skip_and_only:string list * string list ->
   String.t ->
   String.t ->

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -12,6 +12,7 @@ val main
   :  ?without_ownership_checking:bool ->
   ?without_loop_invariants:bool ->
   ?with_loop_leak_checks:bool ->
+  ?exec_c_locs_mode:bool ->
   ?experimental_ownership_stack_mode:bool ->
   ?with_testing:bool ->
   skip_and_only:string list * string list ->

--- a/lib/fulminate/internal.mli
+++ b/lib/fulminate/internal.mli
@@ -82,7 +82,8 @@ val generate_conversion_and_equality_functions
 val has_main : GenTypes.genTypeCategory AilSyntax.sigma -> bool
 
 val generate_global_assignments
-  :  ?experimental_ownership_stack_mode:bool ->
+  :  ?exec_c_locs_mode:bool ->
+  ?experimental_ownership_stack_mode:bool ->
   GenTypes.genTypeCategory AilSyntax.sigma ->
   unit Mucore.file ->
   (Sym.t * (string list * string list)) list

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -146,6 +146,7 @@ typedef hash_table cn_map;
 void initialise_ownership_ghost_state(void);
 void free_ownership_ghost_state(void);
 void initialise_ghost_stack_depth(void);
+void initialise_exec_c_locs_mode(bool flag);
 void initialise_ownership_stack_mode(bool flag);
 signed long get_cn_stack_depth(void);
 void ghost_stack_depth_incr(void);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -19,6 +19,7 @@ signed long cn_stack_depth;
 
 signed long nr_owned_predicates;
 
+_Bool exec_c_locs_mode;
 _Bool ownership_stack_mode;
 
 static signed long UNMAPPED_VAL = -1;
@@ -33,6 +34,7 @@ void reset_fulminate(void) {
   reset_error_msg_info();
   initialise_ownership_ghost_state();
   initialise_ghost_stack_depth();
+  initialise_exec_c_locs_mode(0);
   initialise_ownership_stack_mode(0);
 }
 
@@ -90,14 +92,20 @@ enum cn_trace_granularity set_cn_trace_granularity(
 }
 
 void print_error_msg_info_single(struct cn_error_message_info* info) {
-  cn_printf(CN_LOGGING_ERROR,
-      "function %s, file %s, line %d\n",
-      info->function_name,
-      info->file_name,
-      info->line_number);
-  if (info->cn_source_loc) {
-    cn_printf(
-        CN_LOGGING_ERROR, "original source location: \n%s\n\n", info->cn_source_loc);
+  if (exec_c_locs_mode) {
+    cn_printf(CN_LOGGING_ERROR,
+        "function %s, file %s, line %d\n",
+        info->function_name,
+        info->file_name,
+        info->line_number);
+  } else {
+    if (info->cn_source_loc) {
+      cn_printf(
+          CN_LOGGING_ERROR, "original source location: \n%s\n\n", info->cn_source_loc);
+    } else {
+      cn_printf(CN_LOGGING_ERROR,
+          "no source location found (try running with --exec-c-locs-mode enabled)")
+    }
   }
 }
 
@@ -221,6 +229,10 @@ void free_ownership_ghost_state(void) {
 
 void initialise_ghost_stack_depth(void) {
   cn_stack_depth = 0;
+}
+
+void initialise_exec_c_locs_mode(_Bool flag) {
+  exec_c_locs_mode = flag;
 }
 
 void initialise_ownership_stack_mode(_Bool flag) {


### PR DESCRIPTION
Add CLI mode `exec-c-locs-mode` for running the preprocessor with/without linemarkers during the preprocessing step on entry to Fulminate.

Enabling linemarkers (now the default) during the preproc step allows the specification source locations to be reported, which is useful and necessary for the experimental stack ownership mode (see #329) to work.

Meanwhile, disabling linemarkers during this step provides the correct locations in the Fulminate output, and the binary can be run through lldb to step through the instrumented C line-by-line. This is done when `exec-c-locs-mode` is set.

This mode allows the user to switch between the two.  

~**TODO:** Update Bennet if necessary.~