### PR TITLE
[CN-Testing] Allow fixing of base allocation address

### DIFF
--- a/bin/test.ml
+++ b/bin/test.ml
@@ -88,6 +88,7 @@ let run_tests
       max_bump_blocks
       bump_block_size
       max_input_alloc
+      fixed_alloc_base
       smt_skew_pointer_order
       dsl_log_dir
       lazy_gen
@@ -193,6 +194,7 @@ let run_tests
           max_bump_blocks;
           bump_block_size;
           max_input_alloc;
+          fixed_alloc_base;
           smt_skew_pointer_order;
           dsl_log_dir;
           lazy_gen;
@@ -779,6 +781,17 @@ module Flags = struct
     Arg.(value & opt (some size_converter) None & info [ "max-input-alloc" ] ~doc)
 
 
+  let fixed_alloc_base =
+    let doc =
+      "Pin the random input allocator's buffer to a fixed virtual address (hex 0x... or \
+       decimal). Must be page-aligned. Enables pointer-value reproducibility across runs \
+       when combined with --seed. On Linux uses mmap MAP_FIXED_NOREPLACE; on macOS \
+       passes the address as a hint and verifies the kernel honored it. Aborts if the \
+       mapping cannot be placed at the requested address. Example: 0x100000000000"
+    in
+    Arg.(value & opt (some string) None & info [ "fixed-alloc-base" ] ~doc ~docv:"ADDR")
+
+
   let smt_skew_pointer_order =
     let doc = "Enable pointer ordering skewing in SMT solver" in
     Arg.(value & flag & info [ "smt-skew-pointer-order" ] ~doc)
@@ -887,6 +900,7 @@ let cmd =
     $ Instrument.Flags.max_bump_blocks
     $ Instrument.Flags.bump_block_size
     $ Flags.max_input_alloc
+    $ Flags.fixed_alloc_base
     $ Flags.smt_skew_pointer_order
     $ Flags.dsl_log_dir
     $ Flags.lazy_gen

--- a/lib/testGeneration/buildScripts/bash.ml
+++ b/lib/testGeneration/buildScripts/bash.ml
@@ -253,6 +253,10 @@ let run () =
           |> Option.map (fun n -> [ "--max-input-alloc"; string_of_int n ])
           |> Option.to_list
           |> List.flatten)
+       @ (Config.has_fixed_alloc_base ()
+          |> Option.map (fun addr -> [ "--fixed-alloc-base"; addr ])
+          |> Option.to_list
+          |> List.flatten)
        @
        if Config.is_extrema_skew_disabled () then
          [ "--disable-extrema-skew" ]

--- a/lib/testGeneration/buildScripts/make.ml
+++ b/lib/testGeneration/buildScripts/make.ml
@@ -159,6 +159,10 @@ let define_test_flags () =
        |> Option.map (fun n -> [ "--max-input-alloc"; string_of_int n ])
        |> Option.to_list
        |> List.flatten)
+    @ (Config.has_fixed_alloc_base ()
+       |> Option.map (fun addr -> [ "--fixed-alloc-base"; addr ])
+       |> Option.to_list
+       |> List.flatten)
     @
     if Config.is_extrema_skew_disabled () then
       [ "--disable-extrema-skew" ]

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -104,6 +104,7 @@ type t =
     max_bump_blocks : int option;
     bump_block_size : int option;
     max_input_alloc : int option;
+    fixed_alloc_base : string option;
     smt_skew_pointer_order : bool;
     dsl_log_dir : string option;
     lazy_gen : bool;
@@ -172,6 +173,7 @@ let default =
     max_bump_blocks = None;
     bump_block_size = None;
     max_input_alloc = None;
+    fixed_alloc_base = None;
     smt_skew_pointer_order = false;
     dsl_log_dir = None;
     lazy_gen = false;
@@ -400,6 +402,8 @@ let has_max_bump_blocks () = (Option.get !instance).max_bump_blocks
 let has_bump_block_size () = (Option.get !instance).bump_block_size
 
 let has_max_input_alloc () = (Option.get !instance).max_input_alloc
+
+let has_fixed_alloc_base () = (Option.get !instance).fixed_alloc_base
 
 let is_smt_skew_pointer_order () = (Option.get !instance).smt_skew_pointer_order
 

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -104,6 +104,7 @@ type t =
     max_bump_blocks : int option;
     bump_block_size : int option;
     max_input_alloc : int option;
