### PR TITLE
[Fulminate] Fix range map

### DIFF
--- a/runtime/libcn/include/cn-executable/rmap.h
+++ b/runtime/libcn/include/cn-executable/rmap.h
@@ -32,6 +32,7 @@ rmap rmap_create(unsigned int radix, malloc_f malloc, free_f free);
 void rmap_free(rmap);
 rmap_value_opt_t rmap_find(rmap_key_t k, rmap map);
 rmap_range_res_t rmap_find_range(rmap_key_t k0, rmap_key_t k1, rmap map);
+bool rmap_is_fully_covered(rmap_key_t k0, rmap_key_t k1, rmap map);
 void rmap_add(rmap_key_t k0, rmap_key_t k1, rmap_value_t v, rmap map);
 void rmap_remove(rmap_key_t k0, rmap_key_t k1, rmap map);
 

--- a/runtime/libcn/src/cn-executable/rmap.c
+++ b/runtime/libcn/src/cn-executable/rmap.c
@@ -305,6 +305,76 @@ rmap_range_res_t rmap_find_range(rmap_key_t k0, rmap_key_t k1, rmap map) {
   return res_is_empty(&res) ? NONE_RESULT : SOME_RESULT(res.min, res.max);
 }
 
+static bool subtree_is_full(const struct node *node, rmap map) {
+  switch (node->state) {
+    case EMPTY:
+      return false;
+    case LEAF:
+      return true;
+    case INNER:
+      for (size_t i = 0; i < asize(map); i++)
+        if (!subtree_is_full(&node->inner.children[i], map))
+          return false;
+      return true;
+    case SKIP:
+      return false;
+    default:
+      assert(false);
+  }
+}
+
+static bool is_fully_covered(
+    bits_t bits, rmap_key_t k0, rmap_key_t k1, const struct node *node, rmap map) {
+  size_t i0, i1;
+  switch (node->state) {
+    case EMPTY:
+      return false;
+    case LEAF:
+      return true;
+    case INNER:
+      if (complete_range(bits, k0, k1))
+        return subtree_is_full(node, map);
+
+      i0 = key_to_i(bits, map->radix, k0);
+      i1 = key_to_i(bits, map->radix, k1);
+      bits += map->radix;
+      for (size_t i = i0; i <= i1; ++i) {
+        struct node *n = &node->inner.children[i];
+        bool covered;
+        if (i == i0 && i == i1)
+          covered = is_fully_covered(bits, k0, k1, n, map);
+        else if (i == i0)
+          covered = is_fully_covered(bits, k0, max_key(bits, k0), n, map);
+        else if (i == i1)
+          covered = is_fully_covered(bits, min_key(bits, k1), k1, n, map);
+        else
+          covered = subtree_is_full(n, map);
+        if (!covered)
+          return false;
+      }
+      return true;
+    case SKIP: {
+      rmap_key_t path = node->skip.path;
+      bits_t radix = node->skip.radix;
+
+      if (key_to_i(bits, radix, k0) != path || key_to_i(bits, radix, k1) != path)
+        return false;
+      k0 = max_k(k0, min_key(bits + radix, i_to_key(bits, k0, radix, path)));
+      k1 = min_k(k1, max_key(bits + radix, i_to_key(bits, k1, radix, path)));
+      return is_fully_covered(bits + radix, k0, k1, node->skip.child, map);
+    }
+    default:
+      assert(false);
+  }
+}
+
+bool rmap_is_fully_covered(rmap_key_t k0, rmap_key_t k1, rmap map) {
+  if (k0 == k1)
+    return rmap_find(k0, map).defined;
+  assert(k0 < k1);
+  return is_fully_covered(0, k0, k1, &map->root, map);
+}
+
 static inline bool eq_fringe_node(const struct node *n1, const struct node *n2) {
   switch (n1->state) {
     case EMPTY:

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -520,7 +520,9 @@ enum region_owned c_ownership_check(
   uintptr_t address = (uintptr_t)generic_c_ptr;
   rmap_range_res_t res = ownership_ghost_state_extrema(address, size);
 
-  if (res.defined && res.min == res.max) {
+  if (res.defined && res.min == res.max &&
+      rmap_is_fully_covered(
+          address, address + size - 1, cn_ownership_global_ghost_state)) {
     if (res.max == WILDCARD_DEPTH)
       return FULL_WILDCARD;
     else if (res.max == expected_stack_depth)


### PR DESCRIPTION
There are bugs that used to be detected, that are no longer flagged since https://github.com/rems-project/cn/commit/384f4f3bf1d404c54ee57ae389f309c280c315c0.

I am not that familiar with the code or the data structure, so I asked Claude Code and it gave the report below.
This PR includes its implementation of the first "potential fix".

## Claude Code's Report

<ins>__Analysis: Why commit 384f4f3bf broke bug detection__</ins>

__Root Cause: `rmap_find_range` ignores unmapped gaps__

The commit replaced the byte-by-byte hash-table ownership tracking with a range-map (`rmap`). The new `c_ownership_check` has a __fast path__ that short-circuits based on `rmap_find_range`, but that function __silently ignores unmapped bytes__.

__The fast path in `c_ownership_check` (utils.c:507-517)__

```c
 rmap_range_res_t res = ownership_ghost_state_extrema(address, size);
 if (res.defined && res.min == res.max) {
     if (res.max == WILDCARD_DEPTH)      return FULL_WILDCARD;
     else if (res.max == expected_stack_depth) return NO_WILDCARD;  // <-- BUG
 }
```

 __Why `rmap_find_range` is misleading__

In `rmap.c`, `find_range` returns `res_empty` for `EMPTY` nodes, and `res_append` skips empties:

```c
// rmap.c:256 — EMPTY nodes contribute nothing to the result
case EMPTY:  return res_empty;

// rmap.c:33-38 — res_append skips empty results
static inline result_t res_append(const result_t *a, const result_t *b) {
    bool a_ok = !res_is_empty(a), b_ok = !res_is_empty(b);
    if (a_ok && b_ok) return (result_t){min(a,b), max(a,b)};
    return a_ok ? *a : (b_ok ? *b : res_empty);  // gaps silently dropped
}
```

So `rmap_find_range(addr, addr+size-1)` computes min/max __only over bytes present in the rmap__. Unmapped bytes are invisible.

__The failure scenario__

Consider a multi-byte access (e.g., `CN_LOAD` on a struct field) where:
- Some bytes in `[addr, addr+size-1]` are owned at `expected_stack_depth`
- Some bytes are __not in the rmap at all__ (unmapped / not owned)

1. `rmap_find_range` returns `{defined=true, min=D, max=D}` (only sees mapped bytes)
2. Fast path matches: `res.min == res.max == expected_stack_depth`
3. Returns `NO_WILDCARD` — __skips the byte-by-byte loop that would catch the unmapped bytes__
4. `cn_failure` is never called — __ownership violation goes undetected__

__Before the commit (correct behavior)__

`CN_LOAD` looped byte-by-byte, calling `c_ownership_check` for each individual byte:

```c
for (int __tmp_i = 0; __tmp_i < sizeof(typeof(LV)); __tmp_i++) {
    c_ownership_check("Load", (uintptr_t)__tmp + __tmp_i, get_cn_stack_depth());
}
```

Each byte was checked against the hash table individually. An unmapped byte returned `NULL` from `ht_get`, yielding `UNMAPPED_VAL`, which != `expected_stack_depth`, triggering `cn_failure`.

__Confirmation approach (using `--print-seed` / `--seed`)__

To confirm:

1. Build CN at commit `384f4f3bf^` (parent), run with `--print-seed`
2. Capture a seed that finds the bug.
3. Build CN at commit `384f4f3bf`, run with `--seed=<captured_seed>`
4. Observe the bug is no longer detected with the same input.
5. Optionally add `fprintf(stderr, ...)` in c_ownership_check at the fast-path return to confirm it fires where the old code would have called `cn_failure`.

__Potential fix__

The fast path needs to verify that the __entire range is mapped__ before trusting the min/max. Options:

1. __Add `rmap_is_fully_covered(k0, k1, map)`__ — returns true only if every byte in the range has an entry. Use this as a precondition for the fast path.
2. __Remove the fast path__ — always run the byte-by-byte loop. Correct but slower.
3. __Change `rmap_find_range` semantics__ — return `defined=false` when the range has gaps. But this would break `cn_postcondition_leak_check` and `cn_loop_leak_check`, which intentionally scan the full address space and want to ignore gaps.