### PR TITLE
[Fulminate] Add CLI flag to disable CN statement checking

### DIFF
--- a/bin/instrument.ml
+++ b/bin/instrument.ml
@@ -94,6 +94,7 @@ let generate_executable_specs
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       with_testing
       run
       no_debug_info
@@ -168,6 +169,7 @@ let generate_executable_specs
                 ~without_loop_invariants
                 ~with_loop_leak_checks
                 ~without_lemma_checks
+                ~without_inline_statements
                 ~exec_c_locs_mode
                 ~correct_missing_ownership_mode
                 ~experimental_ownership_stack_mode
@@ -272,6 +274,11 @@ module Flags = struct
   let without_lemma_checks =
     let doc = "Disable runtime checking of lemmas" in
     Arg.(value & flag & info [ "without-lemma-checks" ] ~doc)
+
+
+  let without_inline_statements =
+    let doc = "Disable runtime checking of CN statements (incl. assertions)" in
+    Arg.(value & flag & info [ "without-inline-statements" ] ~doc)
 
 
   let with_test_gen =
@@ -402,6 +409,7 @@ let cmd =
     $ Flags.without_loop_invariants
     $ Flags.with_loop_leak_checks
     $ Flags.without_lemma_checks
+    $ Flags.without_inline_statements
     $ Term.map
         (fun (x, y) -> x || y)
         (Term.product Flags.with_test_gen Flags.with_testing)

--- a/bin/seqTest.ml
+++ b/bin/seqTest.ml
@@ -76,6 +76,7 @@ let run_seq_tests
              ~without_loop_invariants:true
              ~with_loop_leak_checks:false
              ~without_lemma_checks:false
+             ~without_inline_statements:false
              ~exec_c_locs_mode
              ~correct_missing_ownership_mode
              ~experimental_ownership_stack_mode

--- a/bin/test.ml
+++ b/bin/test.ml
@@ -216,6 +216,7 @@ let run_tests
            ~without_loop_invariants:true
            ~with_loop_leak_checks:false
            ~without_lemma_checks:false
+           ~without_inline_statements:false
            ~exec_c_locs_mode
            ~correct_missing_ownership_mode
            ~experimental_ownership_stack_mode

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -4749,36 +4749,6 @@ let rec cn_to_ail_lat_2
     prepend_to_precondition ail_executable_spec (b1, ss)
   (* Postcondition *)
   | LAT.I (post, (stats, loops)) ->
-    let ail_statements =
-      if without_inline_statements then
-        []
-      else (
-        let rec remove_duplicates locs stats =
-          match stats with
-          | [] -> []
-          | (loc, s) :: ss ->
-            let loc_equality x y =
-              String.equal
-                (Cerb_location.location_to_string x)
-                (Cerb_location.location_to_string y)
-            in
-            if List.mem loc_equality loc locs then
-              remove_duplicates locs ss
-            else
-              (loc, s) :: remove_duplicates (loc :: locs) ss
-        in
-        let stats = remove_duplicates [] stats in
-        List.map
-          (fun stat_pair ->
-             cn_to_ail_statements
-               ~without_lemma_checks
-               filename
-               dts
-               globals
-               (Some Statement)
-               stat_pair)
-          stats)
-    in
     let return_cn_binding, return_cn_decl =
       match rm_ctype c_return_type with
       | C.Void -> ([], [])
@@ -4803,6 +4773,34 @@ let rec cn_to_ail_lat_2
         in
         ([ return_cn_binding ], [ mk_stmt return_cn_decl ])
     in
