### PR TITLE
[Bennet] Fix dune file

### DIFF
--- a/runtime/libcn/lib/dune
+++ b/runtime/libcn/lib/dune
@@ -51,7 +51,11 @@
    (glob_files ../include/cn-executable/*.h)
    (glob_files ../include/bennet/*.h)
    (glob_files ../include/bennet/dsl/*.h)
-   (glob_files ../include/bennet/info/*.h))
+   (glob_files ../include/bennet/info/*.h)
+   (glob_files ..//include/bennet/internals/*.h)
+   (glob_files ..//include/bennet/internals/domains/*.h)
+   (glob_files ..//include/bennet/state/*.h)
+   (glob_files ..//include/bennet/utils/*.h))
   (:src
    (glob_files ../src/bennet/*.c)
    (glob_files ../src/bennet/dsl/*.c)


### PR DESCRIPTION
The dune files were missing some headers as dependecies and this cause a race condition which led to the Docker builds spuriously failing with missing headers; this commit adds them.