### PR TITLE
[Fulminate] Fix allocation failure catching

### DIFF
--- a/runtime/libcn/src/cn-executable/fulminate_alloc.c
+++ b/runtime/libcn/src/cn-executable/fulminate_alloc.c
@@ -1,16 +1,27 @@
 #include <stdlib.h>
 
 #include <cn-executable/fulminate_alloc.h>
+#include <cn-executable/utils.h>
 
 allocator fulm_default_alloc =
     (allocator){.malloc = &malloc, .calloc = &calloc, .free = &free};
 
 void *fulm_malloc(size_t size, allocator *alloc) {
-  return alloc->malloc(size);
+  void *res = alloc->malloc(size);
+  if (res == NULL && size != 0) {
+    cn_failure(CN_FAILURE_ALLOC, NON_SPEC);
+  }
+
+  return res;
 }
 
 void *fulm_calloc(size_t count, size_t size, allocator *alloc) {
-  return alloc->calloc(count, size);
+  void *res = alloc->calloc(count, size);
+  if (res == NULL && count != 0 && size != 0) {
+    cn_failure(CN_FAILURE_ALLOC, NON_SPEC);
+  }
+
+  return res;
 }
 
 void fulm_free(void *p, allocator *alloc) {


### PR DESCRIPTION
Regression introduced by #208, which doesn't call `cn_failure(CN_FAILURE_ALLOC, NON_SPEC)` if an allocation failed.