+    let ail_statements =
+      let rec remove_duplicates locs stats =
+        match stats with
+        | [] -> []
+        | (loc, s) :: ss ->
+          let loc_equality x y =
+            String.equal
+              (Cerb_location.location_to_string x)
+              (Cerb_location.location_to_string y)
+          in
+          if List.mem loc_equality loc locs then
+            remove_duplicates locs ss
+          else
+            (loc, s) :: remove_duplicates (loc :: locs) ss
+      in
+      let stats = remove_duplicates [] stats in
+      List.map
+        (fun stat_pair ->
+           cn_to_ail_statements
+             ~without_lemma_checks
+             filename
+             dts
+             globals
+             (Some Statement)
+             stat_pair)
+        stats
+    in
+    let ail_statements = if without_inline_statements then [] else ail_statements in
     let ail_loop_invariants =
       List.map
         (cn_to_ail_loop_inv

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -4636,6 +4636,7 @@ let rec cn_to_ail_lat_2
           without_ownership_checking
           with_loop_leak_checks
           without_lemma_checks
+          without_inline_statements
           filename
           dts
           globals
@@ -4659,6 +4660,7 @@ let rec cn_to_ail_lat_2
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         globals
@@ -4709,6 +4711,7 @@ let rec cn_to_ail_lat_2
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         globals
@@ -4735,6 +4738,7 @@ let rec cn_to_ail_lat_2
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         globals
@@ -4745,19 +4749,35 @@ let rec cn_to_ail_lat_2
     prepend_to_precondition ail_executable_spec (b1, ss)
   (* Postcondition *)
   | LAT.I (post, (stats, loops)) ->
-    let rec remove_duplicates locs stats =
-      match stats with
-      | [] -> []
-      | (loc, s) :: ss ->
-        let loc_equality x y =
-          String.equal
-            (Cerb_location.location_to_string x)
-            (Cerb_location.location_to_string y)
+    let ail_statements =
+      if without_inline_statements then
+        []
+      else (
+        let rec remove_duplicates locs stats =
+          match stats with
+          | [] -> []
+          | (loc, s) :: ss ->
+            let loc_equality x y =
+              String.equal
+                (Cerb_location.location_to_string x)
+                (Cerb_location.location_to_string y)
+            in
+            if List.mem loc_equality loc locs then
+              remove_duplicates locs ss
+            else
+              (loc, s) :: remove_duplicates (loc :: locs) ss
         in
-        if List.mem loc_equality loc locs then
-          remove_duplicates locs ss
-        else
-          (loc, s) :: remove_duplicates (loc :: locs) ss
+        let stats = remove_duplicates [] stats in
+        List.map
+          (fun stat_pair ->
+             cn_to_ail_statements
+               ~without_lemma_checks
+               filename
+               dts
+               globals
+               (Some Statement)
+               stat_pair)
+          stats)
     in
     let return_cn_binding, return_cn_decl =
       match rm_ctype c_return_type with
@@ -4782,19 +4802,6 @@ let rec cn_to_ail_lat_2
               ])
         in
         ([ return_cn_binding ], [ mk_stmt return_cn_decl ])
-    in
-    let stats = remove_duplicates [] stats in
-    let ail_statements =
-      List.map
-        (fun stat_pair ->
-           cn_to_ail_statements
-             ~without_lemma_checks
-             filename
-             dts
-             globals
-             (Some Statement)
-             stat_pair)
-        stats
     in
     let ail_loop_invariants =
       List.map
@@ -4838,6 +4845,7 @@ let rec cn_to_ail_pre_post_aux
           without_ownership_checking
           with_loop_leak_checks
           without_lemma_checks
+          without_inline_statements
           filename
           dts
           preds
@@ -4862,6 +4870,7 @@ let rec cn_to_ail_pre_post_aux
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         preds
@@ -4883,6 +4892,7 @@ let rec cn_to_ail_pre_post_aux
          without_ownership_checking
          with_loop_leak_checks
          without_lemma_checks
+         without_inline_statements
          filename
          dts
          preds
@@ -4920,6 +4930,7 @@ let rec cn_to_ail_pre_post_aux
            without_ownership_checking
            with_loop_leak_checks
            without_lemma_checks
+           without_inline_statements
            filename
            dts
            preds
@@ -4937,6 +4948,7 @@ let rec cn_to_ail_pre_post_aux
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         globals
@@ -4967,6 +4979,7 @@ let cn_to_ail_pre_post
       ~without_ownership_checking
       ~with_loop_leak_checks
       ~without_lemma_checks
+      ~without_inline_statements
       filename
       dts
       preds
@@ -4980,6 +4993,7 @@ let cn_to_ail_pre_post
         without_ownership_checking
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         dts
         preds
