### PR TITLE
Fix Docker CI

### DIFF
--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -22,7 +22,7 @@ RUN opam install z3
 RUN opam install ocaml-lsp-server ocamlformat
 
 # Added make install to make test CI pass
-# Not sure if appropriate for a dev container
+# Unsure if appropriate for a dev container
 RUN eval `opam env` \
   && make install
 

--- a/runtime/libcn/src/cn-executable/rmap.c
+++ b/runtime/libcn/src/cn-executable/rmap.c
@@ -25,7 +25,7 @@ typedef rmap_range_res_t result_t;
 
 static const rmap_value_t val_none = INT_MIN;
 
-static const result_t res_none = (result_t){.min = val_none, .max = val_none};
+static const result_t res_none = (result_t){.min = INT_MIN, .max = INT_MIN};
 
 static inline result_t res_append(result_t a, result_t b) {
   return (result_t){


### PR DESCRIPTION
Sometimes the RedHat image fails with a
`../../src/cn-executable/rmap.c:28:44: error: initializer element is not constant` so this commit tries to address that.

Sometimes the image build can't find alloc.h

`../../src/bennet/prelude.c:5:10: fatal error: bennet/state/alloc.h: No such file or directory`

but I think this is spurious.