### PR TITLE
[README] Adjust the command to start a docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ interactive shell with the Ubuntu image:
 
 ```
 docker pull ghcr.io/rems-project/cn:release-ubuntu
-docker run --rm -it ghcr.io/rems-project/cn:release-ubuntu
+docker run --rm -it ghcr.io/rems-project/cn:release-ubuntu bash
 ```
 
 The `release-devcontainer` tag is the image used by the VS Code Dev Container


### PR DESCRIPTION
When starting the image, we may want to pass a shell to the entrypoint script, so that the entrypoint script starts a shell and the initial process persists. Without that, the docker command exits after printing a warning message:

```
[WARNING] Running as root is not recommended
```

(This is from `opam env` in the entrypoint script.)