+    fixed_alloc_base : string option;
     smt_skew_pointer_order : bool;
     dsl_log_dir : string option;
     lazy_gen : bool;
@@ -257,6 +258,8 @@ val has_max_bump_blocks : unit -> int option
 val has_bump_block_size : unit -> int option
 
 val has_max_input_alloc : unit -> int option
+
+val has_fixed_alloc_base : unit -> string option
 
 val is_smt_skew_pointer_order : unit -> bool
 

--- a/runtime/libcn/include/bennet/state/rand_alloc.h
+++ b/runtime/libcn/include/bennet/state/rand_alloc.h
@@ -31,4 +31,12 @@ void *bennet_rand_alloc_max_ptr(void);
 // Set the memory size for the random allocator (must be called before first allocation)
 void bennet_rand_alloc_set_mem_size(size_t size);
 
+// Pin the allocator buffer to a fixed virtual address (must be called before first
+// allocation). Setting to 0 disables pinning (default). When pinned, the buffer is
+// obtained via mmap at the given page-aligned address; on Linux MAP_FIXED_NOREPLACE
+// is used, on macOS the address is passed as a hint and the returned pointer is
+// verified. If the mapping cannot be placed at the requested address, initialization
+// aborts rather than silently overwriting existing mappings.
+void bennet_rand_alloc_set_fixed_base(uintptr_t addr);
+
 #endif  // BENNET_RAND_ALLOC_H

--- a/runtime/libcn/src/bennet/state/rand_alloc.c
+++ b/runtime/libcn/src/bennet/state/rand_alloc.c
@@ -1,9 +1,13 @@
+#include <sys/mman.h>
+
 #include <assert.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <bennet/internals/domain.h>
 #include <bennet/internals/rand.h>
