### PR TITLE
[CI] Upgrade Ubuntu from 22.04 to 24.04

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
         version: [4.14.1]
 
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -15,7 +15,7 @@ jobs:
 
     name: OUnit and QCheck tests
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout CN

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         version: [4.14.1]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-benchmark.yml.disabled
+++ b/.github/workflows/pr-benchmark.yml.disabled
@@ -28,7 +28,7 @@ jobs:
         version: [4.14.1]
 
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -25,7 +25,7 @@ jobs:
         # version: [4.12.0, 4.14.1]
         version: [4.14.1]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         version: [5.2.0]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ jobs:
 
     name: OCamlFormat
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout CN
@@ -59,7 +59,7 @@ jobs:
   clang-format:
     name: ClangFormat
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout CN
@@ -84,7 +84,7 @@ jobs:
 
     name: C compiler warnings
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout CN
@@ -117,7 +117,7 @@ jobs:
   shellcheck:
     name: ShellCheck
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout CN


### PR DESCRIPTION
The workflows that install CN and use 22.04 have now broken due to the following.
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved cn.~dev  (no changes)
Error:  The compilation of cn.~dev failed at "dune subst".

#=== ERROR while compiling cn.~dev ============================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.1 | pinned(git+file:///home/runner/work/cn/cn#HEAD#c37d4700)
# path                 ~/.opam/4.14.1/.opam-switch/build/cn.~dev
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune subst
# exit-code            1
# env-file             ~/.opam/log/cn-2319-f4b388.env
# output-file          ~/.opam/log/cn-2319-f4b388.out
### output ###
# dune: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by dune)
# dune: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by dune)
```
The testing CI already used 24.04, so this PR updates the rest of the workflows.