### PR TITLE
[Fulminate] Add self-correcting ownership mode

### DIFF
--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -365,8 +365,8 @@ module Flags = struct
 
   let correct_missing_ownership_mode =
     let doc =
-      "Self-correct missing ownership, recording addresses that needed correction and \
-       dumping them at end of test case execution"
+      "Self-correct missing ownership, dumping addresses that needed ownership \
+      during execution"
     in
     Arg.(value & flag & info [ "correct-missing-ownership" ] ~doc)
 end

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -98,6 +98,7 @@ let generate_executable_specs
       run
       no_debug_info
       exec_c_locs_mode
+      correct_missing_ownership_mode
       experimental_ownership_stack_mode
       experimental_unions
       experimental_curly_braces
@@ -168,6 +169,7 @@ let generate_executable_specs
                 ~with_loop_leak_checks
                 ~without_lemma_checks
                 ~exec_c_locs_mode
+                ~correct_missing_ownership_mode
                 ~experimental_ownership_stack_mode
                 ~experimental_curly_braces
                 ~with_testing
@@ -359,6 +361,14 @@ module Flags = struct
   let experimental_curly_braces =
     let doc = "(experimental) Insert curly braces for single-statement control flow" in
     Arg.(value & flag & info [ "insert-curly-braces" ] ~doc)
+
+
+  let correct_missing_ownership_mode =
+    let doc =
+      "Self-correct missing ownership, recording addresses that needed correction and \
+       dumping them at end of test case execution"
+    in
+    Arg.(value & flag & info [ "correct-missing-ownership" ] ~doc)
 end
 
 let cmd =
@@ -398,6 +408,7 @@ let cmd =
     $ Flags.run
     $ Flags.no_debug_info
     $ Flags.exec_c_locs_mode
+    $ Flags.correct_missing_ownership_mode
     $ Flags.experimental_ownership_stack_mode
     $ Flags.experimental_unions
     $ Flags.experimental_curly_braces

--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -365,8 +365,8 @@ module Flags = struct
 
   let correct_missing_ownership_mode =
     let doc =
-      "Self-correct missing ownership, dumping addresses that needed ownership \
-      during execution"
+      "Self-correct missing ownership, dumping addresses that needed ownership during \
+       execution"
     in
     Arg.(value & flag & info [ "correct-missing-ownership" ] ~doc)
 end

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -20,6 +20,7 @@ let run_seq_tests
       (* Executable spec *)
         without_ownership_checking
       exec_c_locs_mode
+      correct_missing_ownership_mode
       experimental_ownership_stack_mode
       (* Test Generation *)
         output_dir
@@ -76,6 +77,7 @@ let run_seq_tests
              ~with_loop_leak_checks:false
              ~without_lemma_checks:false
              ~exec_c_locs_mode
+             ~correct_missing_ownership_mode
              ~experimental_ownership_stack_mode
              ~experimental_curly_braces:false
              ~with_testing:true
@@ -168,6 +170,7 @@ let cmd =
     $ Common.Flags.allow_split_magic_comments
     $ Instrument.Flags.without_ownership_checking
     $ Instrument.Flags.exec_c_locs_mode
+    $ Instrument.Flags.correct_missing_ownership_mode
     $ Instrument.Flags.experimental_ownership_stack_mode
     $ Flags.output_dir
     $ Flags.print_steps

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -20,6 +20,7 @@ let run_tests
       (* Executable spec *)
         without_ownership_checking
       exec_c_locs_mode
+      correct_missing_ownership_mode
       experimental_ownership_stack_mode
       (* without_loop_invariants *)
       (* Test Generation *)
@@ -216,6 +217,7 @@ let run_tests
            ~with_loop_leak_checks:false
            ~without_lemma_checks:false
            ~exec_c_locs_mode
+           ~correct_missing_ownership_mode
            ~experimental_ownership_stack_mode
            ~experimental_curly_braces:false
            ~with_testing:true
@@ -807,6 +809,7 @@ let cmd =
     $ Common.Flags.allow_split_magic_comments
     $ Instrument.Flags.without_ownership_checking
     $ Instrument.Flags.exec_c_locs_mode
+    $ Instrument.Flags.correct_missing_ownership_mode
     $ Instrument.Flags.experimental_ownership_stack_mode
     $ Flags.print_steps
     $ Flags.output_dir

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -539,6 +539,7 @@ let main
       ~with_loop_leak_checks
       ~without_lemma_checks
       ~exec_c_locs_mode
