### PR TITLE
remove special treatment of two stdlib functions in Mucore

### DIFF
--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -352,6 +352,11 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
             (IT.not_ (IT.eq_ (x, IT.int_lit_ 0 (IT.get_bt x) here) here) here)
             loc)
      | _ -> do_wrapI loc ct x)
+  | PEcall (Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")), [ pe_ct; pe ]) ->
+    let@ ct_it = self var_map pe_ct in
+    let@ ct = must_be_ct_const loc ct_it in
+    let@ x = self var_map pe in
+    do_wrapI loc ct x
   | PEcall (f, pes) ->
     let@ xs = ListM.mapM (self var_map) pes in
     (match (f, xs) with
@@ -410,9 +415,6 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
        return (IT.arith_binop bop (e2, e3) loc)
      | Cspecified, [ x ] -> return x
      | _ -> unsupported "pure-expression type" !^"")
-  | PEcatch_exceptional_condition (act, pe) ->
-    let@ x = self var_map pe in
-    do_wrapI loc act.ct x
   | PEbounded_binop (bk, op, pe_x, pe_y) ->
     let@ x = self var_map pe_x in
     let@ y = self var_map pe_y in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -862,6 +862,36 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
     let has = List.length pes in
     let err = WT.Number_arguments { type_ = `Other; has; expect = 2 } in
     fail (fun _ -> { loc; msg = WellTyped err })
+  | PEcall (Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")), [ pe_ct; pe ]) ->
+    let@ ct = check_pexpr_good_ctype_const path_cs pe_ct in
+    let@ () = WellTyped.ensure_bits_type loc (Mu.bt_of_pexpr pe) in
+    let@ () = WellTyped.ensure_base_type loc ~expect (Mu.bt_of_pexpr pe) in
+    let@ arg = check_pexpr path_cs pe in
+    let bt = Memory.bt_of_sct ct in
+    let@ () = WellTyped.ensure_bits_type loc bt in
+    let ity = Option.get (Sctypes.is_integer_type ct) in
+    let@ provable = provable loc in
+    (match provable (LC.T (is_representable_integer arg ity)) with
+     | `True -> return arg
+     | `False ->
+       let@ model = model () in
+       let ub = CF.Undefined.UB036_exceptional_condition in
+       fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } }))
+  | PEcall (Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")), pes) ->
+    let has = List.length pes in
+    let err = WT.Number_arguments { type_ = `Other; has; expect = 2 } in
+    fail (fun _ -> { loc; msg = WellTyped err })
+  | PEcall (Sym (Symbol (_, _, SD_Id "is_representable_integer")), [ pe; pe_ct ]) ->
+    let@ ct = check_pexpr_good_ctype_const path_cs pe_ct in
+    let@ () = WellTyped.ensure_base_type loc ~expect Bool in
+    let@ () = WellTyped.ensure_bits_type loc (Mu.bt_of_pexpr pe) in
+    let ity = Option.get (Sctypes.is_integer_type ct) in
+    let@ arg = check_pexpr path_cs pe in
+    return (is_representable_integer arg ity)
+  | PEcall (Sym (Symbol (_, _, SD_Id "is_representable_integer")), pes) ->
+    let has = List.length pes in
+    let err = WT.Number_arguments { type_ = `Other; has; expect = 2 } in
+    fail (fun _ -> { loc; msg = WellTyped err })
   | PEcall (f, pes) ->
     (match (f, pes) with
      | Sym (Symbol (_, _, SD_Id "wrapI")), [ e1; e2 ] ->
@@ -1055,27 +1085,6 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
         fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } })
     in
     return direct_x
-  | PEcatch_exceptional_condition (act, pe) ->
-    let@ () = WellTyped.check_ct act.loc act.ct in
-    let@ () = WellTyped.ensure_bits_type loc (Mu.bt_of_pexpr pe) in
-    let@ arg = check_pexpr path_cs pe in
-    let bt = Memory.bt_of_sct act.ct in
-    let@ () = WellTyped.ensure_bits_type loc bt in
-    let ity = Option.get (Sctypes.is_integer_type act.ct) in
-    let@ provable = provable loc in
-    (match provable (LC.T (is_representable_integer arg ity)) with
-     | `True -> return arg
-     | `False ->
-       let@ model = model () in
-       let ub = CF.Undefined.UB036_exceptional_condition in
-       fail (fun ctxt -> { loc; msg = Undefined_behaviour { ub; ctxt; model } }))
-  | PEis_representable_integer (pe, act) ->
-    let@ () = WellTyped.check_ct act.loc act.ct in
-    let@ () = WellTyped.ensure_base_type loc ~expect Bool in
-    let@ () = WellTyped.ensure_bits_type loc (Mu.bt_of_pexpr pe) in
-    let ity = Option.get (Sctypes.is_integer_type act.ct) in
-    let@ arg = check_pexpr path_cs pe in
-    return (is_representable_integer arg ity)
   | PEif (pe, e1, e2) ->
     let@ () = WellTyped.ensure_base_type loc ~expect (Mu.bt_of_pexpr e1) in
     let@ () = WellTyped.ensure_base_type loc ~expect (Mu.bt_of_pexpr e2) in

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -269,28 +269,6 @@ let rec n_pexpr ~inherit_loc loc (Pexpr (annots, bty, pe)) : unit Mucore.pexpr =
     annotate (PEbounded_binop (Bound_Except act, iop, arg1, arg2))
   | PEcall (sym1, args) ->
     (match (sym1, args) with
-     (* | Sym (Symbol (_, _, SD_Id "wrapI")), [ arg1; arg2 ] -> *)
-     (*   let ct = ensure_pexpr_ctype loc !^"PEcall(wrapI,_): not a constant ctype" arg1 in *)
-     (*   let arg2 = n_pexpr loc arg2 in *)
-     (*   annotate (PEwrapI (ct, arg2)) *)
-     | Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")), [ arg1; arg2 ] ->
-       let ct =
-         ensure_pexpr_ctype
-           loc
-           !^"PEcall(catch_exceptional_condition,_): not a constant ctype"
-           arg1
-       in
-       let arg2 = n_pexpr loc arg2 in
-       annotate (PEcatch_exceptional_condition (ct, arg2))
-     | Sym (Symbol (_, _, SD_Id "is_representable_integer")), [ arg1; arg2 ] ->
-       let arg1 = n_pexpr loc arg1 in
-       let ct =
-         ensure_pexpr_ctype
-           loc
-           !^"PEcall(is_representable_integer,_): not a constant ctype"
-           arg2
-       in
-       annotate (PEis_representable_integer (arg1, ct))
      | Sym (Symbol (_, _, SD_Id "all_values_representable_in")), [ arg1; arg2 ] ->
        let ct1 =
          ensure_pexpr_ctype

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -76,7 +76,6 @@ type 'TY pexpr_ =
   | PEnot of 'TY pexpr
   | PEop of Cerb_frontend.Core.binop * 'TY pexpr * 'TY pexpr
   | PEconv_int of 'TY pexpr * 'TY pexpr
-  | PEcatch_exceptional_condition of act * 'TY pexpr
   | PEstruct of Sym.t * (Id.t * 'TY pexpr) list
   | PEunion of Sym.t * Id.t * 'TY pexpr
   | PEcfunction of 'TY pexpr
@@ -84,7 +83,6 @@ type 'TY pexpr_ =
   | PEcall of Sym.t generic_name * 'TY pexpr list
   | PElet of 'TY pattern * 'TY pexpr * 'TY pexpr
   | PEif of 'TY pexpr * 'TY pexpr * 'TY pexpr
-  | PEis_representable_integer of 'TY pexpr * act
   | PEare_compatible of 'TY pexpr * 'TY pexpr
 
 and 'TY pexpr = Pexpr of Locations.t * Cerb_frontend.Annot.annot list * 'TY * 'TY pexpr_

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -81,7 +81,6 @@ type 'TY pexpr_ =
   | PEnot of 'TY pexpr
   | PEop of Cerb_frontend.Core.binop * 'TY pexpr * 'TY pexpr
   | PEconv_int of 'TY pexpr * 'TY pexpr
-  | PEcatch_exceptional_condition of act * 'TY pexpr
   | PEstruct of Sym.t * (Id.t * 'TY pexpr) list
   | PEunion of Sym.t * Id.t * 'TY pexpr
   | PEcfunction of 'TY pexpr
@@ -89,7 +88,6 @@ type 'TY pexpr_ =
   | PEcall of Sym.t generic_name * 'TY pexpr list
   | PElet of 'TY pattern * 'TY pexpr * 'TY pexpr
   | PEif of 'TY pexpr * 'TY pexpr * 'TY pexpr
-  | PEis_representable_integer of 'TY pexpr * act
   | PEare_compatible of 'TY pexpr * 'TY pexpr
 
 and 'TY pexpr = Pexpr of Locations.t * Cerb_frontend.Annot.annot list * 'TY * 'TY pexpr_

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -107,10 +107,8 @@ module Make (Config : CONFIG) = struct
     | PEmemop (_, _)
     | PEnot _ | PEstruct _ | PEunion _ | PEcfunction _ | PEmemberof _ | PEconv_int _
     | PElet _ | PEif _ | PEundef _ | PEerror _ | PEcall _
-    | PEcatch_exceptional_condition (_, _)
     | PEbounded_binop (_, _, _, _)
-    | PEare_compatible _
-    | PEis_representable_integer (_, _) ->
+    | PEare_compatible _ ->
       None
 
 
@@ -345,12 +343,6 @@ module Make (Config : CONFIG) = struct
                            pp_pexpr arg1;
                            pp_pexpr arg2
                          ])
-               | PEcatch_exceptional_condition (act, asym) ->
-                 !^"catch_exceptional_condition"
-                 ^^ Pp.parens (pp_ct act.ct ^^ Pp.comma ^^^ pp_pexpr asym)
-               | PEis_representable_integer (asym, act) ->
-                 !^"is_representable_integer"
-                 ^^ Pp.parens (pp_pexpr asym ^^ Pp.comma ^^^ pp_ct act.ct)
                | PEare_compatible (pe1, pe2) ->
                  !^"are_compatible"
                  ^^ Pp.parens (pp_pexpr pe1 ^^ Pp.comma ^^^ pp_pexpr pe2)

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -951,10 +951,6 @@ and pp_pexpr pp_type (Pexpr (loc, annots, ty, pe)) =
            [ pp_symbol sym; pp_identifier id; pp_pexpr pp_type e ]
        | PEconv_int (e1, e2) ->
          pp_constructor1 "PEconv_int" [ pp_pexpr pp_type e1; pp_pexpr pp_type e2 ]
-       | PEcatch_exceptional_condition (act, e) ->
-         pp_constructor1
-           "PEcatch_exceptional_condition"
-           [ pp_act act; pp_pexpr pp_type e ]
        | PEbounded_binop (kind, op, e1, e2) ->
          pp_constructor1
            "PEbounded_binop"
@@ -963,8 +959,6 @@ and pp_pexpr pp_type (Pexpr (loc, annots, ty, pe)) =
              pp_pexpr pp_type e1;
              pp_pexpr pp_type e2
            ]
-       | PEis_representable_integer (e, act) ->
-         pp_constructor1 "PEis_representable_integer" [ pp_pexpr pp_type e; pp_act act ]
        | PEare_compatible (pe1, pe2) ->
          pp_constructor1 "PEare_compatible" [ pp_pexpr pp_type pe1; pp_pexpr pp_type pe2 ]
        | PEundef (loc, ub) ->

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1704,12 +1704,6 @@ module BaseTyping = struct
         | PEcall (Sym (Symbol (_, _, SD_Id ("conv_int" | "conv_loaded_int"))), pes) ->
           let has = List.length pes in
           fail { loc; msg = Number_arguments { type_ = `Other; has; expect = 2 } }
