### PR TITLE
Separate different input generation backends

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,5 @@
+(include_subdirs qualified)
+
 (executable
  (name main)
  (modes exe)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,9 +1,20 @@
 open Cmdliner
 
-let subcommands = [ Wf.cmd; Verify.cmd; Test.cmd; Instrument.cmd; SeqTest.cmd ]
+(* Cmdliner [default] doesn't work with positional arguments (the first
+   positional of a command group is resolved as a subcommand name), so legacy
+   `cn test FILE` invocations are routed to a flat, deprecated `test` command
+   instead of the engine-subcommand group. *)
+let subcommands ~legacy_test =
+  [ Wf.cmd;
+    Verify.cmd;
+    (if legacy_test then Test.legacy_cmd else Test.cmd);
+    Instrument.cmd;
+    SeqTest.cmd
+  ]
+
 
 let () =
   let version_str = Cn_version.git_version ^ " [" ^ Cn_version.git_version_date ^ "]" in
   let cn_info = Cmd.info "cn" ~version:version_str in
-  let argv = Test.argv_with_default_engine Sys.argv in
-  Stdlib.exit @@ Cmd.(eval ~argv (group cn_info subcommands))
+  let legacy_test = Test.wants_legacy Sys.argv in
+  Stdlib.exit @@ Cmd.(eval (group cn_info (subcommands ~legacy_test)))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -5,4 +5,5 @@ let subcommands = [ Wf.cmd; Verify.cmd; Test.cmd; Instrument.cmd; SeqTest.cmd ]
 let () =
   let version_str = Cn_version.git_version ^ " [" ^ Cn_version.git_version_date ^ "]" in
   let cn_info = Cmd.info "cn" ~version:version_str in
-  Stdlib.exit @@ Cmd.(eval (group cn_info subcommands))
+  let argv = Test.argv_with_default_engine Sys.argv in
+  Stdlib.exit @@ Cmd.(eval ~argv (group cn_info subcommands))

--- a/bin/test/bennet.ml
+++ b/bin/test/bennet.ml
@@ -1,0 +1,83 @@
+(* Bennet: randomized test generation (the default engine) *)
+
+open Cn
+open Cmdliner
+
+module Flags = struct
+  let gen_backtrack_attempts =
+    let doc =
+      "Set the maximum attempts to satisfy a constraint before backtracking further, \
+       during input generation"
+    in
+    Arg.(
+      value
+      & opt int TestGeneration.default_cfg.max_backtracks
+      & info [ "max-backtrack-attempts" ] ~doc)
+
+
+  let random_size_splits =
+    let doc = "Randomly split sizes between recursive generator calls" in
+    Arg.(value & flag & info [ "random-size-splits" ] ~doc)
+
+
+  let allowed_size_split_backtracks =
+    let doc =
+      "Set the maximum attempts to split up a generator's size (between recursive calls) \
+       before backtracking further, during input generation"
+    in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.allowed_size_split_backtracks
+      & info [ "allowed-size-split-backtracks" ] ~doc)
+
+
+  let sized_null =
+    let doc = "Does nothing." in
+    let deprecated = "Will be removed after July 31." in
+    Arg.(value & flag & info [ "sized-null" ] ~deprecated ~doc)
+
+
+  let lazy_gen =
+    let doc = "Enable lazy generation" in
+    Arg.(value & flag & info [ "lazy-gen" ] ~doc)
+
+
+  let only_top_level_ite_lifting =
+    let doc = "Only lift top-level ITE expressions" in
+    Arg.(value & flag & info [ "only-top-level-ite-lifting" ] ~doc)
+end
+
+let term : (TestGeneration.config -> TestGeneration.config) Term.t =
+  let make
+        max_backtracks
+        random_size_splits
+        allowed_size_split_backtracks
+        _sized_null
+        lazy_gen
+        only_top_level_ite_lifting
+        (cfg : TestGeneration.config)
+    : TestGeneration.config
+    =
+    { cfg with
+      max_backtracks;
+      random_size_splits;
+      allowed_size_split_backtracks;
+      lazy_gen;
+      only_top_level_ite_lifting
+    }
+  in
+  Term.(
+    const make
+    $ Flags.gen_backtrack_attempts
+    $ Flags.random_size_splits
+    $ Flags.allowed_size_split_backtracks
+    $ Flags.sized_null
+    $ Flags.lazy_gen
+    $ Flags.only_top_level_ite_lifting)
+
+
+let cmd =
+  let doc = "Generate tests using randomized input generation (the default engine)." in
+  Cmd.v
+    (Cmd.info "bennet" ~doc)
+    (Shared.mk_term ~engine:(Term.const TestGeneration.Bennet) ~engine_flags:term)

--- a/bin/test/darcy.ml
+++ b/bin/test/darcy.ml
@@ -1,0 +1,117 @@
+(* Darcy: symbolic (SMT-based) test generation *)
+
+open Cn
+open Cmdliner
+
+module Flags = struct
+  let symbolic_timeout =
+    let doc = "Set timeout for SMT solver in symbolic mode (milliseconds)" in
+    Arg.(value & opt (some int) None & info [ "symbolic-timeout" ] ~doc)
+
+
+  let smt_solver =
+    let doc =
+      "Choose SMT solver backend for symbolic test generation (z3, cvc5 is unsupported)."
+    in
+    Arg.(
+      value
+      & opt (enum TestGeneration.Options.smt_solver) TestGeneration.default_cfg.smt_solver
+      & info [ "solver-type" ] ~docv:"SOLVER" ~doc)
+
+
+  let max_array_length =
+    let doc = "Maximum array length for symbolic mode" in
+    Arg.(
+      value
+      & opt int TestGeneration.default_cfg.max_array_length
+      & info [ "max-array-length" ] ~doc)
+
+
+  let smt_logging =
+    let doc = "Log SMT solver communication to specified file" in
+    Arg.(value & opt (some string) None & info [ "smt-logging" ] ~doc ~docv:"FILE")
+
+
+  let smt_log_unsat_cores =
+    let doc = "Log unsat cores to specified file when constraints are unsatisfiable" in
+    Arg.(
+      value & opt (some string) None & info [ "smt-log-unsat-cores" ] ~doc ~docv:"FILE")
+
+
+  let use_solver_eval =
+    let doc = "(Experimental) Use solver-based evaluation" in
+    Arg.(value & flag & info [ "use-solver-eval" ] ~doc)
+
+
+  let just_reset_solver =
+    let doc =
+      "Just reset the SMT solver instead of closing and creating a new one. WARNING: A \
+       bunch of stuff breaks."
+    in
+    Arg.(value & flag & info [ "just-reset-solver" ] ~doc)
+
+
+  let smt_skewing_mode =
+    let doc =
+      "Set SMT skewing mode for symbolic test generation. Options: uniform (uniform \
+       random values), sized (default, size-based values), none (no skewing)"
+    in
+    Arg.(
+      value
+      & opt
+          (enum TestGeneration.Options.smt_skewing_mode)
+          TestGeneration.default_cfg.smt_skewing_mode
+      & info [ "smt-skewing" ] ~docv:"MODE" ~doc)
+
+
+  let smt_skew_pointer_order =
+    let doc = "Enable pointer ordering skewing in SMT solver" in
+    Arg.(value & flag & info [ "smt-skew-pointer-order" ] ~doc)
+end
+
+let term : (TestGeneration.config -> TestGeneration.config) Term.t =
+  let make
+        symbolic_timeout
+        smt_solver
+        max_array_length
+        smt_logging
+        smt_log_unsat_cores
+        use_solver_eval
+        just_reset_solver
+        smt_skewing_mode
+        smt_skew_pointer_order
+        (cfg : TestGeneration.config)
+    : TestGeneration.config
+    =
+    { cfg with
+      symbolic_timeout;
+      smt_solver;
+      max_array_length;
+      smt_logging;
+      smt_log_unsat_cores;
+      use_solver_eval;
+      just_reset_solver;
+      smt_skewing_mode;
+      smt_skew_pointer_order
+    }
+  in
+  Term.(
+    const make
+    $ Flags.symbolic_timeout
+    $ Flags.smt_solver
+    $ Flags.max_array_length
+    $ Flags.smt_logging
+    $ Flags.smt_log_unsat_cores
+    $ Flags.use_solver_eval
+    $ Flags.just_reset_solver
+    $ Flags.smt_skewing_mode
+    $ Flags.smt_skew_pointer_order)
+
+
+let cmd =
+  let doc =
+    "(Experimental) Generate tests using symbolic (SMT-based) input generation."
+  in
+  Cmd.v
+    (Cmd.info "darcy" ~doc)
+    (Shared.mk_term ~engine:(Term.const TestGeneration.Darcy) ~engine_flags:term)

