### PR TITLE
Fix crash when inferring type of PEmemberof expression

### DIFF
--- a/lib/check.ml
+++ b/lib/check.ml
@@ -941,7 +941,14 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
                 Generic (!^"unsupported c-type in sig of:" ^^^ Sym.pp sym)
                 [@alert "-deprecated"]
             })))
-  | PEmemberof _ -> Cerb_debug.error "todo: PEmemberof"
+  | PEmemberof (tag, member, pe) ->
+    let struct_bt = BT.Struct tag in
+    let@ () = WellTyped.ensure_base_type loc ~expect:struct_bt (Mu.bt_of_pexpr pe) in
+    let@ struct_val = check_pexpr path_cs pe in
+    let@ member_sct = Global.get_struct_member_type loc tag member in
+    let member_bt = Memory.bt_of_sct member_sct in
+    let@ () = WellTyped.ensure_base_type loc ~expect member_bt in
+    return (member_ ~member_bt (struct_val, member) loc)
   | PEwrapI (ity, iop, pe1, pe2) ->
     (* in integers, perform this op and round. in bitvector types, just perform
         the op (for all the ops where wrapping is consistent) *)

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1783,11 +1783,13 @@ module BaseTyping = struct
           else
             fail
               { loc; msg = Generic !^"unsupported: union types" } [@alert "-deprecated"]
-        | PEmemberof (_, _, _)
+        | PEmemberof (tag, member, pe) ->
+          let@ pe = infer_pexpr pe in
+          let@ field_ct = get_struct_member_type loc tag member in
+          return (Memory.bt_of_sct field_ct, PEmemberof (tag, member, pe))
         (* reaching these cases should be prevented by the `is_unreachable` used in
            inferring types of PEif *)
-        | PEerror (_, _) ->
-          todo ()
+        | PEerror (_, _) -> todo ()
         | PEundef (loc, ub) ->
           if !Sym.experimental_unions then
             (* in the case of a well-formedness check when labels are not inlined

--- a/tests/cn/comma_operator_struct_field.error.c
+++ b/tests/cn/comma_operator_struct_field.error.c
@@ -1,0 +1,5 @@
+struct {
+  int a;
+} b;
+void f() /*@ accesses b; @*/ { (0, b).a; }
+int g(void) /*@ accesses b; ensures return==b.a; @*/ { return (0, b).a; }

--- a/tests/cn/comma_operator_struct_field.error.c.verify
+++ b/tests/cn/comma_operator_struct_field.error.c.verify
@@ -1,0 +1,3 @@
+return code: 0
+[1/2]: f -- pass
+[2/2]: g -- pass


### PR DESCRIPTION
This happens on things like (0, s).x