### PR TITLE
[CI] Resolve `mask_ptr.c` for Fulminate

### DIFF
--- a/tests/cn/mask_ptr.c
+++ b/tests/cn/mask_ptr.c
@@ -4,45 +4,66 @@
    issues for the SMT solver for unclear reasons.
 */
 
+#include <stddef.h>
+
 typedef unsigned long long u64;
 
-enum {
-  SHIFT_AMOUNT = 5
-};
+#ifndef CN_UTILS
+void *cn_aligned_alloc(size_t alignment, size_t size);
+void cn_free_sized(void *ptr, size_t size);
+#endif
 
-u64
-foo_integer (u64 y)
+enum { SHIFT_AMOUNT = 5 };
+
+/*@
+function (boolean) isPow2u64(u64 n) {
+    n != 0u64 && (n & (n - 1u64)) == 0u64
+}
+
+spec cn_aligned_alloc(u64 alignment, u64 size);
+requires alignment > 0u64;
+         isPow2u64(alignment);
+ensures  (size == 0u64) ? is_null(return) : !is_null(return);
+         (u64)return % alignment == 0u64;
+         (u64)return <= (u64)return + size;
+         take O = each (u64 i; i < size) {
+             RW<char>(array_shift<char>(return, i))
+         };
+
+spec cn_free_sized(pointer ptr, u64 size);
+requires take O = each (u64 i; i < size) {
+             RW<char>(array_shift<char>(ptr, i))
+         };
+@*/
+
+u64 foo_integer(u64 y)
 /*@ requires mod(y, shift_left(1u64, ((u64) SHIFT_AMOUNT))) == 0u64; @*/
 /* y = 42 */
 /* shift_left(1u64, 5u64) = 0...100000*/
 {
   u64 x = y;
-  x &= ~ ((1UL << SHIFT_AMOUNT) - 1);
+  x &= ~((1UL << SHIFT_AMOUNT) - 1);
   /*@ assert (x == y); @*/
   return x;
 }
 
-
-
-int *
-foo (int *p)
+int *foo(int *p)
 /*@ requires let p_u64 = (u64) p;
              mod(p_u64, shift_left(1u64, ((u64) SHIFT_AMOUNT))) == 0u64; @*/
 {
-  u64 x = ((u64) p);
+  u64 x = ((u64)p);
   int *p2;
 
-  x &= ~ ((1UL << SHIFT_AMOUNT) - 1);
+  x &= ~((1UL << SHIFT_AMOUNT) - 1);
 
-  p2 = ((int *) x);
+  p2 = ((int *)x);
   /*@ assert (((u64) p2) == ((u64) p)); @*/
   return p2;
 }
 
-int main(void)
-/*@ trusted; @*/
-{
-  int r1 = foo_integer(128);
-  int p[1] = {512};
+int main(void) {
+  u64 r1 = foo_integer(128);
+  int *p = cn_aligned_alloc(32, sizeof(int));
   int *r2 = foo(p);
+  cn_free_sized(p, sizeof(int));
 }

--- a/tests/cn/mask_ptr.c.verify
+++ b/tests/cn/mask_ptr.c.verify
@@ -1,3 +1,4 @@
 return code: 0
-[1/2]: foo_integer -- pass
-[2/2]: foo -- pass
+[1/3]: foo_integer -- pass
+[2/3]: foo -- pass
+[3/3]: main -- pass

--- a/tests/cn/mask_ptr.error.c
+++ b/tests/cn/mask_ptr.error.c
@@ -1,0 +1,52 @@
+
+/* A test case about modulus and masking, in both integers and pointers.
+   Originally introduced as a test case because the pointer variant was causing
+   issues for the SMT solver for unclear reasons.
+
+   This variant deliberately passes a misaligned pointer to `foo`, so both
+   CN verification and Fulminate's runtime precondition check fail
+   deterministically.
+*/
+
+typedef unsigned long long u64;
+
+enum {
+  SHIFT_AMOUNT = 5
+};
+
+u64
+foo_integer (u64 y)
+/*@ requires mod(y, shift_left(1u64, ((u64) SHIFT_AMOUNT))) == 0u64; @*/
+/* y = 42 */
+/* shift_left(1u64, 5u64) = 0...100000*/
+{
+  u64 x = y;
+  x &= ~ ((1UL << SHIFT_AMOUNT) - 1);
+  /*@ assert (x == y); @*/
+  return x;
+}
+
+
+
+int *
+foo (int *p)
+/*@ requires let p_u64 = (u64) p;
+             mod(p_u64, shift_left(1u64, ((u64) SHIFT_AMOUNT))) == 0u64; @*/
+{
+  u64 x = ((u64) p);
+  int *p2;
+
+  x &= ~ ((1UL << SHIFT_AMOUNT) - 1);
+
+  p2 = ((int *) x);
+  /*@ assert (((u64) p2) == ((u64) p)); @*/
+  return p2;
+}
+
+int main(void)
+{
+  u64 r1 = foo_integer(128);
+  int buf[8];
+  int *p = (((u64) &buf[0]) % 32 == 0) ? &buf[1] : &buf[0];
+  int *r2 = foo(p);
+}

--- a/tests/cn/mask_ptr.error.c.verify
+++ b/tests/cn/mask_ptr.error.c.verify
@@ -1,0 +1,11 @@
+return code: 1
+[1/3]: foo_integer -- pass
+[2/3]: foo -- pass
+[3/3]: main -- fail
+tests/cn/mask_ptr.error.c:51:13: error: Unprovable constraint
+  int *r2 = foo(p);
+            ^~~~~~ 
+Constraint from tests/cn/mask_ptr.error.c:34:14:
+             mod(p_u64, shift_left(1u64, ((u64) SHIFT_AMOUNT))) == 0u64; @*/
+             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+State file: file:///tmp/state__mask_ptr.error.c__main.html

--- a/tests/run-cn-exec.sh
+++ b/tests/run-cn-exec.sh
@@ -88,7 +88,6 @@ SUCCESS=$(find cn -name '*.c' \
     ! -name "spec_null_shift.c" \
     ! -name "alloc_token.c" \
     ! -name "ptr_diff.c" \
-    ! -name "mask_ptr.c" \
     ! -name "previously_inconsistent_assumptions1.c" \
     ! -name "previously_inconsistent_assumptions2.c" \
     ! -name "ptr_relop.c" \
@@ -153,7 +152,6 @@ BUGGY="\
        cn/spec_null_shift.c \
        cn/alloc_token.c \
        cn/ptr_diff.c \
-       cn/mask_ptr.c \
        cn/ptr_relop.c \
        cn/ptr_relop.error.c \
        cn/int_to_ptr.c \


### PR DESCRIPTION
Currently `mask_ptr.c` is marked as `BUGGY` in the Fulminate CI. However, Fulminate runs fine on it.

It fails because of `main` using a stack pointer which doesn't satisfy the stricter alignment precondition.
However, `main` is `trusted`, so the file passes CN's CI, but fails Fulminate's.

---

We resolve this oddity by having two files, `mask_ptr.c` and `mask_ptr.error.c`.

The first uses `cn_aligned_alloc` to produce a pointer with the increased alignment.
This allows the proof to go through for `main` as well.

The second uses pointer arithmetic to create a pointer that always violates the increased alignment requirement.
Since we removed `trusted` from `main`, this causes both the proof and Fulminate to fail.