@@ -28,6 +32,7 @@ typedef struct {
 
 // Add a static buffer for the random allocator
 static size_t rand_alloc_mem_size = (1024 * 1024 * 32);  // 32 MB default
+static uintptr_t rand_alloc_fixed_base = 0;              // 0 = disabled
 static rand_alloc global_rand_alloc;
 
 // Initialize the allocator
@@ -36,12 +41,69 @@ static void bennet_rand_alloc_init(void) {
     return;
   }
 
-  global_rand_alloc.buffer = malloc(rand_alloc_mem_size);
-  if (!global_rand_alloc.buffer) {
-    fprintf(stderr,
-        "CRITICAL: Failed to allocate %zu MB for rand_alloc buffer!\n",
-        rand_alloc_mem_size / (1024 * 1024));
-    cn_failure(CN_FAILURE_FULM_ALLOC, NON_SPEC);
+  if (rand_alloc_fixed_base != 0) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    assert(page_size > 0);
+    assert(rand_alloc_fixed_base % (uintptr_t)page_size == 0);
+
+    void *addr = (void *)rand_alloc_fixed_base;
+    void *mapped;
+#ifdef MAP_FIXED_NOREPLACE
+    mapped = mmap(addr,
+        rand_alloc_mem_size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE,
+        -1,
+        0);
+    if (mapped == MAP_FAILED) {
+      fprintf(stderr,
+          "CRITICAL: mmap(MAP_FIXED_NOREPLACE) failed for %zu bytes at %p: %s\n",
+          rand_alloc_mem_size,
+          addr,
+          strerror(errno));
+      exit(1);
+    }
+    if (mapped != addr) {
+      munmap(mapped, rand_alloc_mem_size);
+      fprintf(stderr,
+          "CRITICAL: MAP_FIXED_NOREPLACE did not honor requested address %p (got %p)\n",
+          addr,
+          mapped);
+      exit(1);
+    }
+#else
+    // macOS: no MAP_FIXED_NOREPLACE. Pass addr as a hint (no MAP_FIXED) and
+    // verify the kernel honored it; if not, unmap and abort rather than
+    // silently relocating (which would defeat the point of pinning).
+    mapped = mmap(
+        addr, rand_alloc_mem_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (mapped == MAP_FAILED) {
+      fprintf(stderr,
+          "CRITICAL: mmap failed for %zu bytes at %p: %s\n",
+          rand_alloc_mem_size,
+          addr,
+          strerror(errno));
+      exit(1);
+    }
+    if (mapped != addr) {
+      munmap(mapped, rand_alloc_mem_size);
+      fprintf(stderr,
+          "CRITICAL: kernel did not honor fixed-base hint %p (got %p); cannot pin "
+          "rand_alloc buffer. Try a different --fixed-alloc-base address.\n",
+          addr,
+          mapped);
+      exit(1);
+    }
+#endif
+    global_rand_alloc.buffer = (char *)mapped;
+  } else {
+    global_rand_alloc.buffer = malloc(rand_alloc_mem_size);
+    if (!global_rand_alloc.buffer) {
+      fprintf(stderr,
+          "CRITICAL: Failed to allocate %zu MB for rand_alloc buffer!\n",
+          rand_alloc_mem_size / (1024 * 1024));
+      exit(1);
+    }
   }
   global_rand_alloc.buffer_len = rand_alloc_mem_size;
   bennet_vector_init(rand_alloc_region)(&global_rand_alloc.regions);
@@ -202,4 +264,16 @@ void bennet_rand_alloc_set_mem_size(size_t size) {
     exit(1);
   }
   rand_alloc_mem_size = size;
+}
+
+// Pin the allocator buffer to a fixed virtual address (must be called before first
+// allocation). Setting to 0 disables pinning.
+void bennet_rand_alloc_set_fixed_base(uintptr_t addr) {
+  if (global_rand_alloc.buffer != NULL) {
+    fprintf(stderr,
+        "Error: Cannot set rand_alloc fixed base after allocator has been "
+        "initialized.\n");
+    exit(1);
+  }
+  rand_alloc_fixed_base = addr;
 }

--- a/runtime/libcn/src/bennet/state/rand_alloc.c
+++ b/runtime/libcn/src/bennet/state/rand_alloc.c
@@ -1,5 +1,15 @@
 #include <sys/mman.h>
 
+// Portable anonymous-mapping flag: prefer MAP_ANONYMOUS (POSIX), fall back to
+// MAP_ANON (macOS / older BSDs).
+#if defined(MAP_ANONYMOUS)
+  #define CN_MAP_ANON MAP_ANONYMOUS
+#elif defined(MAP_ANON)
+  #define CN_MAP_ANON MAP_ANON
+#else
+  #error "Neither MAP_ANONYMOUS nor MAP_ANON is defined"
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -52,7 +62,7 @@ static void bennet_rand_alloc_init(void) {
     mapped = mmap(addr,
         rand_alloc_mem_size,
         PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE,
+        MAP_PRIVATE | CN_MAP_ANON | MAP_FIXED_NOREPLACE,
         -1,
         0);
     if (mapped == MAP_FAILED) {
@@ -72,11 +82,15 @@ static void bennet_rand_alloc_init(void) {
       exit(1);
     }
 #else
-    // macOS: no MAP_FIXED_NOREPLACE. Pass addr as a hint (no MAP_FIXED) and
-    // verify the kernel honored it; if not, unmap and abort rather than
+    // Fallback: no MAP_FIXED_NOREPLACE. Pass addr as a hint (no MAP_FIXED)
+    // and verify the kernel honored it; if not, unmap and abort rather than
     // silently relocating (which would defeat the point of pinning).
-    mapped = mmap(
-        addr, rand_alloc_mem_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    mapped = mmap(addr,
+        rand_alloc_mem_size,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | CN_MAP_ANON,
+        -1,
+        0);
     if (mapped == MAP_FAILED) {
       fprintf(stderr,
           "CRITICAL: mmap failed for %zu bytes at %p: %s\n",

--- a/runtime/libcn/src/cn-testing/test.c
+++ b/runtime/libcn/src/cn-testing/test.c
@@ -336,6 +336,9 @@ int cn_test_main(int argc, char* argv[]) {
     } else if (strcmp("--max-input-alloc", arg) == 0) {
       bennet_rand_alloc_set_mem_size(strtoul(argv[i + 1], NULL, 10));
       i++;
+    } else if (strcmp("--fixed-alloc-base", arg) == 0) {
+      bennet_rand_alloc_set_fixed_base((uintptr_t)strtoull(argv[i + 1], NULL, 0));
+      i++;
     } else if (strcmp("--only", arg) == 0) {
       char* test_names = argv[i + 1];
       char* test_names_copy = strdup(test_names);


### PR DESCRIPTION
For pointer generation, we allocate a large buffer and generate addresses inside it (depending on ownership and size required).

This PR adds `--fixed-alloc-base=<ADDR>` which allows setting the address of this buffer.