+      ~correct_missing_ownership_mode
       ~experimental_ownership_stack_mode
       ~experimental_curly_braces
       ~with_testing
@@ -753,6 +754,7 @@ let main
       let global_ownership_init_pair =
         generate_global_assignments
           ~exec_c_locs_mode
+          ~correct_missing_ownership_mode
           ~experimental_ownership_stack_mode
           ?max_bump_blocks
           ?bump_block_size

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -14,6 +14,7 @@ val main
   with_loop_leak_checks:bool ->
   without_lemma_checks:bool ->
   exec_c_locs_mode:bool ->
+  correct_missing_ownership_mode:bool ->
   experimental_ownership_stack_mode:bool ->
   experimental_curly_braces:bool ->
   with_testing:bool ->

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -661,6 +661,7 @@ let has_main (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) =
 
 let generate_global_assignments
       ?(exec_c_locs_mode = false)
+      ?(correct_missing_ownership_mode = false)
       ?(experimental_ownership_stack_mode = false)
       ?max_bump_blocks
       ?bump_block_size
@@ -707,6 +708,7 @@ let generate_global_assignments
           @ List.map
               generate_flag_init_stat
               [ (exec_c_locs_mode, "exec_c_locs_mode");
+                (correct_missing_ownership_mode, "correct_missing_ownership");
                 (experimental_ownership_stack_mode, "ownership_stack_mode")
               ]
           @ global_map_stmts_ )

--- a/lib/fulminate/internal.mli
+++ b/lib/fulminate/internal.mli
@@ -98,6 +98,7 @@ val has_main : GenTypes.genTypeCategory AilSyntax.sigma -> bool
 
 val generate_global_assignments
   :  ?exec_c_locs_mode:bool ->
+  ?correct_missing_ownership_mode:bool ->
   ?experimental_ownership_stack_mode:bool ->
   ?max_bump_blocks:int ->
   ?bump_block_size:int ->

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -156,6 +156,7 @@ void initialise_ownership_ghost_state(void);
 void free_ownership_ghost_state(void);
 void initialise_ghost_stack_depth(void);
 void initialise_exec_c_locs_mode(bool flag);
+void initialise_correct_missing_ownership(bool flag);
 void initialise_ownership_stack_mode(bool flag);
 signed long get_cn_stack_depth(void);
 void ghost_stack_depth_incr(void);

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -518,6 +518,29 @@ void cn_get_or_put_ownership(enum spec_mode spec_mode,
   }
 }
 
