### PR TITLE
[build] relax function type cast error

### DIFF
--- a/runtime/libcn/lib/dune
+++ b/runtime/libcn/lib/dune
@@ -9,7 +9,7 @@
    -Wall
    -fdiagnostics-color=always
    -Werror
-   -Wcast-function-type
+   -Wcast-function-type-mismatch
    -Werror=date-time
    -Werror=implicit-function-declaration
    -Werror=implicit-int


### PR DESCRIPTION
The previously used [`-Wcast-function-type`](https://clang.llvm.org/docs/DiagnosticsReference.html#id178) also enables `-Wcast-function-type-strict` on recent versions of Clang. This does not like casts turning function parameter types to `void *` (which happens throughout `cn-smt/`). This stricter check is only relevant when using CFI.