--- a/bin/test/lucas.ml
+++ b/bin/test/lucas.ml
@@ -1,0 +1,124 @@
+(* Lucas: Bennet's randomized pipeline generalized by framing generation as iterative refinement of abstract-domain elements.
+
+   The abstract-domain flags live here and are only accepted by this
+   engine. *)
+
+open Cn
+open Cmdliner
+
+module Flags = struct
+  let static_absint =
+    let doc =
+      "(Experimental) Use static abstract interpretation with specified domain (or a \
+       comma-separated list). (e.g., 'interval', 'wrapped_interval', 'tristate')"
+    in
+    Arg.(
+      value
+      & opt
+          (list
+             (enum
+                [ ("interval", "interval");
+                  ("wrapped_interval", "wrapped_interval");
+                  ("tristate", "tristate")
+                ]))
+          []
+      & info [ "static-absint" ] ~docv:"DOMAIN" ~doc)
+
+
+  let local_iterations =
+    let doc = "Maximum iterations for local abstract interpretation refinement" in
+    Arg.(
+      value
+      & opt int TestGeneration.default_cfg.local_iterations
+      & info [ "local-iterations" ] ~doc)
+
+
+  let smt_pruning_before_absinst =
+    let doc =
+      "(Experimental) Use SMT solver to prune unsatisfiable branches before abstract \
+       interpretation"
+    in
+    Arg.(
+      value
+      & opt (enum [ ("none", `None); ("fast", `Fast); ("slow", `Slow) ]) `None
+      & info [ "smt-pruning-before-absint" ] ~doc)
+
+
+  let smt_pruning_after_absinst =
+    let doc =
+      "(Experimental) Use SMT solver to prune unsatisfiable branches after abstract \
+       interpretation"
+    in
+    Arg.(
+      value
+      & opt (enum [ ("none", `None); ("fast", `Fast); ("slow", `Slow) ]) `None
+      & info [ "smt-pruning-after-absint" ] ~doc)
+
+
+  let smt_pruning_keep_redundant_assertions =
+    let doc =
+      "(Experimental) Keep assertions even if provably redundant during SMT pruning"
+    in
+    Arg.(value & flag & info [ "smt-pruning-keep-redundant-assertions" ] ~doc)
+
+
+  let smt_pruning_at_runtime =
+    let doc = "(Experimental) Use SMT solver to prune branches at runtime" in
+    Arg.(value & flag & info [ "smt-pruning-at-runtime" ] ~doc)
+
+
+  let runtime_assert_domain =
+    let doc = "Enable assert_domain checks at runtime (disabled by default)" in
+    Arg.(value & flag & info [ "runtime-assert-domain" ] ~doc)
+
+
+  let experimental_learning =
+    let doc = "Use experimental domain learning" in
+    Arg.(value & flag & info [ "experimental-learning" ] ~doc)
+end
+
+let term : (TestGeneration.config -> TestGeneration.config) Term.t =
+  let make
+        static_absint
+        local_iterations
+        smt_pruning_before_absinst
+        smt_pruning_after_absinst
+        smt_pruning_keep_redundant_assertions
+        smt_pruning_at_runtime
+        runtime_assert_domain
+        experimental_learning
+        (cfg : TestGeneration.config)
+    : TestGeneration.config
+    =
+    { cfg with
+      static_absint;
+      local_iterations;
+      smt_pruning_before_absinst;
+      smt_pruning_after_absinst;
+      smt_pruning_remove_redundant_assertions = not smt_pruning_keep_redundant_assertions;
+      smt_pruning_at_runtime;
+      runtime_assert_domain;
+      experimental_learning
+    }
+  in
+  Term.(
+    const make
+    $ Flags.static_absint
+    $ Flags.local_iterations
+    $ Flags.smt_pruning_before_absinst
+    $ Flags.smt_pruning_after_absinst
+    $ Flags.smt_pruning_keep_redundant_assertions
+    $ Flags.smt_pruning_at_runtime
+    $ Flags.runtime_assert_domain
+    $ Flags.experimental_learning)
+
+
+let cmd =
+  let doc =
+    "(Experimental) Generate tests via randomized refinement of abstract elements."
+  in
+  Cmd.v
+    (Cmd.info "lucas" ~doc)
+    (Shared.mk_term
+       ~engine:(Term.const TestGeneration.Lucas)
+       ~engine_flags:(Shared.compose_flags Bennet.term term))

--- a/bin/test/shared.ml
+++ b/bin/test/shared.ml
@@ -1,8 +1,16 @@
+(* Shared infrastructure for the `cn test` engine subcommands. *)
+
 module CF = Cerb_frontend
 module CB = Cerb_backend
 open Cn
 
-let run_tests
+(* An engine's flags are a config updater: applied on top of the config built
+   from the common flags, so unset engine flags keep their defaults. *)
+type engine_flags = TestGeneration.config -> TestGeneration.config
+
+let run
+      (* Engine *)
+        (engine : TestGeneration.engine)
       (* Common *)
         filename
       cc
@@ -32,9 +40,7 @@ let run_tests
       skip_fulminate
       dont_run
       num_samples
-      max_backtracks
       max_unfolds
-      max_array_length
       build_tool
       sanitizers
       print_seed
@@ -46,13 +52,6 @@ let run_tests
       progress_level
       until_timeout
       exit_fast
-      max_stack_depth
-      max_depth_failures
-      max_generator_size
-      sizing_strategy
-      random_size_splits
-      allowed_size_split_backtracks
-      _sized_null
       coverage
       disable_passes
       trap
@@ -62,39 +61,20 @@ let run_tests
       inline
       experimental_struct_asgn_destruction
       experimental_product_arg_destruction
-      experimental_learning
       experimental_arg_pruning
       experimental_return_pruning
-      static_absint
-      local_iterations
-      smt_pruning_before_absinst
-      smt_pruning_after_absinst
-      smt_pruning_keep_redundant_assertions
-      smt_pruning_at_runtime
-      runtime_assert_domain
-      symbolic
-      symbolic_timeout
-      use_solver_eval
-      smt_solver
-      smt_logging
-      smt_log_unsat_cores
       print_size_info
       print_backtrack_info
       print_satisfaction_info
       print_discard_info
       print_timing_info
-      just_reset_solver
-      smt_skewing_mode
       max_bump_blocks
       bump_block_size
       max_input_alloc
-      smt_skew_pointer_order
       dsl_log_dir
-      lazy_gen
       disable_specialization
-      only_top_level_ite_lifting
-      disable_extrema_skew
-      discard_factor
+      (* Engine-specific *)
+        (engine_flags : engine_flags)
   =
   (* flags *)
   Cerb_debug.debug_level := debug_level;
@@ -132,37 +112,20 @@ let run_tests
     ~handle_error
     ~f:(fun ~cabs_tunit ~prog5 ~ail_prog ~statement_locs:_ ~paused ->
       let config : TestGeneration.config =
-        { skip_and_only = (skip, only);
+        { TestGeneration.default_cfg with
+          skip_and_only = (skip, only);
           cc;
           print_steps;
           num_samples;
-          max_backtracks;
           build_tool;
           sanitizers;
           inline;
           experimental_struct_asgn_destruction;
           experimental_product_arg_destruction;
-          experimental_learning;
           experimental_arg_pruning;
           experimental_return_pruning;
-          static_absint;
-          local_iterations;
-          smt_pruning_before_absinst;
-          smt_pruning_after_absinst;
-          smt_pruning_remove_redundant_assertions =
-            not smt_pruning_keep_redundant_assertions;
-          smt_pruning_at_runtime;
-          runtime_assert_domain;
-          symbolic;
-          symbolic_timeout;
-          use_solver_eval;
-          smt_solver;
-          disable_specialization;
-          only_top_level_ite_lifting;
-          smt_logging;
-          smt_log_unsat_cores;
+          engine;
           max_unfolds;
-          max_array_length;
           print_seed;
           input_timeout;
           null_in_every;
@@ -172,12 +135,6 @@ let run_tests
           progress_level;
           until_timeout;
           exit_fast;
-          max_stack_depth;
-          max_depth_failures;
-          max_generator_size;
-          sizing_strategy;
-          random_size_splits;
-          allowed_size_split_backtracks;
           coverage;
           disable_passes;
           trap;
@@ -189,18 +146,14 @@ let run_tests
           print_satisfaction_info;
           print_discard_info;
           print_timing_info;
-          just_reset_solver;
-          smt_skewing_mode;
           max_bump_blocks;
           bump_block_size;
           max_input_alloc;
-          smt_skew_pointer_order;
           dsl_log_dir;
-          lazy_gen;
-          disable_extrema_skew;
-          discard_factor
+          disable_specialization
         }
       in
+      let config = engine_flags config in
       TestGeneration.set_config config;
       let _, sigma = ail_prog in
       if
@@ -304,6 +257,7 @@ let parse_size_value s =
 
 let size_converter = Arg.conv (parse_size_value, fun ppf n -> Format.fprintf ppf "%d" n)
 
+(* Flags shared by all engines *)
 module Flags = struct
   let print_steps =
     let doc =
@@ -360,30 +314,11 @@ module Flags = struct
       value & opt int TestGeneration.default_cfg.num_samples & info [ "num-samples" ] ~doc)
 
 
-  let gen_backtrack_attempts =
-    let doc =
-      "Set the maximum attempts to satisfy a constraint before backtracking further, \
-       during input generation"
-    in
-    Arg.(
-      value
-      & opt int TestGeneration.default_cfg.max_backtracks
-      & info [ "max-backtrack-attempts" ] ~doc)
-
-
   let gen_max_unfolds =
     let doc =
       "Maximum number of times to inline function calls in symbolic mode (default: 10)"
     in
     Arg.(value & opt (some int) None & info [ "max-unfolds" ] ~doc)
-
-
-  let max_array_length =
-    let doc = "Maximum array length for symbolic mode" in
-    Arg.(
-      value
-      & opt int TestGeneration.default_cfg.max_array_length
-      & info [ "max-array-length" ] ~doc)
 
 
   let build_tool =
@@ -479,62 +414,6 @@ module Flags = struct
     Arg.(value & flag & info [ "exit-fast" ] ~doc)
 
 
-  let max_stack_depth =
-    let doc = "Maximum stack depth for generators" in
-    Arg.(
-      value
-      & opt (some int) TestGeneration.default_cfg.max_stack_depth
-      & info [ "max-stack-depth" ] ~doc)
-
-
-  let max_depth_failures =
-    let doc = "Maximum number of depth failures allowed before giving up" in
-    Arg.(
-      value
-      & opt (some int) TestGeneration.default_cfg.max_depth_failures
-      & info [ "max-depth-failures" ] ~doc)
-
-
-  let max_generator_size =
-    let doc = "Maximum size for generated values" in
-    Arg.(
-      value
-      & opt (some int) TestGeneration.default_cfg.max_generator_size
-      & info [ "max-generator-size" ] ~doc)
-
-
-  let sizing_strategy =
-    let doc = "Strategy for deciding test case size." in
-    Arg.(
-      value
-      & opt
-          (some (enum TestGeneration.Options.sizing_strategy))
-          TestGeneration.default_cfg.sizing_strategy
-      & info [ "sizing-strategy" ] ~doc)
-
-
-  let random_size_splits =
-    let doc = "Randomly split sizes between recursive generator calls" in
-    Arg.(value & flag & info [ "random-size-splits" ] ~doc)
-
-
-  let allowed_size_split_backtracks =
-    let doc =
-      "Set the maximum attempts to split up a generator's size (between recursive calls) \
-       before backtracking further, during input generation"
-    in
-    Arg.(
-      value
-      & opt (some int) TestGeneration.default_cfg.allowed_size_split_backtracks
-      & info [ "allowed-size-split-backtracks" ] ~doc)
-
-
-  let sized_null =
-    let doc = "Does nothing." in
-    let deprecated = "Will be removed after July 31." in
-    Arg.(value & flag & info [ "sized-null" ] ~deprecated ~doc)
-
-
   let coverage =
     let doc = "(Experimental) Record coverage of tests via [lcov]" in
     Arg.(value & flag & info [ "coverage" ] ~doc)
@@ -543,11 +422,6 @@ module Flags = struct
   let disable_specialization =
     let doc = "Disable integer specialization in the generator pipeline" in
     Arg.(value & flag & info [ "disable-specialization" ] ~doc)
-
-
-  let only_top_level_ite_lifting =
-    let doc = "Only lift top-level ITE expressions" in
-    Arg.(value & flag & info [ "only-top-level-ite-lifting" ] ~doc)
 
 
   let disable_passes =
@@ -611,11 +485,6 @@ module Flags = struct
     Arg.(value & flag & info [ "experimental-product-arg-destruction" ] ~doc)
 
 
-  let experimental_learning =
-    let doc = "Use experimental domain learning" in
-    Arg.(value & flag & info [ "experimental-learning" ] ~doc)
-
-
   let experimental_arg_pruning =
     let doc = "Enable experimental unused argument pruning optimization" in
     Arg.(value & flag & info [ "experimental-arg-pruning" ] ~doc)
@@ -624,71 +493,6 @@ module Flags = struct
   let experimental_return_pruning =
     let doc = "Enable experimental unused return value pruning optimization" in
     Arg.(value & flag & info [ "experimental-return-pruning" ] ~doc)
-
-
-  let smt_pruning_before_absinst =
-    let doc =
-      "(Experimental) Use SMT solver to prune unsatisfiable branches before abstract \
-       interpretation"
-    in
-    Arg.(
-      value
-      & opt (enum [ ("none", `None); ("fast", `Fast); ("slow", `Slow) ]) `None
-      & info [ "smt-pruning-before-absint" ] ~doc)
-
-
-  let smt_pruning_after_absinst =
-    let doc =
-      "(Experimental) Use SMT solver to prune unsatisfiable branches after abstract \
-       interpretation"
-    in
-    Arg.(
-      value
-      & opt (enum [ ("none", `None); ("fast", `Fast); ("slow", `Slow) ]) `None
-      & info [ "smt-pruning-after-absint" ] ~doc)
-
-
-  let smt_pruning_keep_redundant_assertions =
-    let doc =
-      "(Experimental) Keep assertions even if provably redundant during SMT pruning"
-    in
-    Arg.(value & flag & info [ "smt-pruning-keep-redundant-assertions" ] ~doc)
-
-
-  let smt_pruning_at_runtime =
-    let doc = "(Experimental) Use SMT solver to prune branches at runtime" in
-    Arg.(value & flag & info [ "smt-pruning-at-runtime" ] ~doc)
-
-
-  let runtime_assert_domain =
-    let doc = "Enable assert_domain checks at runtime (disabled by default)" in
-    Arg.(value & flag & info [ "runtime-assert-domain" ] ~doc)
-
-
-  let static_absint =
-    let doc =
-      "(Experimental) Use static abstract interpretation with specified domain (or a \
-       comma-separated list). (e.g., 'interval', 'wrapped_interval', 'tristate')"
-    in
-    Arg.(
-      value
-      & opt
-          (list
-             (enum
-                [ ("interval", "interval");
-                  ("wrapped_interval", "wrapped_interval");
-                  ("tristate", "tristate")
-                ]))
-          []
-      & info [ "static-absint" ] ~docv:"DOMAIN" ~doc)
-
-
-  let local_iterations =
-    let doc = "Maximum iterations for local abstract interpretation refinement" in
-    Arg.(
-      value
-      & opt int TestGeneration.default_cfg.local_iterations
-      & info [ "local-iterations" ] ~doc)
 
 
   let print_size_info =
@@ -716,66 +520,6 @@ module Flags = struct
     Arg.(value & flag & info [ "print-timing-info" ] ~doc)
 
 
-  let just_reset_solver =
-    let doc =
-      "Just reset the SMT solver instead of closing and creating a new one. WARNING: A \
-       bunch of stuff breaks."
-    in
-    Arg.(value & flag & info [ "just-reset-solver" ] ~doc)
-
-
-  let smt_skewing_mode =
-    let doc =
-      "Set SMT skewing mode for symbolic test generation. Options: uniform (uniform \
-       random values), sized (default, size-based values), none (no skewing)"
-    in
-    Arg.(
-      value
-      & opt
-          (enum TestGeneration.Options.smt_skewing_mode)
-          TestGeneration.default_cfg.smt_skewing_mode
-      & info [ "smt-skewing" ] ~docv:"MODE" ~doc)
-
-
-  let symbolic =
-    let doc =
-      "(Experimental) Use symbolic execution for test generation instead of concrete \
-       value generation."
-    in
-    Arg.(value & flag & info [ "symbolic" ] ~doc)
-
-
-  let symbolic_timeout =
-    let doc = "Set timeout for SMT solver in symbolic mode (milliseconds)" in
-    Arg.(value & opt (some int) None & info [ "symbolic-timeout" ] ~doc)
-
-
-  let smt_solver =
-    let doc =
-      "Choose SMT solver backend for symbolic test generation (z3, cvc5 is unsupported)."
-    in
-    Arg.(
-      value
-      & opt (enum TestGeneration.Options.smt_solver) TestGeneration.default_cfg.smt_solver
-      & info [ "solver-type" ] ~docv:"SOLVER" ~doc)
-
-
-  let use_solver_eval =
-    let doc = "(Experimental) Use solver-based evaluation" in
-    Arg.(value & flag & info [ "use-solver-eval" ] ~doc)
-
-
-  let smt_logging =
-    let doc = "Log SMT solver communication to specified file" in
-    Arg.(value & opt (some string) None & info [ "smt-logging" ] ~doc ~docv:"FILE")
-
-
-  let smt_log_unsat_cores =
-    let doc = "Log unsat cores to specified file when constraints are unsatisfiable" in
-    Arg.(
-      value & opt (some string) None & info [ "smt-log-unsat-cores" ] ~doc ~docv:"FILE")
-
-
   let max_input_alloc =
     let doc =
       "Maximum memory size for the random input allocator (default: 32m). Supports \
@@ -783,11 +527,6 @@ module Flags = struct
        33554432, 64m"
     in
     Arg.(value & opt (some size_converter) None & info [ "max-input-alloc" ] ~doc)
-
-
-  let smt_skew_pointer_order =
-    let doc = "Enable pointer ordering skewing in SMT solver" in
-    Arg.(value & flag & info [ "smt-skew-pointer-order" ] ~doc)
 
 
   let dsl_log_dir =
@@ -798,14 +537,40 @@ module Flags = struct
     Arg.(value & opt (some string) None & info [ "dsl-log-dir" ] ~docv:"DIR" ~doc)
 
 
-  let lazy_gen =
-    let doc = "Enable lazy generation" in
-    Arg.(value & flag & info [ "lazy-gen" ] ~doc)
+  let max_stack_depth =
+    let doc = "Maximum stack depth for generators" in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.max_stack_depth
+      & info [ "max-stack-depth" ] ~doc)
 
 
-  let disable_extrema_skew =
-    let doc = "Disable extreme value (MIN/MAX) skewing in sized generators" in
-    Arg.(value & flag & info [ "disable-extrema-skew" ] ~doc)
+  let max_depth_failures =
+    let doc = "Maximum number of depth failures allowed before giving up" in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.max_depth_failures
+      & info [ "max-depth-failures" ] ~doc)
+
+
+  let max_generator_size =
+    let doc =
+      "Maximum size for generated values (also bounds generator recursion depth)"
+    in
+    Arg.(
+      value
+      & opt (some int) TestGeneration.default_cfg.max_generator_size
+      & info [ "max-generator-size" ] ~doc)
+
+
+  let sizing_strategy =
+    let doc = "Strategy for deciding test case size." in
+    Arg.(
+      value
+      & opt
+          (some (enum TestGeneration.Options.sizing_strategy))
+          TestGeneration.default_cfg.sizing_strategy
+      & info [ "sizing-strategy" ] ~doc)
 
 
   let discard_factor =
@@ -814,107 +579,121 @@ module Flags = struct
       value
       & opt int TestGeneration.default_cfg.discard_factor
       & info [ "discard-factor" ] ~doc)
+
+
+  let disable_extrema_skew =
+    let doc = "Disable extreme value (MIN/MAX) skewing in sized generators" in
+    Arg.(value & flag & info [ "disable-extrema-skew" ] ~doc)
 end
 
-let cmd =
-  let open Term in
-  let test_t =
-    const run_tests
-    $ Common.Flags.file
-    $ Common.Flags.cc
-    $ Common.Flags.macros
-    $ Common.Flags.permissive
-    $ Common.Flags.incl_dirs
-    $ Common.Flags.incl_files
-    $ Common.Flags.debug_level
-    $ Common.Flags.print_level
-    $ Common.Flags.csv_times
-    $ Common.Flags.astprints
-    $ Common.Flags.no_inherit_loc
-    $ Common.Flags.magic_comment_char_dollar
-    $ Common.Flags.allow_split_magic_comments
-    $ Instrument.Flags.without_ownership_checking
-    $ Instrument.Flags.exec_c_locs_mode
-    $ Instrument.Flags.correct_missing_ownership_mode
-    $ Instrument.Flags.experimental_ownership_stack_mode
-    $ Flags.print_steps
-    $ Flags.output_dir
-    $ Flags.only
-    $ Flags.skip
-    $ Flags.only_fulminate
-    $ Flags.skip_fulminate
-    $ Flags.dont_run
-    $ Flags.gen_num_samples
-    $ Flags.gen_backtrack_attempts
-    $ Flags.gen_max_unfolds
-    $ Flags.max_array_length
-    $ Flags.build_tool
-    $ Term.product Flags.sanitize Flags.no_sanitize
-    $ Flags.print_seed
-    $ Flags.input_timeout
-    $ Flags.null_in_every
-    $ Flags.seed
-    $ Flags.logging_level
-    $ Flags.trace_granularity
-    $ Flags.progress_level
-    $ Flags.until_timeout
-    $ Flags.exit_fast
+(* Compose two engine flag updaters *)
+let compose_flags (a : engine_flags Term.t) (b : engine_flags Term.t)
+  : engine_flags Term.t
+  =
+  Term.(const (fun f g cfg -> g (f cfg)) $ a $ b)
+
+
+(* Generation flags shared by all engines. They configure the shared test
+   harness and generator sizing, which also bound Darcy's path selection:
+   the path selectors check the per-test size (from --max-generator-size and
+   --sizing-strategy) and stack depth, the harness loop applies
+   --discard-factor, and sized skewing (--disable-extrema-skew) is used by
+   both the random sized domain and Darcy's default SMT skewing mode. *)
+let gen_term : engine_flags Term.t =
+  let make
+        max_stack_depth
+        max_depth_failures
+        max_generator_size
+        sizing_strategy
+        discard_factor
+        disable_extrema_skew
+        (cfg : TestGeneration.config)
+    : TestGeneration.config
+    =
+    { cfg with
+      max_stack_depth;
+      max_depth_failures;
+      max_generator_size;
+      sizing_strategy;
+      discard_factor;
+      disable_extrema_skew
+    }
+  in
+  Term.(
+    const make
     $ Flags.max_stack_depth
     $ Flags.max_depth_failures
     $ Flags.max_generator_size
     $ Flags.sizing_strategy
-    $ Flags.random_size_splits
-    $ Flags.allowed_size_split_backtracks
-    $ Flags.sized_null
-    $ Flags.coverage
-    $ Flags.disable_passes
-    $ Flags.trap
-    $ Flags.no_replays
-    $ Flags.no_replicas
-    $ Flags.output_tyche
-    $ Flags.inline
-    $ Flags.experimental_struct_asgn_destruction
-    $ Flags.experimental_product_arg_destruction
-    $ Flags.experimental_learning
-    $ Flags.experimental_arg_pruning
-    $ Flags.experimental_return_pruning
-    $ Flags.static_absint
-    $ Flags.local_iterations
-    $ Flags.smt_pruning_before_absinst
-    $ Flags.smt_pruning_after_absinst
-    $ Flags.smt_pruning_keep_redundant_assertions
-    $ Flags.smt_pruning_at_runtime
-    $ Flags.runtime_assert_domain
-    $ Flags.symbolic
-    $ Flags.symbolic_timeout
-    $ Flags.use_solver_eval
-    $ Flags.smt_solver
-    $ Flags.smt_logging
-    $ Flags.smt_log_unsat_cores
-    $ Flags.print_size_info
-    $ Flags.print_backtrack_info
-    $ Flags.print_satisfaction_info
-    $ Flags.print_discard_info
-    $ Flags.print_timing_info
-    $ Flags.just_reset_solver
-    $ Flags.smt_skewing_mode
-    $ Instrument.Flags.max_bump_blocks
-    $ Instrument.Flags.bump_block_size
-    $ Flags.max_input_alloc
-    $ Flags.smt_skew_pointer_order
-    $ Flags.dsl_log_dir
-    $ Flags.lazy_gen
-    $ Flags.disable_specialization
-    $ Flags.only_top_level_ite_lifting
-    $ Flags.disable_extrema_skew
     $ Flags.discard_factor
-  in
-  let doc =
-    "Generates tests for all functions in [FILE] with CN specifications.\n\
-    \    The tests use randomized inputs, which are guaranteed to satisfy the CN \
-     precondition.\n\
-    \    A script [run_tests.sh] for building and running the tests will be placed in \
-     [output-dir]."
-  in
-  let info = Cmd.info "test" ~doc in
-  Cmd.v info test_t
+    $ Flags.disable_extrema_skew)
+
+
+(* The common flag chain, shared by all engine subcommands. [engine] decides
+   which pipeline runs; [engine_flags] is the engine's config updater, so
+   wrong-engine flags are rejected as unknown options. *)
+let mk_term ~(engine : TestGeneration.engine Term.t) ~(engine_flags : engine_flags Term.t)
+  : unit Term.t
+  =
+  let open Term in
+  const run
+  $ engine
+  $ Common.Flags.file
+  $ Common.Flags.cc
+  $ Common.Flags.macros
+  $ Common.Flags.permissive
+  $ Common.Flags.incl_dirs
+  $ Common.Flags.incl_files
+  $ Common.Flags.debug_level
+  $ Common.Flags.print_level
+  $ Common.Flags.csv_times
+  $ Common.Flags.astprints
+  $ Common.Flags.no_inherit_loc
+  $ Common.Flags.magic_comment_char_dollar
+  $ Common.Flags.allow_split_magic_comments
+  $ Instrument.Flags.without_ownership_checking
+  $ Instrument.Flags.exec_c_locs_mode
+  $ Instrument.Flags.correct_missing_ownership_mode
+  $ Instrument.Flags.experimental_ownership_stack_mode
+  $ Flags.print_steps
+  $ Flags.output_dir
+  $ Flags.only
+  $ Flags.skip
+  $ Flags.only_fulminate
+  $ Flags.skip_fulminate
+  $ Flags.dont_run
+  $ Flags.gen_num_samples
+  $ Flags.gen_max_unfolds
+  $ Flags.build_tool
+  $ Term.product Flags.sanitize Flags.no_sanitize
+  $ Flags.print_seed
+  $ Flags.input_timeout
+  $ Flags.null_in_every
+  $ Flags.seed
+  $ Flags.logging_level
+  $ Flags.trace_granularity
+  $ Flags.progress_level
+  $ Flags.until_timeout
+  $ Flags.exit_fast
+  $ Flags.coverage
+  $ Flags.disable_passes
+  $ Flags.trap
+  $ Flags.no_replays
+  $ Flags.no_replicas
+  $ Flags.output_tyche
+  $ Flags.inline
+  $ Flags.experimental_struct_asgn_destruction
+  $ Flags.experimental_product_arg_destruction
+  $ Flags.experimental_arg_pruning
+  $ Flags.experimental_return_pruning
+  $ Flags.print_size_info
+  $ Flags.print_backtrack_info
+  $ Flags.print_satisfaction_info
+  $ Flags.print_discard_info
+  $ Flags.print_timing_info
+  $ Instrument.Flags.max_bump_blocks
+  $ Instrument.Flags.bump_block_size
+  $ Flags.max_input_alloc
+  $ Flags.dsl_log_dir
+  $ Flags.disable_specialization
+  $ compose_flags gen_term engine_flags

--- a/bin/test/test.ml
+++ b/bin/test/test.ml
@@ -1,0 +1,69 @@
+(* The `cn test` command group: engine subcommands (bennet/darcy/lucas) plus
+   the deprecated flat `--symbolic` interface as the default term. *)
+
+open Cn
+open Cmdliner
+
+let symbolic_flag =
+  let doc =
+    "(Experimental) Use symbolic execution for test generation instead of concrete value \
+     generation."
+  in
+  let deprecated = "Use 'cn test darcy' instead." in
+  Arg.(value & flag & info [ "symbolic" ] ~deprecated ~doc)
+
+
+let warn_default_engine () =
+  prerr_endline
+    "cn test: deprecated: no engine selected, defaulting to 'bennet'; select one \
+     explicitly with 'cn test bennet|darcy|lucas'"
+
+
+(* Deprecated flat interface: `cn test FILE` runs bennet (the previous default
+   behavior) and `cn test --symbolic FILE` still works (as darcy). It accepts
+   the full flat flag set for backward compatibility. *)
+let legacy_t =
+  let engine =
+    let from_symbolic symbolic =
+      if symbolic then
+        TestGeneration.Darcy
+      else (
+        warn_default_engine ();
+        TestGeneration.Bennet)
+    in
+    Term.(const from_symbolic $ symbolic_flag)
+  in
+  Shared.mk_term ~engine ~engine_flags:(Shared.compose_flags Bennet.term Darcy.term)
+
+
+(* Cmdliner resolves the first positional of a command group as a subcommand
+   name and errors before the default term can run, so `cn test FILE` would
+   fail with "unknown command". Rewrite argv to insert "bennet" when the
+   argument after "test" is neither a flag nor (a prefix of) an engine name,
+   preserving the old default. *)
+let argv_with_default_engine (argv : string array) : string array =
+  let is_prefix_of s cmd =
+    String.length s > 0
+    && String.length s <= String.length cmd
+    && String.equal s (String.sub cmd 0 (String.length s))
+  in
+  match Array.to_list argv with
+  | exe :: maybe_test :: arg :: rest
+    when is_prefix_of maybe_test "test"
+         && (not (String.starts_with ~prefix:"-" arg))
+         && not (List.exists (is_prefix_of arg) [ "bennet"; "darcy"; "lucas" ]) ->
+    warn_default_engine ();
+    Array.of_list (exe :: maybe_test :: "bennet" :: arg :: rest)
+  | _ -> argv
+
+
+let cmd =
+  let doc =
+    "Generates tests for all functions in [FILE] with CN specifications.\n\
+    \    The inputs are guaranteed to satisfy the CN precondition.\n\
+    \    Engines: bennet (random backtracking search, the default), darcy \
+     (symbolic/SMT-based), lucas (randomized refinement of abstract elements).\n\
+    \    A script [run_tests.sh] for building and running the tests will be placed in \
+     [output-dir]."
+  in
+  Cmd.group ~default:legacy_t (Cmd.info "test" ~doc) [ Bennet.cmd; Darcy.cmd; Lucas.cmd ]

--- a/bin/test/test.ml
+++ b/bin/test/test.ml
@@ -1,5 +1,10 @@
-(* The `cn test` command group: engine subcommands (bennet/darcy/lucas) plus
-   the deprecated flat `--symbolic` interface as the default term. *)
+(* The `cn test` command group: engine subcommands (bennet/darcy/lucas), plus a
+   deprecated flat interface (`cn test [--symbolic] FILE`) for backward
+   compatibility. Cmdliner resolves the first positional of a command group as
+   a subcommand name and errors before any default term runs, so the group
+   itself cannot handle `cn test FILE`. Instead, main.ml consults
+   [wants_legacy] and evaluates a command tree containing [legacy_cmd] (a flat
+   `test` command whose Cmd.info is marked deprecated) in place of [cmd]. *)
 
 open Cn
 open Cmdliner
@@ -13,22 +18,23 @@ let symbolic_flag =
   Arg.(value & flag & info [ "symbolic" ] ~deprecated ~doc)
 
 
-let warn_default_engine () =
-  prerr_endline
-    "cn test: deprecated: no engine selected, defaulting to 'bennet'; select one \
-     explicitly with 'cn test bennet|darcy|lucas'"
-
-
-(* Deprecated flat interface: `cn test FILE` runs bennet (the previous default
-   behavior) and `cn test --symbolic FILE` still works (as darcy). It accepts
+(* Deprecated flat interface: `cn test FILE` runs Bennet (the previous default
+   behavior) and `cn test --symbolic FILE` still works (as Darcy). It accepts
    the full flat flag set for backward compatibility. *)
 let legacy_t =
   let engine =
     let from_symbolic symbolic =
-      if symbolic then
-        TestGeneration.Darcy
+      if symbolic then (
+        Cn.Pp.(
+          warn_noloc
+            !^"Use 'cn test darcy' instead. Plain `cn test` will be removed after July \
+               15th.");
+        TestGeneration.Darcy)
       else (
-        warn_default_engine ();
+        Cn.Pp.(
+          warn_noloc
+            !^"Use 'cn test bennet' instead. Plain `cn test` will be removed after July \
+               15th.");
         TestGeneration.Bennet)
     in
     Term.(const from_symbolic $ symbolic_flag)
@@ -36,34 +42,32 @@ let legacy_t =
   Shared.mk_term ~engine ~engine_flags:(Shared.compose_flags Bennet.term Darcy.term)
 
 
-(* Cmdliner resolves the first positional of a command group as a subcommand
-   name and errors before the default term can run, so `cn test FILE` would
-   fail with "unknown command". Rewrite argv to insert "bennet" when the
-   argument after "test" is neither a flag nor (a prefix of) an engine name,
-   preserving the old default. *)
-let argv_with_default_engine (argv : string array) : string array =
-  let is_prefix_of s cmd =
+let doc =
+  "Generates tests for all functions in [FILE] with CN specifications.\n\
+  \    The inputs are guaranteed to satisfy the CN precondition.\n\
+  \    Engines: bennet (random backtracking search, the default), darcy \
+   (symbolic/SMT-based), lucas (randomized refinement of abstract elements).\n\
+  \    A script [run_tests.sh] for building and running the tests will be placed in \
+   [output-dir]."
+
+
+let cmd = Cmd.group (Cmd.info "test" ~doc) [ Bennet.cmd; Darcy.cmd; Lucas.cmd ]
+
+let legacy_cmd = Cmd.v (Cmd.info "test" ~doc) legacy_t
+
+(* Whether argv is a legacy flat invocation: `cn test ARG ...` where ARG is
+   neither (a prefix of) an engine name nor a help/version request. Engine
+   names are prefix-matched because Cmdliner resolves unambiguous command-name
+   prefixes. *)
+let wants_legacy (argv : string array) : bool =
+  let is_prefix_of s cmd' =
     String.length s > 0
-    && String.length s <= String.length cmd
-    && String.equal s (String.sub cmd 0 (String.length s))
+    && String.length s <= String.length cmd'
+    && String.equal s (String.sub cmd' 0 (String.length s))
   in
   match Array.to_list argv with
-  | exe :: maybe_test :: arg :: rest
-    when is_prefix_of maybe_test "test"
-         && (not (String.starts_with ~prefix:"-" arg))
-         && not (List.exists (is_prefix_of arg) [ "bennet"; "darcy"; "lucas" ]) ->
-    warn_default_engine ();
-    Array.of_list (exe :: maybe_test :: "bennet" :: arg :: rest)
-  | _ -> argv
-
-
-let cmd =
-  let doc =
-    "Generates tests for all functions in [FILE] with CN specifications.\n\
-    \    The inputs are guaranteed to satisfy the CN precondition.\n\
-    \    Engines: bennet (random backtracking search, the default), darcy \
-     (symbolic/SMT-based), lucas (randomized refinement of abstract elements).\n\
-    \    A script [run_tests.sh] for building and running the tests will be placed in \
-     [output-dir]."
-  in
-  Cmd.group ~default:legacy_t (Cmd.info "test" ~doc) [ Bennet.cmd; Darcy.cmd; Lucas.cmd ]
+  | _exe :: maybe_test :: arg :: _ when is_prefix_of maybe_test "test" ->
+    (not (List.exists (is_prefix_of arg) [ "bennet"; "darcy"; "lucas" ]))
+    && (not (String.starts_with ~prefix:"--help" arg))
+    && not (String.equal arg "--version")
+  | _ -> false

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -6,10 +6,18 @@ CN has testing capabilities available via the `cn test` subcommand.
 
 Currently, CN supports only per-function tests, but additional types of testing may become available in the future.
 
-Running `cn test <filename.c>` generates C files with the testing infrastructure, the instrumented program under test, and a build script named `run_tests.sh`.
+`cn test` chooses an input generation engine via subcommand:
+
+- `cn test bennet <filename.c>` uses randomized input generation (Bennet, the default).
+- `cn test darcy <filename.c>` uses symbolic (SMT-based) input generation (Darcy). This replaces the deprecated `cn test --symbolic` flag.
+- `cn test lucas <filename.c>` uses randomized refinement of abstract elements (Lucas), generalizing Bennet's randomized pipeline. It accepts Bennet's flags plus the abstract-domain flags.
+
+Each engine subcommand only accepts the flags relevant to it (plus the common testing flags), so e.g. `--smt-logging` is rejected under `bennet`, and the abstract-domain flags (e.g. `--static-absint`) are only available under `lucas`.
+
+Running `cn test <engine> <filename.c>` generates C files with the testing infrastructure, the instrumented program under test, and a build script named `run_tests.sh`.
 This script compiles the C files and runs the tests.
 
-By default, running `cn test` will automatically run `run_tests.sh`, which produces a test executable `tests.out`.
+By default, running `cn test <engine>` will automatically run `run_tests.sh`, which produces a test executable `tests.out`.
 This can be disabled by using the `--no-run` flag.
 
 The default behavior of testing is to rely on Fulminate for checking, which does not detect undefined behavior.
@@ -45,6 +53,6 @@ There is currently no way to write custom property-based tests.
 However, once lemmas can be tested, a lemma describing the desired property could be written to test it.
 
 In terms of unit tests, one can simply define a function that performs the desired operations.
-This function will get detected by `cn test` and turned into a constant test.
+This function will get detected by `cn test <engine>` and turned into a constant test.
 Any assertions that one would make about the result would have to be captured by the post-condition.
 In the future, existing infrastructure like `cn_assert` might be adapted for general use.

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -2,9 +2,10 @@ type build_tool =
   | Bash
   | Make
 
-type generation_mode =
-  | Concrete (* Backtracking random search *)
-  | Symbolic (* Symbolic constraint-based generation *)
+type engine =
+  | Bennet (* Backtracking random search *)
+  | Darcy (* Symbolic constraint-based generation *)
+  | Lucas (* Randomized refinement of abstract elements *)
 
 type logging_level =
   | None
@@ -62,7 +63,7 @@ type t =
     smt_pruning_remove_redundant_assertions : bool;
     smt_pruning_at_runtime : bool;
     runtime_assert_domain : bool;
-    symbolic : bool;
+    engine : engine;
     symbolic_timeout : int option; (* SMT solver timeout for symbolic solving (ms) *)
     max_unfolds : int option; (* Maximum unfolds for symbolic execution *)
     max_array_length : int; (* For symbolic execution *)
@@ -132,7 +133,7 @@ let default =
     smt_pruning_remove_redundant_assertions = true;
     smt_pruning_at_runtime = false;
     runtime_assert_domain = false;
-    symbolic = false;
+    engine = Bennet;
     symbolic_timeout = None;
     max_unfolds = None;
     max_array_length = 50;
@@ -377,7 +378,11 @@ let will_print_discard_info () = (Option.get !instance).print_discard_info
 
 let will_print_timing_info () = (Option.get !instance).print_timing_info
 
-let is_symbolic_enabled () = (Option.get !instance).symbolic
+let get_engine () = (Option.get !instance).engine
+
+let is_symbolic_enabled () =
+  match get_engine () with Darcy -> true | Bennet | Lucas -> false
+
 
 let has_symbolic_timeout () = (Option.get !instance).symbolic_timeout
 

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -2,9 +2,10 @@ type build_tool =
   | Bash
   | Make
 
-type generation_mode =
-  | Concrete (* Existing arbitrary/guided fuzzing *)
-  | Symbolic (* New symbolic constraint-based generation *)
+type engine =
+  | Bennet (* Backtracking random search *)
+  | Darcy (* Symbolic constraint-based generation *)
+  | Lucas (* Randomized refinement of abstract elements *)
 
 type logging_level =
   | None
@@ -62,7 +63,7 @@ type t =
     smt_pruning_remove_redundant_assertions : bool;
     smt_pruning_at_runtime : bool;
     runtime_assert_domain : bool;
-    symbolic : bool;
+    engine : engine;
     symbolic_timeout : int option; (* SMT solver timeout for symbolic solving (ms) *)
     max_unfolds : int option; (* Maximum unfolds for symbolic execution *)
     max_array_length : int; (* For symbolic execution *)
@@ -232,6 +233,8 @@ val will_print_satisfaction_info : unit -> bool
 val will_print_discard_info : unit -> bool
 
 val will_print_timing_info : unit -> bool
+
+val get_engine : unit -> engine
 
 val is_symbolic_enabled : unit -> bool
 

--- a/lib/testGeneration/testGeneration.ml
+++ b/lib/testGeneration/testGeneration.ml
@@ -13,6 +13,11 @@ module Private = struct
   module Bennet = Bennet
 end
 
+type engine = TestGenConfig.engine =
+  | Bennet
+  | Darcy
+  | Lucas
+
 type config = Config.t
 
 let default_cfg : config = Config.default

--- a/lib/testGeneration/testGeneration.mli
+++ b/lib/testGeneration/testGeneration.mli
@@ -2,6 +2,13 @@ module Private : sig
   module Bennet = Bennet
 end
 
+module Config = TestGenConfig
+
+type engine = TestGenConfig.engine =
+  | Bennet
+  | Darcy
+  | Lucas
+
 type config = TestGenConfig.t
 
 val default_cfg : config

--- a/tests/run-cn-test-gen.py
+++ b/tests/run-cn-test-gen.py
@@ -150,7 +150,7 @@ def format_size(nbytes):
     return f"{nbytes}b"
 
 
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 
 
 def _config_hash(config_str):
@@ -227,13 +227,16 @@ def _kill_active_procs():
 
 
 def get_test_type(test_file, config):
-    """Determine the expected test result type based on filename and config."""
+    """Determine the expected test result type based on filename and config.
+
+    The config string starts with the engine subcommand (bennet/darcy/lucas).
+    """
     test_file = Path(test_file).name
 
     if (test_file.endswith('learn_cast.special.c')
         or test_file.endswith('learn_multiple.special.c')
             or test_file.endswith('pointer_ordering.special.c')):
-        if '--symbolic' in config:
+        if config.startswith('darcy'):
             return 'PASS'
         else:
             return 'SKIP'
@@ -253,7 +256,8 @@ def run_cn_test(cn_path, test_file, config, memory_limit=None):
     """Run CN test with given configuration and return (return_code, elapsed_time, test_output, oom)."""
     start_time = time.time()
 
-    cmd = [cn_path, 'test', str(test_file)] + config.split()
+    # config starts with the engine subcommand, which must precede the file
+    cmd = [cn_path, 'test'] + config.split() + [str(test_file)]
 
     # Wrap with systemd-run for cgroup memory limits on Linux
     use_systemd = memory_limit is not None and _use_systemd
@@ -440,32 +444,33 @@ def main():
     env['ASAN_OPTIONS'] = 'allocator_may_return_null=1:detect_leaks=0'
     os.environ.update(env)
 
-    # Base configuration
-    solver_config = f" --solver-type={args.solver_type}" if args.solver_type else ""
-
+    # Base configuration (common flags only; engine-specific flags are added below)
     base_config = (
         f"-I{opam_prefix}/lib/cerberus-lib/runtime/libc/include/posix "
         "--input-timeout=1000 "
         "--progress-level=function "
         "--sanitize=address,undefined "
         "--allow-split-magic-comments "
-        "--max-generator-size=16 "
         "--print-seed"
-        f"{solver_config}"
     )
 
-    # Set configurations based on symbolic option
+    # Set engine and configurations based on symbolic option. Each alt config
+    # carries its engine: abstract-domain flags are only accepted by the lucas
+    # engine (lucas = bennet + abstract domains).
     if args.symbolic:
+        if args.solver_type:
+            base_config += f" --solver-type={args.solver_type}"
         alt_configs = [
-            "--symbolic --coverage --print-backtrack-info --print-satisfaction-info --smt-pruning-at-runtime --symbolic-timeout=2000",
-            "--symbolic --coverage --print-backtrack-info --print-satisfaction-info --smt-pruning-before-absint=slow"
+            ("darcy", "--coverage --print-backtrack-info --print-satisfaction-info --symbolic-timeout=2000"),
+            ("darcy", "--coverage --print-backtrack-info --print-satisfaction-info")
         ]
     else:
+        base_config += " --max-generator-size=16"
         alt_configs = [
-            "--coverage --sizing-strategy=quickcheck --inline=everything",
-            "--coverage --experimental-learning --print-backtrack-info --print-size-info --static-absint=wrapped_interval --smt-pruning-after-absint=slow --runtime-assert-domain --local-iterations=15",
-            "--sizing-strategy=uniform --lazy-gen --experimental-product-arg-destruction --experimental-return-pruning --experimental-arg-pruning --static-absint=interval --smt-pruning-before-absint=fast",
-            "--experimental-learning --print-satisfaction-info --output-tyche=results.jsonl --inline=nonrec --static-absint=tristate"
+            ("bennet", "--coverage --sizing-strategy=quickcheck --inline=everything"),
+            ("lucas", "--coverage --experimental-learning --print-backtrack-info --print-size-info --static-absint=wrapped_interval --smt-pruning-after-absint=slow --runtime-assert-domain --local-iterations=15"),
+            ("lucas", "--sizing-strategy=uniform --lazy-gen --experimental-product-arg-destruction --experimental-return-pruning --experimental-arg-pruning --static-absint=interval --smt-pruning-before-absint=fast"),
+            ("lucas", "--experimental-learning --print-satisfaction-info --output-tyche=results.jsonl --inline=nonrec --static-absint=tristate")
         ]
 
     # Set build tools based on argument
@@ -530,9 +535,9 @@ def main():
     # Build flat job list
     jobs = []
     for tf in test_files:
-        for alt_config in alt_configs:
+        for engine, alt_config in alt_configs:
             for build_tool in build_tools:
-                full_config = f"{base_config} {alt_config} --build-tool={build_tool}"
+                full_config = f"{engine} {base_config} {alt_config} --build-tool={build_tool}"
 
                 if args.symbolic and Path(tf).name == "ini_queue.fail.c":
                     full_config += ' --exit-fast'
@@ -570,7 +575,8 @@ def main():
         if m:
             cfg = cfg.replace(
                 m.group(), f'--max-generator-size={int(m.group(1)) // 2}')
-        else:
+        elif cfg.startswith(('bennet', 'lucas')):
+            # --max-generator-size only exists on the bennet and lucas engines
             cfg += ' --max-generator-size=16'
         return cfg
 


### PR DESCRIPTION
Currently, a single flag can turn on a completely different testing backend. This preserves the existing `cn test`, while giving a deprecation warning. This is partially in anticipation of upcoming work, which will add further confusion.