+void report_and_correct_missing_ownership(
+    int64_t addr, size_t size, int depth, int expected_stack_depth) {
+  if (depth == UNMAPPED_VAL || depth < expected_stack_depth) {
+    assert(size > 0);
+    // report missing ownership
+    if (global_error_msg_info)
+      print_error_msg_info_single(global_error_msg_info);
+    if (size == 1) {
+      cn_printf(CN_LOGGING_INFO,
+          "  ==> " FMT_PTR " missing ownership specification.\n",
+          (unsigned long)addr);
+    } else {
+      cn_printf(CN_LOGGING_INFO,
+          "  ==> " FMT_PTR "..." FMT_PTR " (%d bytes) missing ownership specification.\n",
+          (unsigned long)addr,
+          (unsigned long)addr + size - 1,
+          (int)size);
+    }
+    // correct entry in ghost state
+    ownership_ghost_state_set(addr, size, expected_stack_depth, 0);
+  }
+}
+
 enum region_owned c_ownership_check(
     char* access_kind, void* generic_c_ptr, int size, signed long expected_stack_depth) {
   if (size < 1)
@@ -526,35 +549,45 @@ enum region_owned c_ownership_check(
   uintptr_t address = (uintptr_t)generic_c_ptr;
   rmap_range_res_t res = ownership_ghost_state_extrema(address, size);
 
+  // contiguous range mapped to a single stack depth
   if (res.defined && res.min == res.max) {
     if (res.max == WILDCARD_DEPTH)
       return FULL_WILDCARD;
     else if (res.max == expected_stack_depth)
       return NO_WILDCARD;
+    else if (correct_missing_ownership) {
+      report_and_correct_missing_ownership(address, size, res.max, expected_stack_depth);
+      return NO_WILDCARD;
+    }
   }
 
+  // ownership error handling
   for (size_t addr = address; addr < address + size; addr++) {
     int depth = ownership_ghost_state_get(addr);
     if (depth != expected_stack_depth && depth != WILDCARD_DEPTH) {
-      print_error_msg_info(global_error_msg_info);
-      cn_printf(CN_LOGGING_ERROR, "%s failed.\n", access_kind);
-      if (depth == UNMAPPED_VAL) {
-        cn_printf(CN_LOGGING_ERROR,
-            "  ==> " FMT_PTR "[%d] (" FMT_PTR ") not owned\n",
-            addr,
-            0,
-            addr);
+      if (correct_missing_ownership) {
+        report_and_correct_missing_ownership(addr, 1, depth, expected_stack_depth);
       } else {
-        cn_printf(CN_LOGGING_ERROR,
-            "  ==> " FMT_PTR "[%d] (" FMT_PTR
-            ") not owned at expected function call stack depth %ld\n",
-            addr,
-            0,
-            addr,
-            expected_stack_depth);
-        cn_printf(CN_LOGGING_ERROR, "  ==> (owned at stack depth: %d)\n", depth);
+        print_error_msg_info(global_error_msg_info);
+        cn_printf(CN_LOGGING_ERROR, "%s failed.\n", access_kind);
+        if (depth == UNMAPPED_VAL) {
+          cn_printf(CN_LOGGING_ERROR,
+              "  ==> " FMT_PTR "[%d] (" FMT_PTR ") not owned\n",
+              addr,
+              0,
+              addr);
+        } else {
+          cn_printf(CN_LOGGING_ERROR,
+              "  ==> " FMT_PTR "[%d] (" FMT_PTR
+              ") not owned at expected function call stack depth %ld\n",
+              addr,
+              0,
+              addr,
+              expected_stack_depth);
+          cn_printf(CN_LOGGING_ERROR, "  ==> (owned at stack depth: %d)\n", depth);
+        }
+        cn_failure(CN_FAILURE_CHECK_OWNERSHIP, C_ACCESS);
       }
-      cn_failure(CN_FAILURE_CHECK_OWNERSHIP, C_ACCESS);
     }
   }
 

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -22,6 +22,7 @@ signed long cn_stack_depth;
 signed long nr_owned_predicates;
 
 _Bool exec_c_locs_mode;
+_Bool correct_missing_ownership;
 _Bool ownership_stack_mode;
 
 static signed long UNMAPPED_VAL = -1;
@@ -50,6 +51,7 @@ void fulminate_init(void) {
   initialise_ownership_ghost_state();
   initialise_ghost_stack_depth();
   initialise_exec_c_locs_mode(0);
+  initialise_correct_missing_ownership(0);
   initialise_ownership_stack_mode(0);
 
   fulminate_initialized = true;
@@ -258,6 +260,10 @@ void initialise_ghost_stack_depth(void) {
 
 void initialise_exec_c_locs_mode(_Bool flag) {
   exec_c_locs_mode = flag;
+}
+
+void initialise_correct_missing_ownership(_Bool flag) {
+  correct_missing_ownership = flag;
 }
 
 void initialise_ownership_stack_mode(_Bool flag) {

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -520,8 +520,11 @@ void cn_get_or_put_ownership(enum spec_mode spec_mode,
 
 void report_and_correct_missing_ownership(
     int64_t addr, size_t size, int depth, int expected_stack_depth) {
+  // TODO: switch depth check depending on access kind
+  // see https://github.com/rems-project/cn-private/blob/main/notes/notes124-2025-09-02-fulminate-inferring-ownership.md
   if (depth == UNMAPPED_VAL || depth < expected_stack_depth) {
     assert(size > 0);
+
     // report missing ownership
     if (global_error_msg_info)
       print_error_msg_info_single(global_error_msg_info);
@@ -536,6 +539,7 @@ void report_and_correct_missing_ownership(
           (unsigned long)addr + size - 1,
           (int)size);
     }
+
     // correct entry in ghost state
     ownership_ghost_state_set(addr, size, expected_stack_depth, 0);
   }


### PR DESCRIPTION
Add `--correct-missing-ownership` mode to Fulminate such that it doesn't fail on the missing ownership errors, instead dumping the missing addresses and correcting those values in the ownership ghost state as it goes. It's still in its early stages, and doesn't do anything to help the user _fix_ the ownership specs, like e.g. printing the source location where the missing spec might need to go, or even the source location where the missing ownership was detected.