-        | PEcatch_exceptional_condition (act, pe) ->
-          let@ pe = infer_pexpr pe in
-          return (bt_of_pexpr pe, PEcatch_exceptional_condition (act, pe))
-        | PEis_representable_integer (pe, act) ->
-          let@ pe = infer_pexpr pe in
-          return (Bool, PEis_representable_integer (pe, act))
         | PEnot pe ->
           let@ pe = infer_pexpr pe in
           return (Bool, PEnot pe)
@@ -1735,6 +1729,24 @@ module BaseTyping = struct
               nm_pes
           in
           return (Struct nm, PEstruct (nm, nm_pes))
+        | PEcall
+            ( (Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")) as f),
+              [ pe_ct; pe ] ) ->
+          let@ pe = infer_pexpr pe in
+          let@ pe_ct = check_pexpr CType pe_ct in
+          return (bt_of_pexpr pe, PEcall (f, [ pe_ct; pe ]))
+        | PEcall (Sym (Symbol (_, _, SD_Id "catch_exceptional_condition")), pes) ->
+          let has = List.length pes in
+          fail { loc; msg = Number_arguments { type_ = `Other; has; expect = 2 } }
+        | PEcall
+            ((Sym (Symbol (_, _, SD_Id "is_representable_integer")) as f), [ pe; pe_ct ])
+          ->
+          let@ pe = infer_pexpr pe in
+          let@ pe_ct = check_pexpr CType pe_ct in
+          return (Bool, PEcall (f, [ pe; pe_ct ]))
+        | PEcall (Sym (Symbol (_, _, SD_Id "is_representable_integer")), pes) ->
+          let has = List.length pes in
+          fail { loc; msg = Number_arguments { type_ = `Other; has; expect = 2 } }
         | PEcall (f, pes) ->
           (match (f, pes) with
            | Sym (Symbol (_, _, SD_Id "wrapI")), [ e1; e2 ] ->


### PR DESCRIPTION
`catch_exceptional_condition` and `is_representable_integer`