@@ -5066,6 +5080,7 @@ let cn_to_ail_lemma filename dts preds globals (sym, (loc, lemmat)) =
       ~with_loop_leak_checks:true (* Value doesn't matter - no loop invariants here *)
       ~without_lemma_checks:false
         (* If this function is being called, then lemma checks have been enabled *)
+      ~without_inline_statements:false
       filename
       dts
       preds

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -5080,7 +5080,7 @@ let cn_to_ail_lemma filename dts preds globals (sym, (loc, lemmat)) =
       ~with_loop_leak_checks:true (* Value doesn't matter - no loop invariants here *)
       ~without_lemma_checks:false
         (* If this function is being called, then lemma checks have been enabled *)
-      ~without_inline_statements:false
+      ~without_inline_statements:false (* Lemma has no inline statements anyway *)
       filename
       dts
       preds

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -4773,7 +4773,7 @@ let rec cn_to_ail_lat_2
         in
         ([ return_cn_binding ], [ mk_stmt return_cn_decl ])
     in
-    let ail_statements =
+    let gen_ail_statements stats =
       let rec remove_duplicates locs stats =
         match stats with
         | [] -> []
@@ -4800,7 +4800,9 @@ let rec cn_to_ail_lat_2
              stat_pair)
         stats
     in
-    let ail_statements = if without_inline_statements then [] else ail_statements in
+    let ail_statements =
+      if without_inline_statements then [] else gen_ail_statements stats
+    in
     let ail_loop_invariants =
       List.map
         (cn_to_ail_loop_inv

--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -231,6 +231,7 @@ val cn_to_ail_pre_post
   :  without_ownership_checking:bool ->
   with_loop_leak_checks:bool ->
   without_lemma_checks:bool ->
+  without_inline_statements:bool ->
   string ->
   AilSyntax.sigma_cn_datatype list ->
   (Sym.t * Definition.Predicate.t) list ->

--- a/lib/fulminate/fulminate.ml
+++ b/lib/fulminate/fulminate.ml
@@ -538,6 +538,7 @@ let main
       ~without_loop_invariants
       ~with_loop_leak_checks
       ~without_lemma_checks
+      ~without_inline_statements
       ~exec_c_locs_mode
       ~correct_missing_ownership_mode
       ~experimental_ownership_stack_mode
@@ -580,6 +581,7 @@ let main
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       filename
       filtered_instrumentation
       cabs_tunit

--- a/lib/fulminate/fulminate.mli
+++ b/lib/fulminate/fulminate.mli
@@ -13,6 +13,7 @@ val main
   without_loop_invariants:bool ->
   with_loop_leak_checks:bool ->
   without_lemma_checks:bool ->
+  without_inline_statements:bool ->
   exec_c_locs_mode:bool ->
   correct_missing_ownership_mode:bool ->
   experimental_ownership_stack_mode:bool ->

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -168,6 +168,7 @@ let generate_c_specs_from_cn_internal
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       filename
       (instrumentation : Extract.instrumentation)
       (cabs_tunit : CF.Cabs.translation_unit)
@@ -189,6 +190,7 @@ let generate_c_specs_from_cn_internal
       ~without_ownership_checking
       ~with_loop_leak_checks
       ~without_lemma_checks
+      ~without_inline_statements
       filename
       dts
       preds
@@ -225,6 +227,7 @@ let generate_c_specs_internal
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       filename
       (instrumentation : Extract.instrumentation)
       (cabs_tunit : CF.Cabs.translation_unit)
@@ -243,6 +246,7 @@ let generate_c_specs_internal
         without_loop_invariants
         with_loop_leak_checks
         without_lemma_checks
+        without_inline_statements
         filename
         instrumentation
         cabs_tunit
@@ -321,6 +325,7 @@ let generate_c_specs
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       filename
       instrumentation_list
       (cabs_tunit : CF.Cabs.translation_unit)
@@ -334,6 +339,7 @@ let generate_c_specs
       without_loop_invariants
       with_loop_leak_checks
       without_lemma_checks
+      without_inline_statements
       filename
       instrumentation
       cabs_tunit

--- a/lib/fulminate/internal.mli
+++ b/lib/fulminate/internal.mli
@@ -25,6 +25,7 @@ val generate_c_specs
   bool ->
   bool ->
   bool ->
+  bool ->
   string ->
   Extract.instrumentation list ->
   Cabs.translation_unit ->


### PR DESCRIPTION
Add `--without-inline-statements` to disable CN statement checks, which are already mostly no-ops except for `assert` and `apply` for lemmas. Useful for @msaljuk's in-progress work on Lua-Fulminate