### PR TITLE
[Fulminate] Fix regression introduced by #441

### DIFF
--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -613,9 +613,10 @@ static inline void cn_postfix(void* ptr, size_t size) {
 #define CN_LOAD(LV)                                                                      \
   ({                                                                                     \
     typeof(LV)* __tmp = &(LV);                                                           \
-    update_cn_error_message_info_access_check(0);                                                                                  \
-    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                                  \
-      bool w = c_ownership_check("Load", (uintptr_t) __tmp + __tmp_i, get_cn_stack_depth());                          \
+    update_cn_error_message_info_access_check(0);                                        \
+    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                \
+      bool w =                                                                           \
+          c_ownership_check("Load", (uintptr_t)__tmp + __tmp_i, get_cn_stack_depth());   \
     }                                                                                    \
     cn_load(__tmp, sizeof(typeof(LV)));                                                  \
     *__tmp;                                                                              \
@@ -625,9 +626,10 @@ static inline void cn_postfix(void* ptr, size_t size) {
   ({                                                                                     \
     typeof(LV)* __tmp;                                                                   \
     __tmp = &(LV);                                                                       \
-    update_cn_error_message_info_access_check(0);                                                                                 \
-    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                                  \
-      bool w = c_ownership_check("Store", (uintptr_t) __tmp + __tmp_i, get_cn_stack_depth());                         \
+    update_cn_error_message_info_access_check(0);                                        \
+    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                \
+      bool w =                                                                           \
+          c_ownership_check("Store", (uintptr_t)__tmp + __tmp_i, get_cn_stack_depth());  \
     }                                                                                    \
     cn_store(__tmp, sizeof(typeof(LV)));                                                 \
     *__tmp op## = (X);                                                                   \
@@ -639,9 +641,10 @@ static inline void cn_postfix(void* ptr, size_t size) {
   ({                                                                                     \
     typeof(LV)* __tmp;                                                                   \
     __tmp = &(LV);                                                                       \
-    update_cn_error_message_info_access_check(0);                                                                                 \
-    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                                  \
-      bool w = c_ownership_check("Postfix operation", (uintptr_t) __tmp + __tmp_i, get_cn_stack_depth());             \
+    update_cn_error_message_info_access_check(0);                                        \
+    for (int __tmp_i = 0; __tmp_i < (int)sizeof(typeof(LV)); __tmp_i++) {                \
+      bool w = c_ownership_check(                                                        \
+          "Postfix operation", (uintptr_t)__tmp + __tmp_i, get_cn_stack_depth());        \
     }                                                                                    \
     cn_postfix(__tmp, sizeof(typeof(LV)));                                               \
     (*__tmp) OP;                                                                         \


### PR DESCRIPTION
I named one of the variables in the ownership checking macros `i` and it clashed with a C variable called `i`.

Thanks @moratorium08 for finding the commit that introduced this.