### PR TITLE
Fix faulty test failure check

### DIFF
--- a/lib/seqTests/buildScript.ml
+++ b/lib/seqTests/buildScript.ml
@@ -66,9 +66,13 @@ let compile ~filename_base =
        ("Failed to compile '" ^ filename_base ^ ".test.c' in ${TEST_DIR}.")
   ^^ (twice hardline
       ^^ attempt
+           (* skip recompiling instrumented program file *)
            (String.concat
               " "
-              ([ Config.get_cc ();
+              ([ "{ [ -f \"./" ^ filename_base ^ ".exec.o\" ]";
+                 "&& [ ! \"./" ^ filename_base ^ ".exec.c\"";
+                 "-nt \"./" ^ filename_base ^ ".exec.o\" ]; } ||";
+                 Config.get_cc ();
                  "${CFLAGS}";
                  "${CPPFLAGS}";
                  "-c";

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -191,8 +191,6 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
   ^^ twice hardline
   ^^ string "#include <cn-executable/utils.h>"
   ^^ twice hardline
-  ^^ string SUtils.seq_failure_callback_def
-  ^^ twice hardline
   ^^ string "int main"
   ^^ parens (string "int argc, char* argv[]")
   ^^ break 1
@@ -202,11 +200,7 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
           (hardline
            ^^
            let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-           separate_map hardline SUtils.stmt_to_doc init_ghost
-           ^^ hardline
-           ^^ string "set_cn_failure_cb(&seq_failure_cb);"
-           ^^ hardline
-           ^^ sequence)
+           separate_map hardline SUtils.stmt_to_doc init_ghost ^^ hardline ^^ sequence)
         ^^ hardline)
 
 

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -191,6 +191,8 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
   ^^ twice hardline
   ^^ string "#include <cn-executable/utils.h>"
   ^^ twice hardline
+  ^^ string SUtils.seq_failure_callback_def
+  ^^ twice hardline
   ^^ string "int main"
   ^^ parens (string "int argc, char* argv[]")
   ^^ break 1
@@ -200,7 +202,11 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
           (hardline
            ^^
            let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-           separate_map hardline SUtils.stmt_to_doc init_ghost ^^ hardline ^^ sequence)
+           separate_map hardline SUtils.stmt_to_doc init_ghost
+           ^^ hardline
+           ^^ string "set_cn_failure_cb(&seq_failure_cb);"
+           ^^ hardline
+           ^^ sequence)
         ^^ hardline)
 
 

--- a/lib/seqTests/utils.ml
+++ b/lib/seqTests/utils.ml
@@ -174,6 +174,20 @@ let rec combine_stats (stats_list : T.test_stats list) (combined_stats : T.test_
     combine_stats stats_list combined_stats
 
 
+(* differentiate b/w precondition failure because an unsatisfying call was generated vs
+   a precondition violation within a function in the program under test *)
+let seq_failure_callback_def =
+  String.concat
+    "\n"
+    [ "void seq_failure_cb(enum cn_failure_mode failure_mode, enum spec_mode spec_mode)";
+      "{";
+      "  if (failure_mode == CN_FAILURE_USER_ALLOC) { return; }";
+      "  if (spec_mode == PRE && get_cn_stack_depth() > 1) { exit(POST); }";
+      "  exit(spec_mode);";
+      "}"
+    ]
+
+
 let create_intermediate_test_file
       (sequences : Pp.document list)
       (tests_to_try : Pp.document list)
@@ -193,6 +207,8 @@ let create_intermediate_test_file
              ^^
              let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
              separate_map hardline stmt_to_doc init_ghost
+             ^^ hardline
+             ^^ string "set_cn_failure_cb(&seq_failure_cb);"
              ^^ hardline
              ^^ sequence
              ^^ hardline
@@ -232,6 +248,8 @@ let create_intermediate_test_file
         ])
    ^^ twice hardline
    ^^ fun_decls)
+  ^^ twice hardline
+  ^^ string seq_failure_callback_def
   ^^ twice hardline
   ^^ separate
        (twice hardline)

--- a/tests/cn-seq-test-gen/src/nested_precondition.fail.c
+++ b/tests/cn-seq-test-gen/src/nested_precondition.fail.c
@@ -1,0 +1,24 @@
+/* Regression test: a function under test that violates its callee's
+   precondition is a bug and must be reported and not discarded.
+*/
+
+void callee(int x)
+/*@
+requires
+  x >= 0i32;
+ensures
+  true;
+@*/
+{
+}
+
+void buggy()
+/*@
+requires
+  true;
+ensures
+  true;
+@*/
+{
+  callee(-1);
+}


### PR DESCRIPTION
`seq-test` marked any generated call causing a precondition failure as invalid and discarded it. However, a precondition violated inside a nested call should be marked as a bug in the function under test. Reclassify nested precondition failures as violations. Top-level preconditions are checked at ghost stack depth 1, nested callees at depth >= 2. 

Also the updated the test runner script to stop recompiling the instrumented program under test file on every iteration.