### PR TITLE
Refactor Terms and IndexTerms modules

### DIFF
--- a/lib/alloc.ml
+++ b/lib/alloc.ml
@@ -25,13 +25,13 @@ module History = struct
   let it loc = IndexTerms.sym_ (sym, bt, loc)
 
   let lookup_ptr ptr loc =
-    assert (BaseTypes.(equal (IndexTerms.get_bt ptr) (Loc ())));
+    assert (BaseTypes.(equal (Terms.get_bt ptr) (Loc ())));
     IndexTerms.(map_get_ (it loc) (allocId_ ptr loc) loc)
 
 
   type value =
-    { base : IndexTerms.t;
-      size : IndexTerms.t
+    { base : Terms.Normal.t;
+      size : Terms.Normal.t
     }
 
   let split value loc =

--- a/lib/alloc.mli
+++ b/lib/alloc.mli
@@ -13,20 +13,20 @@ module History : sig
 
   val value_bt : BaseTypes.t
 
-  val make_value : base:IndexTerms.t -> size:int -> Locations.t -> IndexTerms.t
+  val make_value : base:Terms.Normal.t -> size:int -> Locations.t -> Terms.Normal.t
 
   val bt : BaseTypes.t
 
-  val it : Cerb_location.t -> IndexTerms.t
+  val it : Cerb_location.t -> Terms.Normal.t
 
-  val lookup_ptr : IndexTerms.t -> Locations.t -> IndexTerms.t
+  val lookup_ptr : Terms.Normal.t -> Locations.t -> Terms.Normal.t
 
   type value =
-    { base : IndexTerms.t;
-      size : IndexTerms.t
+    { base : Terms.Normal.t;
+      size : Terms.Normal.t
     }
 
-  val split : IndexTerms.t -> Cerb_location.t -> value
+  val split : Terms.Normal.t -> Cerb_location.t -> value
 
   val sbt : BaseTypes.Surface.t
 end

--- a/lib/argumentTypes.ml
+++ b/lib/argumentTypes.ml
@@ -1,6 +1,6 @@
 open Locations
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Req = Request
 module LC = LogicalConstraints
 module LAT = LogicalArgumentTypes
@@ -27,7 +27,7 @@ let rec subst i_subst (substitution : _ Subst.t) at =
 
 and alpha_rename i_subst s t =
   let s' = Sym.fresh_same s in
-  (s', subst i_subst (IT.make_rename ~from:s ~to_:s') t)
+  (s', subst i_subst (T.make_rename ~from:s ~to_:s') t)
 
 
 and suitably_alpha_rename i_subst syms s t =
@@ -130,7 +130,7 @@ let rec map (f : 'i -> 'j) (at : 'i t) : 'j t =
   | L t -> L (LAT.map f t)
 
 
-type ift = IndexTerms.t t
+type ift = T.t t
 
 type ft = ReturnTypes.t t
 

--- a/lib/bugExplanation/replicators.ml
+++ b/lib/bugExplanation/replicators.ml
@@ -2,6 +2,7 @@ module CF = Cerb_frontend
 module A = CF.AilSyntax
 module C = CF.Ctype
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module AT = ArgumentTypes
 module LAT = LogicalArgumentTypes
@@ -446,7 +447,7 @@ let compile_it
       filename
       (sigma : CF.GenTypes.genTypeCategory A.sigma)
       (prog5 : unit Mucore.file)
-      (it : IT.t)
+      (it : T.t)
   =
   CtA.cn_to_ail_expr_toplevel
     filename
@@ -462,7 +463,7 @@ let owned_sct_call
       (sigma : CF.GenTypes.genTypeCategory A.sigma)
       (prog5 : unit Mucore.file)
       (sct : Sctypes.t)
-      (pointer : IT.t)
+      (pointer : T.t)
   : A.bindings
     * CF.GenTypes.genTypeCategory A.statement_ list
     * CF.GenTypes.genTypeCategory A.expression
@@ -564,7 +565,7 @@ let compile_lat
     match lat with
     | Define ((x, it), _, lat') ->
       let b1, s1, e = compile_it filename sigma prog5 it in
-      let b2 = [ Utils.create_binding x (bt_to_ctype (IT.get_bt it)) ] in
+      let b2 = [ Utils.create_binding x (bt_to_ctype (T.get_bt it)) ] in
       let s2 = A.[ AilSdeclaration [ (x, Some e) ] ] in
       let b3, s3 = aux lat' in
       (b1 @ b2 @ b3, s1 @ s2 @ s3)
@@ -596,7 +597,7 @@ let compile_clauses
     : A.bindings * CF.GenTypes.genTypeCategory A.statement_ list
     =
     let aux_it it =
-      if BT.equal (IT.get_bt it) BT.Unit then
+      if BT.equal (T.get_bt it) BT.Unit then
         ([], [ A.AilSreturnVoid ])
       else (
         let b, s, e = compile_it filename sigma prog5 it in
@@ -604,7 +605,7 @@ let compile_clauses
     in
     match cls with
     | [ cl ] ->
-      assert (IT.is_true cl.guard);
+      assert (Terms.is_true cl.guard);
       compile_lat ~f:aux_it filename sigma prog5 cl.packing_ft
     | cl :: cls' ->
       let b_if, s_if, e_if = compile_it filename sigma prog5 cl.guard in
@@ -731,7 +732,7 @@ let compile_spec
   let lat =
     LAT.subst
       (fun _ x -> x)
-      (IT.make_subst
+      (T.make_subst
          (List.map
             (fun (x, y) ->
                (x, IT.sym_ (y, fst (List.assoc Sym.equal x args), Locations.other __LOC__)))

--- a/lib/bugExplanation/shapeAnalyzers.ml
+++ b/lib/bugExplanation/shapeAnalyzers.ml
@@ -4,6 +4,7 @@ module C = CF.Ctype
 module BT = BaseTypes
 module AT = ArgumentTypes
 module LAT = LogicalArgumentTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module CtA = Fulminate.Cn_to_ail
 module Utils = Fulminate.Utils
@@ -118,7 +119,7 @@ let compile_it
       filename
       (sigma : CF.GenTypes.genTypeCategory A.sigma)
       (prog5 : unit Mucore.file)
-      (it : IT.t)
+      (it : T.t)
   =
   CtA.cn_to_ail_expr_toplevel
     filename
@@ -129,8 +130,8 @@ let compile_it
     it
 
 
-let get_parent_and_size (sct : Sctypes.t) (arg : IT.t) loc =
-  let rec aux (it : IT.t) =
+let get_parent_and_size (sct : Sctypes.t) (arg : T.t) loc =
+  let rec aux (it : T.t) =
     match it with
     | IT (ArrayShift { base; ct; index }, _, loc) ->
       let base, offset = aux base in
@@ -141,7 +142,7 @@ let get_parent_and_size (sct : Sctypes.t) (arg : IT.t) loc =
     | IT (MemberShift (base, tag, member), _, loc) ->
       aux
         (IT.pointer_offset_
-           (base, IT.(IT (OffsetOf (tag, member), Memory.size_bt, loc)))
+           (base, (IT (OffsetOf (tag, member), Memory.size_bt, loc)))
            loc)
     | IT (_, _, loc) -> (it, IT.num_lit_ Z.zero Memory.uintptr_bt loc)
   in
@@ -154,7 +155,7 @@ let owned_sct_call
       (sigma : CF.GenTypes.genTypeCategory A.sigma)
       (prog5 : unit Mucore.file)
       (sct : Sctypes.t)
-      (pointer : IT.t)
+      (pointer : T.t)
   : A.bindings
     * CF.GenTypes.genTypeCategory A.statement_ list
     * CF.GenTypes.genTypeCategory A.expression
@@ -259,7 +260,7 @@ let compile_lat
     match lat with
     | Define ((x, it), _, lat') ->
       let b1, s1, e = compile_it filename sigma prog5 it in
-      let b2 = [ Utils.create_binding x (CtA.bt_to_ail_ctype (IT.get_bt it)) ] in
+      let b2 = [ Utils.create_binding x (CtA.bt_to_ail_ctype (T.get_bt it)) ] in
       let s2 = A.[ AilSdeclaration [ (x, Some e) ] ] in
       let b3, s3 = aux lat' in
       (b1 @ b2 @ b3, s1 @ s2 @ s3)
@@ -291,7 +292,7 @@ let compile_clauses
     : A.bindings * CF.GenTypes.genTypeCategory A.statement_ list
     =
     let aux_it it =
-      if BT.equal (IT.get_bt it) BT.Unit then
+      if BT.equal (T.get_bt it) BT.Unit then
         ([], [ A.AilSreturnVoid ])
       else (
         let b, s, e = compile_it filename sigma prog5 it in
@@ -299,7 +300,7 @@ let compile_clauses
     in
     match cls with
     | [ cl ] ->
-      assert (IT.is_true cl.guard);
+      assert (Terms.is_true cl.guard);
       compile_lat ~f:aux_it filename sigma prog5 cl.packing_ft
     | cl :: cls' ->
       let b_if, s_if, e_if = compile_it filename sigma prog5 cl.guard in
@@ -407,7 +408,7 @@ let compile_spec
   let lat =
     LAT.subst
       (fun _ x -> x)
-      (IT.make_subst
+      (T.make_subst
          (List.map
             (fun (x, y) ->
                (x, IT.sym_ (y, fst (List.assoc Sym.equal x args), Locations.other __LOC__)))

--- a/lib/bugExplanation/shapeAnalyzers.ml
+++ b/lib/bugExplanation/shapeAnalyzers.ml
@@ -141,9 +141,7 @@ let get_parent_and_size (sct : Sctypes.t) (arg : T.t) loc =
           loc )
     | IT (MemberShift (base, tag, member), _, loc) ->
       aux
-        (IT.pointer_offset_
-           (base, (IT (OffsetOf (tag, member), Memory.size_bt, loc)))
-           loc)
+        (IT.pointer_offset_ (base, IT (OffsetOf (tag, member), Memory.size_bt, loc)) loc)
     | IT (_, _, loc) -> (it, IT.num_lit_ Z.zero Memory.uintptr_bt loc)
   in
   let base, offset = aux arg in

--- a/lib/builtins.ml
+++ b/lib/builtins.ml
@@ -120,7 +120,8 @@ let is_null_def : builtin_fn_def =
 let has_alloc_id_def =
   ( "has_alloc_id",
     Sym.fresh "has_alloc_id",
-    mk_arg1 (fun p loc' -> Terms.Surface.inj @@ IT.hasAllocId_ (Terms.Surface.proj p) loc') )
+    mk_arg1 (fun p loc' ->
+      Terms.Surface.inj @@ IT.hasAllocId_ (Terms.Surface.proj p) loc') )
 
 
 let ptr_eq_def : builtin_fn_def =

--- a/lib/builtins.ml
+++ b/lib/builtins.ml
@@ -57,7 +57,7 @@ let definition name args body =
   ( name,
     Sym.fresh name,
     Definition.Function.
-      { loc; emit_coq = false; args; body = Def body; return_bt = IT.get_bt body } )
+      { loc; emit_coq = false; args; body = Def body; return_bt = Terms.get_bt body } )
 
 
 let mk_builtin_arg0 name = definition name []
@@ -120,7 +120,7 @@ let is_null_def : builtin_fn_def =
 let has_alloc_id_def =
   ( "has_alloc_id",
     Sym.fresh "has_alloc_id",
-    mk_arg1 (fun p loc' -> IT.Surface.inj @@ IT.hasAllocId_ (IT.Surface.proj p) loc') )
+    mk_arg1 (fun p loc' -> Terms.Surface.inj @@ IT.hasAllocId_ (Terms.Surface.proj p) loc') )
 
 
 let ptr_eq_def : builtin_fn_def =
@@ -152,49 +152,49 @@ let addr_eq_def : builtin_fn_def =
 let mul_uf_def =
   ( "mul_uf",
     Sym.fresh "mul_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop MulNoSMT (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop MulNoSMT (it, it') loc (Terms.get_bt it)) )
 
 
 let div_uf_def =
   ( "div_uf",
     Sym.fresh "div_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop DivNoSMT (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop DivNoSMT (it, it') loc (Terms.get_bt it)) )
 
 
 let power_uf_def =
   ( "power_uf",
     Sym.fresh "power_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop ExpNoSMT (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop ExpNoSMT (it, it') loc (Terms.get_bt it)) )
 
 
 let rem_uf_def =
   ( "rem_uf",
     Sym.fresh "rem_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop RemNoSMT (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop RemNoSMT (it, it') loc (Terms.get_bt it)) )
 
 
 let mod_uf_def =
   ( "mod_uf",
     Sym.fresh "mod_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop ModNoSMT (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop ModNoSMT (it, it') loc (Terms.get_bt it)) )
 
 
 let xor_uf_def =
   ( "xor_uf",
     Sym.fresh "xor_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop BW_Xor (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop BW_Xor (it, it') loc (Terms.get_bt it)) )
 
 
 let bw_and_uf_def =
   ( "bw_and_uf",
     Sym.fresh "bw_and_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop BW_And (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop BW_And (it, it') loc (Terms.get_bt it)) )
 
 
 let bw_or_uf_def =
   ( "bw_or_uf",
     Sym.fresh "bw_or_uf",
-    mk_arg2 (fun (it, it') loc -> IT.binop BW_Or (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop BW_Or (it, it') loc (Terms.get_bt it)) )
 
 
 let bw_clz_uf_def =
@@ -216,31 +216,31 @@ let bw_fls_uf_def =
 let shift_left_def =
   ( "shift_left",
     Sym.fresh "shift_left",
-    mk_arg2 (fun (it, it') loc -> IT.binop ShiftLeft (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop ShiftLeft (it, it') loc (Terms.get_bt it)) )
 
 
 let shift_right_def =
   ( "shift_right",
     Sym.fresh "shift_right",
-    mk_arg2 (fun (it, it') loc -> IT.binop ShiftRight (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop ShiftRight (it, it') loc (Terms.get_bt it)) )
 
 
 let power_def =
   ( "power",
     Sym.fresh "power",
-    mk_arg2 (fun (it, it') loc -> IT.binop Exp (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop Exp (it, it') loc (Terms.get_bt it)) )
 
 
 let rem_def =
   ( "rem",
     Sym.fresh "rem",
-    mk_arg2 (fun (it, it') loc -> IT.binop Rem (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop Rem (it, it') loc (Terms.get_bt it)) )
 
 
 let mod_def =
   ( "mod",
     Sym.fresh "mod",
-    mk_arg2 (fun (it, it') loc -> IT.binop Mod (it, it') loc (IT.get_bt it)) )
+    mk_arg2 (fun (it, it') loc -> IT.binop Mod (it, it') loc (Terms.get_bt it)) )
 
 
 let is_some_def = ("is_some", Sym.fresh "is_some", mk_arg1 IT.isSome_)
@@ -252,9 +252,9 @@ let get_opt_def = ("get_opt", Sym.fresh "get_opt", mk_arg1 IT.getOpt_)
 let builtin_funs
   : (string
     * Sym.t
-    * (BaseTypes.Surface.t IT.annot list ->
+    * (BaseTypes.Surface.t Terms.annot list ->
       Locations.t ->
-      (BaseTypes.Surface.t IT.annot, err) result))
+      (BaseTypes.Surface.t Terms.annot, err) result))
       list
   =
   [ mul_uf_def;
@@ -310,8 +310,8 @@ let apply_builtin_fun_defs fsym args _loc =
         args
     in
     (* Create and apply substitution *)
-    let subst = IT.make_subst subst_list in
-    Some (IT.subst subst body)
+    let subst = Terms.Normal.make_subst subst_list in
+    Some (Terms.Normal.subst subst body)
 
 
 (* This list of names is later passed to the frontend in bin/main.ml so that

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -73,7 +73,8 @@ let mk_local_ptr state src_loc =
 
 let is_local_ptr ptr =
   Option.bind (Terms.is_pred_ ptr) (function
-    | name, [ ix ] when Sym.equal name local_sym_ptr -> Option.map Z.to_int (Terms.is_z ix)
+    | name, [ ix ] when Sym.equal name local_sym_ptr ->
+      Option.map Z.to_int (Terms.is_z ix)
     | _ -> None)
 
 
@@ -137,10 +138,7 @@ let rec is_const_num = function
   | IT (Binop (binop, x, y), _, _) ->
     is_const_num x
     && is_const_num y
-    &&
-      (match binop with
-      | Add | Sub | Mul | Div | Exp | Rem | Mod -> true
-      | _ -> false)
+    && (match binop with Add | Sub | Mul | Div | Exp | Rem | Mod -> true | _ -> false)
   | _ -> false
 
 
@@ -328,11 +326,15 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
      | OpMul, _, Some (`Two_loc two_loc, `Exp exp) ->
        let exp_loc = Terms.get_loc y_v in
        return
-         (IT.mul_ (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc) loc)
+         (IT.mul_
+            (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc)
+            loc)
      | OpDiv, _, Some (`Two_loc two_loc, `Exp exp) ->
        let exp_loc = Terms.get_loc y_v in
        return
-         (IT.div_ (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc) loc)
+         (IT.div_
+            (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc)
+            loc)
      | _, _, _ ->
        let@ res = simp_const_pe (f x_v y_v) in
        return res)
@@ -417,7 +419,8 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
       | IOpSub -> IT.sub_ (x, y) loc
       | IOpMul -> IT.mul_ (x, y) loc
       | IOpShl -> IT.arith_binop Terms.ShiftLeft (x, IT.cast_ (Terms.get_bt x) y here) loc
-      | IOpShr -> IT.arith_binop Terms.ShiftRight (x, IT.cast_ (Terms.get_bt x) y here) loc
+      | IOpShr ->
+        IT.arith_binop Terms.ShiftRight (x, IT.cast_ (Terms.get_bt x) y here) loc
       | IOpDiv -> failwith "TODO division operator"
       | IOpRem_t -> failwith "TODO remainder operator"
     in

--- a/lib/cLogicalFuns.ml
+++ b/lib/cLogicalFuns.ml
@@ -3,6 +3,7 @@ module IntMap = Map.Make (Int)
 module CF = Cerb_frontend
 module BT = BaseTypes
 module Mu = Mucore
+module T = Terms.Normal
 module IT = IndexTerms
 open Cerb_pp_prelude
 open TypeErrors
@@ -13,9 +14,9 @@ open Effectful.Make (Typing)
 let fail_n m = fail (fun _ctxt -> m)
 
 type 'a exec_result =
-  | Call_Ret of IT.t
-  | Compute of IT.t * 'a
-  | If_Else of IT.t * 'a exec_result * 'a exec_result
+  | Call_Ret of T.t
+  | Compute of T.t * 'a
+  | If_Else of T.t * 'a exec_result * 'a exec_result
 
 let ov_to_it loc (Mu.OV (bt, ov)) =
   match ov with
@@ -48,7 +49,7 @@ let val_to_it loc (Mu.V (_, v)) =
 let local_sym_ptr = Sym.fresh "local_ptr"
 
 type state =
-  { loc_map : IT.t option IntMap.t;
+  { loc_map : T.t option IntMap.t;
     next_loc : int
   }
 
@@ -71,8 +72,8 @@ let mk_local_ptr state src_loc =
 
 
 let is_local_ptr ptr =
-  Option.bind (IT.is_pred_ ptr) (function
-    | name, [ ix ] when Sym.equal name local_sym_ptr -> Option.map Z.to_int (IT.is_z ix)
+  Option.bind (Terms.is_pred_ ptr) (function
+    | name, [ ix ] when Sym.equal name local_sym_ptr -> Option.map Z.to_int (Terms.is_z ix)
     | _ -> None)
 
 
@@ -82,7 +83,7 @@ let get_local_ptr loc ptr =
     fail_n
       { loc;
         msg =
-          Generic (Pp.item "use of non-local pointer" (IT.pp ptr)) [@alert "-deprecated"]
+          Generic (Pp.item "use of non-local pointer" (T.pp ptr)) [@alert "-deprecated"]
       }
   | Some ix -> return ix
 
@@ -96,7 +97,7 @@ let triv_simp_ctxt = Simplify.default Global.empty
 
 let simp_const loc lpp it =
   let it2 = Simplify.IndexTerms.simp triv_simp_ctxt it in
-  match (IT.is_z it2, IT.get_bt it2) with
+  match (Terms.is_z it2, Terms.get_bt it2) with
   | Some _z, _ -> return it2
   | _, BT.Integer ->
     fail_n
@@ -105,7 +106,7 @@ let simp_const loc lpp it =
           Generic
             (Pp.item
                "getting expr from C syntax: failed to simplify integer to numeral"
-               (Pp.typ (Lazy.force lpp) (IT.pp it2)))
+               (Pp.typ (Lazy.force lpp) (T.pp it2)))
           [@alert "-deprecated"]
       }
   | _, _ -> return it2
@@ -115,7 +116,7 @@ let do_wrapI loc ct it =
   match Sctypes.is_integer_type ct with
   | Some ity ->
     let ity_bt = Memory.bt_of_sct ct in
-    if BT.equal ity_bt (IT.get_bt it) then
+    if BT.equal ity_bt (Terms.get_bt it) then
       return it
     else
       return (IT.wrapI_ (ity, it) loc)
@@ -132,13 +133,13 @@ let do_wrapI loc ct it =
    and permitted for multiply/divide or not - similar to a simplifier-based notion in
    welltyped and a solver-based notion in check. *)
 let rec is_const_num = function
-  | IT.IT (IT.Const _, _, _) -> true
-  | IT.IT (IT.Binop (binop, x, y), _, _) ->
+  | Terms.(IT (Const _, _, _)) -> true
+  | IT (Binop (binop, x, y), _, _) ->
     is_const_num x
     && is_const_num y
     &&
       (match binop with
-      | IT.Add | IT.Sub | IT.Mul | IT.Div | IT.Exp | IT.Rem | IT.Mod -> true
+      | Add | Sub | Mul | Div | Exp | Rem | Mod -> true
       | _ -> false)
   | _ -> false
 
@@ -152,7 +153,7 @@ let rec add_pattern p v var_map =
   | CaseCtor (Ctuple, ps) ->
     let@ vs =
       match v with
-      | IT.IT (IT.Tuple vs, _, _) -> return vs
+      | Terms.(IT (Tuple vs, _, _)) -> return vs
       | it ->
         fail_n
           { loc;
@@ -160,7 +161,7 @@ let rec add_pattern p v var_map =
               Generic
                 (Pp.item
                    "getting expr from C syntax: cannot tuple-split val"
-                   (Pp.typ (IT.pp it) (Pp_mucore.Basic.pp_pattern p)))
+                   (Pp.typ (T.pp it) (Pp_mucore.Basic.pp_pattern p)))
               [@alert "-deprecated"]
           }
     in
@@ -186,13 +187,13 @@ let signed_int_ity = Sctypes.(IntegerTypes.Signed IntegerBaseTypes.Int_)
 let signed_int_ty = Memory.bt_of_sct (Sctypes.Integer signed_int_ity)
 
 let is_two_pow it =
-  match IT.get_term it with
+  match T.get_term it with
   | Terms.Binop (Terms.ExpNoSMT, x, y)
-    when Option.equal Z.equal (IT.get_num_z x) (Some (Z.of_int 2)) ->
-    Some (`Two_loc (IT.get_loc x), `Exp y)
+    when Option.equal Z.equal (Terms.get_num_z x) (Some (Z.of_int 2)) ->
+    Some (`Two_loc (Terms.get_loc x), `Exp y)
   | Terms.Binop (Terms.Exp, x, y)
-    when Option.equal Z.equal (IT.get_num_z x) (Some (Z.of_int 2)) ->
-    Some (`Two_loc (IT.get_loc x), `Exp y)
+    when Option.equal Z.equal (Terms.get_num_z x) (Some (Z.of_int 2)) ->
+    Some (`Two_loc (Terms.get_loc x), `Exp y)
   | _ -> None
 
 
@@ -220,14 +221,14 @@ let return_z_within_range loc z bt orig_pexpr =
 
 
 let must_be_ct_const loc ct_it =
-  match IT.is_const ct_it with
-  | Some (IT.CType_const ct, _) -> return ct
+  match Terms.is_const ct_it with
+  | Some (Terms.CType_const ct, _) -> return ct
   | Some _ -> assert false (* shouldn't be possible given type *)
   | None ->
     fail_n
       { loc;
         msg =
-          Generic (Pp.item "expr from C syntax: non-constant type" (IT.pp ct_it))
+          Generic (Pp.item "expr from C syntax: non-constant type" (Terms.pp ct_it))
           [@alert "-deprecated"]
       }
 
@@ -325,13 +326,13 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
     in
     (match (op, x_v, is_two_pow y_v) with
      | OpMul, _, Some (`Two_loc two_loc, `Exp exp) ->
-       let exp_loc = IT.get_loc y_v in
+       let exp_loc = Terms.get_loc y_v in
        return
-         (IT.mul_ (x_v, IT.exp_ (IT.int_lit_ 2 (IT.get_bt x_v) two_loc, exp) exp_loc) loc)
+         (IT.mul_ (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc) loc)
      | OpDiv, _, Some (`Two_loc two_loc, `Exp exp) ->
-       let exp_loc = IT.get_loc y_v in
+       let exp_loc = Terms.get_loc y_v in
        return
-         (IT.div_ (x_v, IT.exp_ (IT.int_lit_ 2 (IT.get_bt x_v) two_loc, exp) exp_loc) loc)
+         (IT.div_ (x_v, IT.exp_ (IT.int_lit_ 2 (Terms.get_bt x_v) two_loc, exp) exp_loc) loc)
      | _, _, _ ->
        let@ res = simp_const_pe (f x_v y_v) in
        return res)
@@ -349,29 +350,29 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
        simp_const_pe
          (bool_ite_1_0
             bool_rep_ty
-            (IT.not_ (IT.eq_ (x, IT.int_lit_ 0 (IT.get_bt x) here) here) here)
+            (IT.not_ (IT.eq_ (x, IT.int_lit_ 0 (Terms.get_bt x) here) here) here)
             loc)
      | _ -> do_wrapI loc ct x)
   | PEcall (f, pes) ->
     let@ xs = ListM.mapM (self var_map) pes in
     (match (f, xs) with
      | Sym (Symbol (_, _, SD_Id "ctype_width")), [ x ]
-       when Option.is_some (IT.is_ctype_const x) ->
-       let ct = Option.get (IT.is_ctype_const x) in
+       when Option.is_some (Terms.is_ctype_const x) ->
+       let ct = Option.get (Terms.is_ctype_const x) in
        return_z_within_range loc (Z.of_int (Memory.size_of_ctype ct * 8)) bt pexpr
      | Sym (Symbol (_, _, SD_Id "params_length")), [ x ] ->
        (match IT.dest_list x with
         | Some xs -> return (IT.int_ (List.length xs) loc)
         | None -> unsupported "pure-expression type" !^"")
      | Sym (Symbol (_, _, SD_Id "params_nth")), [ x; y ] ->
-       (match (IT.dest_list x, IT.is_z y) with
+       (match (IT.dest_list x, Terms.is_z y) with
         | Some its, Some i -> return (List.nth its (Z.to_int i))
         | _ -> unsupported "pure-expression type" !^"")
      | _ -> unsupported "pure-expression type" !^"")
   | PEare_compatible (pe1, pe2) ->
     let@ x1 = self var_map pe1 in
     let@ x2 = self var_map pe2 in
-    (match (IT.is_ctype_const x1, IT.is_ctype_const x2) with
+    (match (Terms.is_ctype_const x1, Terms.is_ctype_const x2) with
      | Some ct1, Some ct2 -> return (IT.bool_ (Sctypes.equal ct1 ct2) loc)
      | _ -> unsupported "are-compatible applied to non-constants" !^"")
   | PEctor (ctor, pes) ->
@@ -398,9 +399,9 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
        let@ _ct = must_be_ct_const loc e1 in
        let bop =
          match ctor with
-         | CivAND -> IT.BW_And
-         | CivOR -> IT.BW_Or
-         | CivXOR -> IT.BW_Xor
+         | CivAND -> Terms.BW_And
+         | CivOR -> BW_Or
+         | CivXOR -> BW_Xor
          | _ -> assert false
        in
        return (IT.arith_binop bop (e2, e3) loc)
@@ -415,8 +416,8 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
       | IOpAdd -> IT.add_ (x, y) loc
       | IOpSub -> IT.sub_ (x, y) loc
       | IOpMul -> IT.mul_ (x, y) loc
-      | IOpShl -> IT.arith_binop Terms.ShiftLeft (x, IT.cast_ (IT.get_bt x) y here) loc
-      | IOpShr -> IT.arith_binop Terms.ShiftRight (x, IT.cast_ (IT.get_bt x) y here) loc
+      | IOpShl -> IT.arith_binop Terms.ShiftLeft (x, IT.cast_ (Terms.get_bt x) y here) loc
+      | IOpShr -> IT.arith_binop Terms.ShiftRight (x, IT.cast_ (Terms.get_bt x) y here) loc
       | IOpDiv -> failwith "TODO division operator"
       | IOpRem_t -> failwith "TODO remainder operator"
     in
@@ -425,7 +426,7 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
     let@ x = self var_map pe in
     let sig_it =
       Option.(
-        let@ sym, _ = IT.is_sym x in
+        let@ sym, _ = Terms.is_sym x in
         let@ c_sig = Pmap.lookup sym ctxt.call_funinfo in
         IT.const_of_c_sig c_sig loc)
     in
@@ -438,7 +439,7 @@ let rec symb_exec_pexpr ctxt var_map pexpr =
              Generic
                (Pp.item
                   "getting expr from C syntax: c-function ptr"
-                  (Pp.typ (IT.pp x) (Pp_mucore_ast.pp_pexpr pexpr)))
+                  (Pp.typ (T.pp x) (Pp_mucore_ast.pp_pexpr pexpr)))
              [@alert "-deprecated"]
          })
   | _ -> unsupported "pure-expression type" !^""
@@ -546,14 +547,14 @@ let rec symb_exec_expr ctxt state_vars expr =
            fail_n
              { loc;
                msg =
-                 Generic (Pp.item "unavailable memory address" (IT.pp p_v))
+                 Generic (Pp.item "unavailable memory address" (T.pp p_v))
                  [@alert "-deprecated"]
              }
          | Some None ->
            fail_n
              { loc;
                msg =
-                 Generic (Pp.item "uninitialised memory address" (IT.pp p_v))
+                 Generic (Pp.item "uninitialised memory address" (T.pp p_v))
                  [@alert "-deprecated"]
              }
          | Some (Some ix) -> return ix
@@ -577,8 +578,8 @@ let rec symb_exec_expr ctxt state_vars expr =
     let@ x = symb_exec_pexpr ctxt var_map pe1 in
     let unop =
       match fn with
-      | "ctz" -> IT.BW_CTZ_NoSMT
-      | "generic_ffs" -> IT.BW_FFS_NoSMT
+      | "ctz" -> Terms.BW_CTZ_NoSMT
+      | "generic_ffs" -> BW_FFS_NoSMT
       | _ -> assert false
     in
     let t = IT.arith_unop unop x loc in
@@ -594,7 +595,7 @@ let rec symb_exec_expr ctxt state_vars expr =
             Generic
               (Pp.item
                  ("getting expr from C syntax: function val: " ^ msg)
-                 (Pp.typ (Pp_mucore.pp_pexpr fun_pe) (IT.pp fun_it)))
+                 (Pp.typ (Pp_mucore.pp_pexpr fun_pe) (T.pp fun_it)))
             [@alert "-deprecated"]
         }
     in
@@ -606,7 +607,7 @@ let rec symb_exec_expr ctxt state_vars expr =
         return ()
     in
     let@ nm =
-      match IT.is_sym fun_it with
+      match Terms.is_sym fun_it with
       | None -> fail_fun_it "not a constant function address"
       | Some (nm, _) -> return nm
     in
@@ -662,7 +663,7 @@ let rec filter_syms ss p =
 let rec get_ret_it loc body bt = function
   | Call_Ret v ->
     let@ () =
-      if BT.equal (IT.get_bt v) bt then
+      if BT.equal (Terms.get_bt v) bt then
         return ()
       else
         fail_n
@@ -671,7 +672,7 @@ let rec get_ret_it loc body bt = function
               Generic
                 (Pp.item
                    "get_ret_it: basetype mismatch"
-                   (Pp.infix_arrow (IT.pp_with_typ v) (BT.pp bt)))
+                   (Pp.infix_arrow (T.pp_with_typ v) (BT.pp bt)))
               [@alert "-deprecated"]
           }
     in
@@ -716,7 +717,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
     let rec mk_var_map acc args_and_body def_args =
       match (args_and_body, def_args) with
       | Mu.Computational ((s, bt), _, args_and_body), v :: def_args ->
-        if BT.equal bt (IT.get_bt v) then
+        if BT.equal bt (Terms.get_bt v) then
           mk_var_map (Sym.Map.add s v acc) args_and_body def_args
         else
           fail_n
@@ -725,7 +726,7 @@ let c_fun_to_it id_loc glob_context (id : Sym.t) fsym def (fn : 'bty Mu.fun_map_
                 Generic
                   Pp.(
                     !^"mismatched arguments:"
-                    ^^^ parens (BT.pp (IT.get_bt v) ^^^ IT.pp v)
+                    ^^^ parens (BT.pp (Terms.get_bt v) ^^^ T.pp v)
                     ^^^ !^"and"
                     ^^^ parens (BT.pp bt ^^^ Sym.pp s))
                 [@alert "-deprecated"]
@@ -829,7 +830,7 @@ let add_logical_funs_from_c call_funinfo funs_to_convert funs =
            (lazy
              (Pp.item
                 "converted c function body to logical fun"
-                (Pp.typ (Sym.pp c_fun_sym) (IT.pp it))));
+                (Pp.typ (Sym.pp c_fun_sym) (Terms.pp it))));
          return (loc, l_fun_sym, it))
       funs_to_convert
   in

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -1,5 +1,6 @@
 module WT = WellTyped
 module CF = Cerb_frontend
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 module LRT = LogicalReturnTypes
@@ -105,7 +106,7 @@ let unsupported loc doc =
   fail (fun _ -> { loc; msg = Unsupported (!^"unsupported" ^^^ doc) })
 
 
-let check_ptrval (loc : Locations.t) ~(expect : BT.t) (ptrval : pointer_value) : IT.t m =
+let check_ptrval (loc : Locations.t) ~(expect : BT.t) (ptrval : pointer_value) : T.t m =
   let@ () = WellTyped.ensure_base_type loc ~expect BT.(Loc ()) in
   CF.Impl_mem.case_ptrval
     ptrval
@@ -141,7 +142,7 @@ let expect_must_be_map_bt loc ~expect =
     fail (fun _ -> { loc; msg })
 
 
-let rec check_mem_value (loc : Locations.t) ~(expect : BT.t) (mem : mem_value) : IT.t m =
+let rec check_mem_value (loc : Locations.t) ~(expect : BT.t) (mem : mem_value) : T.t m =
   CF.Impl_mem.case_mem_value
     mem
     (fun ct ->
@@ -181,7 +182,7 @@ and check_struct
       (loc : Locations.t)
       (tag : Sym.t)
       (member_values : (Id.t * Sctypes.t * mem_value) list)
-  : IT.t m
+  : T.t m
   =
   let@ layout = Global.get_struct_decl loc tag in
   let member_types = Memory.member_types layout in
@@ -201,7 +202,7 @@ and check_struct
 
 
 and check_union (_loc : Locations.t) (_tag : Sym.t) (_id : Id.t) (_mv : mem_value)
-  : IT.t m
+  : T.t m
   =
   Cerb_debug.error "todo: union types"
 
@@ -218,7 +219,7 @@ let ensure_bitvector_type (loc : Locations.t) ~(expect : BT.t) : (BT.sign * int)
       })
 
 
-let rec check_object_value (loc : Locations.t) (Mu.OV (expect, ov)) : IT.t m =
+let rec check_object_value (loc : Locations.t) (Mu.OV (expect, ov)) : T.t m =
   match ov with
   | OVinteger iv ->
     let z = Memory.z_of_ival iv in
@@ -263,7 +264,7 @@ and check_loaded_value loc lv =
   | Mu.LVunspecified _ -> assert false
 
 
-let rec check_value (loc : Locations.t) (Mu.V (expect, v)) : IT.t m =
+let rec check_value (loc : Locations.t) (Mu.V (expect, v)) : T.t m =
   match v with
   | Vobject ov ->
     let@ () = WellTyped.ensure_base_type loc ~expect (Mu.bt_of_object_value ov) in
@@ -309,7 +310,7 @@ let is_representable_integer arg ity =
   let here = Locations.other __LOC__ in
   let maxInt = Memory.max_integer_type ity in
   let minInt = Memory.min_integer_type ity in
-  let bt = IT.get_bt arg in
+  let bt = T.get_bt arg in
   if !cnBV then (
     let bits = Option.get (BT.is_bits_bt bt) in
     assert (BT.fits_range bits maxInt);
@@ -334,13 +335,13 @@ let unique_model loc t =
 
 let check_single_ct loc expr =
   let@ expr = WellTyped.check_term loc BT.CType expr in
-  match is_ctype_const expr with
+  match Terms.is_ctype_const expr with
   | Some v -> return v
   | None ->
     let@ model = unique_model loc expr in
     (match model with
      | `Inconsistent_context -> assert false
-     | `Unique v -> return (Option.get (is_ctype_const v))
+     | `Unique v -> return (Option.get (Terms.is_ctype_const v))
      | `No_unique_model ->
        fail (fun _ ->
          { loc;
@@ -363,7 +364,7 @@ let determined_as_one_of loc t candidates =
       | [] -> return `None_of_these
       | (c, c_t) :: cs ->
         let equality = eq_ (c_t, t) loc in
-        if Option.get (IT.is_bool (Option.get (Solver.eval model equality))) then (
+        if Option.get (Terms.is_bool (Option.get (Solver.eval model equality))) then (
           match provable (LC.T equality) with
           | `True -> return (`This c)
           | `False -> identify cs)
@@ -375,7 +376,7 @@ let determined_as_one_of loc t candidates =
 
 let known_function_pointer loc p =
   let@ global = get_global () in
-  match IT.is_sym p with
+  match Terms.is_sym p with
   | Some (s, _) when Global.is_fun_decl global s ->
     (* the function pointer is a known constant *)
     return (`Known s)
@@ -398,7 +399,7 @@ let known_function_pointer loc p =
              Generic
                (Pp.item
                   "Function pointer must be provably equal to a defined function."
-                  (IT.pp p))
+                  (T.pp p))
              [@alert "-deprecated"]
          })
      | `Inconsistent_context -> return `Inconsistent_context)
@@ -417,7 +418,7 @@ let integer_wrapI loc ity n =
 
 let check_conv_int loc ~expect ct arg =
   assert (
-    match (!cnBV, expect, IT.get_bt arg) with
+    match (!cnBV, expect, T.get_bt arg) with
     | true, BT.Bits _, BT.Bits _ -> true
     | false, BT.Integer, BT.Integer -> true
     | _ -> false);
@@ -433,7 +434,7 @@ let check_conv_int loc ~expect ct arg =
     fail (fun ctxt ->
       { loc; msg = Int_unrepresentable { value = arg; ict = ct; ctxt; model } })
   in
-  let bt = IT.get_bt arg in
+  let bt = T.get_bt arg in
   (* TODO: can we (later) optimise this? *)
   let here = Locations.other __LOC__ in
   let@ value =
@@ -543,7 +544,7 @@ let valid_for_deref loc pointer ct =
     ({ name = Owned (ct, Uninit); pointer; iargs = [] }, None)
 
 
-let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
+let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : T.t m =
   let (Mu.Pexpr (loc, _, expect, pe_)) = pe in
   let provable loc =
     let@ provable = Typing.provable loc in
@@ -560,7 +561,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
        let@ () = WellTyped.ensure_base_type loc ~expect bt in
        return (sym_ (sym, bt, loc))
      | Value lvt ->
-       let@ () = WellTyped.ensure_base_type loc ~expect (IT.get_bt lvt) in
+       let@ () = WellTyped.ensure_base_type loc ~expect (T.get_bt lvt) in
        return lvt)
   | PEval v ->
     let@ () = WellTyped.ensure_base_type loc ~expect (Mu.bt_of_value v) in
@@ -622,7 +623,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
      | (Civmax | Civmin), [ e ] ->
        let@ () = WellTyped.ensure_base_type loc ~expect:CType (Mu.bt_of_pexpr e) in
        let@ e = check_pexpr path_cs e in
-       let ct = Option.get (IT.is_ctype_const e) in
+       let ct = Option.get (Terms.is_ctype_const e) in
        let@ () = WellTyped.check_ct loc ct in
        let ity = Option.get (Sctypes.is_integer_type ct) in
        let@ () = WellTyped.ensure_base_type loc ~expect (Memory.bt_of_sct ct) in
@@ -633,7 +634,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
      | (Civsizeof | Civalignof), [ e ] ->
        let@ () = WellTyped.ensure_base_type loc ~expect:CType (Mu.bt_of_pexpr e) in
        let@ e = check_pexpr path_cs e in
-       let ct = Option.get (IT.is_ctype_const e) in
+       let ct = Option.get (Terms.is_ctype_const e) in
        let@ () = WellTyped.check_ct loc ct in
        let@ n =
          match ctor with
@@ -667,7 +668,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
      | CivCOMPL, [ e1; e2 ] ->
        let@ () = WellTyped.ensure_base_type loc ~expect:CType (Mu.bt_of_pexpr e1) in
        let@ e1 = check_pexpr path_cs e1 in
-       let ct = Option.get (is_ctype_const e1) in
+       let ct = Option.get (Terms.is_ctype_const e1) in
        let@ () = WellTyped.check_ct loc ct in
        let () = match ct with Integer _ -> () | _ -> assert false in
        let@ () = WellTyped.ensure_base_type loc ~expect (Memory.bt_of_sct ct) in
@@ -684,7 +685,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
      | (CivAND | CivOR | CivXOR), [ e1; e2; e3 ] ->
        let@ () = WellTyped.ensure_base_type loc ~expect:CType (Mu.bt_of_pexpr e1) in
        let@ e1 = check_pexpr path_cs e1 in
-       let ct = Option.get (is_ctype_const e1) in
+       let ct = Option.get (Terms.is_ctype_const e1) in
        let@ () = WellTyped.check_ct loc ct in
        let () = match ct with Integer _ -> () | _ -> assert false in
        let@ () = WellTyped.ensure_base_type loc ~expect (Memory.bt_of_sct ct) in
@@ -958,7 +959,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
        let@ () = WellTyped.ensure_base_type loc ~expect:Integer (Mu.bt_of_pexpr e2) in
        let@ e1 = check_pexpr path_cs e1 in
        let@ e2 = check_pexpr path_cs e2 in
-       (match (IT.dest_list e1, IT.is_z e2) with
+       (match (IT.dest_list e1, Terms.is_z e2) with
         | Some its, Some i -> return (List.nth its (Z.to_int i))
         | _ ->
           let msg = "Could not evaluate params_nth arguments to constants." in
@@ -1043,7 +1044,7 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
     in
     let@ arg1 = check_pexpr path_cs pe1 in
     let@ arg2 = check_pexpr path_cs pe2 in
-    let arg1_bt_range = BT.bits_range (Option.get (BT.is_bits_bt (IT.get_bt arg1))) in
+    let arg1_bt_range = BT.bits_range (Option.get (BT.is_bits_bt (T.get_bt arg1))) in
     let here = Locations.other __LOC__ in
     let arg2_bits_lost = IT.not_ (IT.in_z_range arg2 arg1_bt_range here) here in
     let x =
@@ -1055,13 +1056,13 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
         ite_
           ( arg2_bits_lost,
             IT.int_lit_ 0 expect loc,
-            arith_binop Terms.ShiftLeft (arg1, cast_ (IT.get_bt arg1) arg2 loc) loc )
+            arith_binop Terms.ShiftLeft (arg1, cast_ (T.get_bt arg1) arg2 loc) loc )
           loc
       | IOpShr ->
         ite_
           ( arg2_bits_lost,
             IT.int_lit_ 0 expect loc,
-            arith_binop Terms.ShiftRight (arg1, cast_ (IT.get_bt arg1) arg2 loc) loc )
+            arith_binop Terms.ShiftRight (arg1, cast_ (T.get_bt arg1) arg2 loc) loc )
           loc
       | IOpDiv -> div_ (arg1, arg2) loc
       | IOpRem_t -> rem_ (arg1, arg2) loc
@@ -1093,11 +1094,11 @@ let rec check_pexpr path_cs (pe : BT.t Mu.pexpr) : IT.t m =
       | IOpMul ->
         (mul_ (arg1, arg2) loc, mul_ (large arg1, large arg2) loc, bool_ true here)
       | IOpShl ->
-        ( arith_binop Terms.ShiftLeft (arg1, cast_ (IT.get_bt arg1) arg2 loc) loc,
+        ( arith_binop Terms.ShiftLeft (arg1, cast_ (T.get_bt arg1) arg2 loc) loc,
           arith_binop Terms.ShiftLeft (large arg1, large arg2) loc,
           IT.in_z_range arg2 (Z.zero, Z.of_int bits) loc )
       | IOpShr ->
-        ( arith_binop Terms.ShiftRight (arg1, cast_ (IT.get_bt arg1) arg2 loc) loc,
+        ( arith_binop Terms.ShiftRight (arg1, cast_ (T.get_bt arg1) arg2 loc) loc,
           arith_binop Terms.ShiftRight (large arg1, large arg2) loc,
           IT.in_z_range arg2 (Z.zero, Z.of_int bits) loc )
       | IOpDiv -> failwith "TODO division operator"
@@ -1203,7 +1204,7 @@ and check_pexpr_good_ctype_const path_cs pe =
   let loc = Mu.loc_of_pexpr pe in
   let@ () = WellTyped.ensure_base_type loc ~expect:BT.CType (Mu.bt_of_pexpr pe) in
   let@ pe = check_pexpr path_cs pe in
-  let ct = Option.get (IT.is_ctype_const pe) in
+  let ct = Option.get (Terms.is_ctype_const pe) in
   let@ () = WellTyped.check_ct loc ct in
   return ct
 
@@ -1213,7 +1214,7 @@ module Spine : sig
     :  Loc.t ->
     fsym:Sym.t ->
     BT.t Mu.pexpr list ->
-    (Locations.t * IT.t list) option ->
+    (Locations.t * T.t list) option ->
     AT.ft ->
     (RT.t -> unit m) ->
     unit m
@@ -1221,7 +1222,7 @@ module Spine : sig
   val calltype_lt
     :  Loc.t ->
     BT.t Mu.pexpr list ->
-    (Locations.t * IT.t list) option ->
+    (Locations.t * T.t list) option ->
     AT.lt * Where.label ->
     (False.t -> unit m) ->
     unit m
@@ -1229,7 +1230,7 @@ module Spine : sig
   val calltype_lemma
     :  Loc.t ->
     lemma:Sym.t ->
-    (Locations.t * IT.t list) option ->
+    (Locations.t * T.t list) option ->
     AT.lemmat ->
     (LRT.t -> unit m) ->
     unit m
@@ -1286,11 +1287,11 @@ end = struct
             (args_acc @ [ arg ])
             args
             gargs
-            (subst rt_subst (make_subst [ (s, arg) ]) ftyp)
+            (subst rt_subst (T.make_subst [ (s, arg) ]) ftyp)
             k
         | _, garg :: gargs, Ghost ((s, bt), info, ftyp) ->
           let@ garg = WellTyped.check_term (fst info) bt garg in
-          aux args_acc args gargs (subst rt_subst (make_subst [ (s, garg) ]) ftyp) k
+          aux args_acc args gargs (subst rt_subst (T.make_subst [ (s, garg) ]) ftyp) k
         | [], [], L ftyp ->
           let@ () =
             match situation with
@@ -1380,8 +1381,8 @@ let load loc pointer ct =
 
 let instantiate loc filter arg =
   let arg_s = Sym.fresh_make_uniq "instance" in
-  let arg_it = sym_ (arg_s, IT.get_bt arg, loc) in
-  let@ () = add_l arg_s (IT.get_bt arg_it) (loc, lazy (Sym.pp arg_s)) in
+  let arg_it = sym_ (arg_s, T.get_bt arg, loc) in
+  let@ () = add_l arg_s (T.get_bt arg_it) (loc, lazy (Sym.pp arg_s)) in
   let@ () = add_c loc (LC.T (eq__ arg_it arg loc)) in
   let@ constraints = get_cs () in
   let extra_assumptions1 =
@@ -1390,11 +1391,11 @@ let instantiate loc filter arg =
       (LC.Set.elements constraints)
   in
   let extra_assumptions2, type_mismatch =
-    List.partition (fun ((_, bt), _) -> BT.equal bt (IT.get_bt arg_it)) extra_assumptions1
+    List.partition (fun ((_, bt), _) -> BT.equal bt (T.get_bt arg_it)) extra_assumptions1
   in
   let extra_assumptions =
     List.map
-      (fun ((s, _), t) -> LC.T (IT.subst (IT.make_subst [ (s, arg_it) ]) t))
+      (fun ((s, _), t) -> LC.T (T.subst (T.make_subst [ (s, arg_it) ]) t))
       extra_assumptions2
   in
   if List.length extra_assumptions == 0 then
@@ -1407,7 +1408,7 @@ let instantiate loc filter arg =
          Pp.warn
            loc
            (!^"did not instantiate on basetype mismatch:"
-            ^^^ Pp.list BT.pp [ bt; IT.get_bt arg_it ]))
+            ^^^ Pp.list BT.pp [ bt; T.get_bt arg_it ]))
     type_mismatch;
   add_cs loc extra_assumptions
 
@@ -1475,7 +1476,7 @@ let call_prefix = function
 
 
 (* TODO: De-CPS'ify check_expr and remove the function below.  *)
-let check_pexpr (pe : BT.t Mu.pexpr) (k : IT.t -> unit m) : unit m =
+let check_pexpr (pe : BT.t Mu.pexpr) (k : T.t -> unit m) : unit m =
   let@ lvt = check_pexpr [] pe in
   k lvt
 
@@ -1485,7 +1486,7 @@ let rec cn_prog_sub_let f = function
     let@ pointer = WellTyped.check_term loc (Loc ()) pointer in
     let@ () = WellTyped.check_ct loc ct in
     let@ value = load loc pointer ct in
-    let subbed = Cnprog.subst f (IT.make_subst [ (sym, value) ]) cn_prog in
+    let subbed = Cnprog.subst f (T.make_subst [ (sym, value) ]) cn_prog in
     cn_prog_sub_let f subbed
   | Pure (loc, x) -> return (loc, x)
 
@@ -1493,10 +1494,10 @@ let rec cn_prog_sub_let f = function
 let bytes_constraints
       loc
       (to_from : CF.Cn.to_from)
-      ~(value : IT.t)
-      ~(byte_arr : IT.t)
+      ~(value : T.t)
+      ~(byte_arr : T.t)
       (ct : Sctypes.t)
-  : IT.t t
+  : T.t t
   =
   (* FIXME this hard codes big endianness but this should be switchable *)
   let here = Locations.other __LOC__ in
@@ -1504,7 +1505,7 @@ let bytes_constraints
   | Sctypes.Void | Array (_, _) | Struct _ | Function (_, _, _) | Byte ->
     fail (fun _ -> { loc; msg = Unsupported_byte_conv_ct ct })
   | Integer it ->
-    let bt = IT.get_bt value in
+    let bt = T.get_bt value in
     let lhs = value in
     let bytes =
       List.init (Memory.size_of_integer_type it) (fun i ->
@@ -1518,7 +1519,7 @@ let bytes_constraints
           (fun i byte ->
              let casted = cast_ bt (getOpt_ byte here) here in
              let shift_amt = int_lit_ (i * 8) bt here in
-             IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
+             Terms.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
           bytes
       in
       List.fold_left (fun x y -> IT.add_ (x, y) here) (List.hd shifted) (List.tl shifted)
@@ -1549,7 +1550,7 @@ let bytes_constraints
           (fun i byte ->
              let casted = cast_ bt (getOpt_ byte here) here in
              let shift_amt = int_lit_ (i * 8) bt here in
-             IT.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
+             Terms.IT (Binop (ShiftLeft, casted, shift_amt), bt, here))
           bytes
       in
       List.fold_left (fun x y -> IT.add_ (x, y) here) (List.hd shifted) (List.tl shifted)
@@ -1626,7 +1627,7 @@ let bytes_constraints
        return (and_ [ all_some; bytes_prov_eq; eq_ (value_addr, bytes_addr) here ] here))
 
 
-let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
+let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
   let (Expr (loc, annots, expect, e_)) = e in
   let@ () = add_trace_information labels annots in
   let here = Locations.other __LOC__ in
@@ -1812,7 +1813,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
        check_pexpr pe (fun arg ->
          let sym, result = IT.fresh_named (BT.Loc ()) "intToPtr" loc in
          let@ _ = add_a sym (Loc ()) (here, lazy (Sym.pp sym)) in
-         let cond = eq_ (arg, int_lit_ 0 (get_bt arg) here) here in
+         let cond = eq_ (arg, int_lit_ 0 (T.get_bt arg) here) here in
          let null_case = eq_ (result, null_ here) here in
          (* NOTE: the allocation ID is intentionally left unconstrained *)
          let alloc_case =
@@ -1933,7 +1934,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
              IT.fresh_named (BT.Loc ()) ("&ARG" ^ string_of_int n) loc
            | _ -> IT.fresh_anon (BT.Loc ()) loc
          in
-         let@ () = add_a ret_s (IT.get_bt ret) (loc, lazy (Pp.string "allocation")) in
+         let@ () = add_a ret_s (T.get_bt ret) (loc, lazy (Pp.string "allocation")) in
          let@ () = add_c loc (LC.T (representable_ (Pointer act.ct, ret) loc)) in
          let align_v = cast_ Memory.uintptr_bt arg loc in
          let@ () = add_c loc (LC.T (alignedI_ ~align:align_v ~t:ret loc)) in
@@ -2057,7 +2058,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
          check_pexpr pe1 (fun vt1 ->
            let unop =
              match fn with
-             | "ctz" -> BW_CTZ_NoSMT
+             | "ctz" -> Terms.BW_CTZ_NoSMT
              | "generic_ffs" -> BW_FFS_NoSMT
              | _ -> assert false
            in
@@ -2107,7 +2108,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
           | None -> (loc, [])
           | Some (ghost_loc, gargs) -> (ghost_loc, gargs)
         in
-        let@ its = ListM.mapM (cn_prog_sub_let IT.subst) its in
+        let@ its = ListM.mapM (cn_prog_sub_let T.subst) its in
         let its = List.map snd its in
         (* checks pes against their annotations, and that they match ft's argument types *)
         Spine.calltype_ft
@@ -2121,7 +2122,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
              let prefix = call_prefix (FunctionCall fsym) in
              let s' = Sym.fresh_make_uniq_kind ~prefix "return" in
              let@ () = add_l s' bt (loc, lazy (Sym.pp s')) in
-             let su = IT.make_rename ~from:s ~to_:s' in
+             let su = T.make_rename ~from:s ~to_:s' in
              let@ () = bind_logical_return loc prefix (LRT.subst su lrt) in
              k (IT.sym_ (s', bt, here))))
   | Eif (c_pe, e1, e2) ->
@@ -2293,10 +2294,10 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
           | I_Everything -> return (fun _ -> true)
           | I_Function f ->
             let@ _ = Global.get_logical_function_def loc f in
-            return (IT.mentions_call f)
+            return (Terms.mentions_call f)
           | I_Good ct ->
             let@ () = WellTyped.check_ct loc ct in
-            return (IT.mentions_good ct)
+            return (Terms.mentions_good ct)
         in
         let@ it = WellTyped.infer_term it in
         instantiate loc filter it
@@ -2385,7 +2386,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
         let@ it = WellTyped.infer_term it in
         let@ simp_ctxt = simp_ctxt () in
         let it = Simplify.IndexTerms.simp simp_ctxt it in
-        print stdout (item "printed" (IT.pp it));
+        print stdout (item "printed" (T.pp it));
         return ()
     in
     (* let@ stmts = ListM.mapM (cn_prog_sub_let Cnstatement.subst) cn_progs in *)
@@ -2409,7 +2410,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : IT.t -> unit m) : unit m =
            in
            let branch it nm =
              let@ () = add_c loc (LC.T it) in
-             debug 5 (lazy (item ("splitting case " ^ nm) (IT.pp it)));
+             debug 5 (lazy (item ("splitting case " ^ nm) (T.pp it)));
              let@ provable = provable loc in
              let here = Locations.other __LOC__ in
              match provable (LC.T (bool_ false here)) with
@@ -2466,7 +2467,7 @@ let check_expr_top loc labels rt e =
     let (RT.Computational ((return_s, return_bt), _info, lrt)) = rt in
     match return_bt with
     | Unit ->
-      let lrt = LRT.subst (IT.make_subst [ (return_s, lvt) ]) lrt in
+      let lrt = LRT.subst (T.make_subst [ (return_s, lvt) ]) lrt in
       let@ original_resources = all_resources loc in
       Spine.subtype loc lrt (fun () ->
         let@ () = all_empty loc original_resources in
@@ -2487,7 +2488,7 @@ let check_expr_top loc labels rt e =
 let bind_arguments (_loc : Locations.t) (full_args : _ Mu.arguments) =
   let rec aux_l resources = function
     | Mu.Define ((s, it), ((loc, _) as info), args) ->
-      let@ () = add_l s (IT.get_bt it) (fst info, lazy (Sym.pp s)) in
+      let@ () = add_l s (T.get_bt it) (fst info, lazy (Sym.pp s)) in
       let@ () = add_c (fst info) (LC.T (def_ s it loc)) in
       aux_l resources args
     | Constraint (lc, info, args) ->
@@ -2924,21 +2925,21 @@ let ctz_proxy_ft =
   let info = (here, Some "ctz_proxy builtin ft") in
   let n_sym, n = IT.fresh_named BT.(Bits (Unsigned, 32)) "n_" here in
   let ret_sym, ret = IT.fresh_named BT.(Bits (Signed, 32)) "return" here in
-  let neq_0 = LC.T (IT.not_ (IT.eq_ (n, IT.int_lit_ 0 (IT.get_bt n) here) here) here) in
+  let neq_0 = LC.T (IT.not_ (IT.eq_ (n, IT.int_lit_ 0 (T.get_bt n) here) here) here) in
   let eq_ctz =
     LC.T
       (IT.eq_
-         (ret, cast_ (IT.get_bt ret) (IT.arith_unop Terms.BW_CTZ_NoSMT n here) here)
+         (ret, cast_ (T.get_bt ret) (IT.arith_unop Terms.BW_CTZ_NoSMT n here) here)
          here)
   in
   let rt =
     RT.mComputational
-      ((ret_sym, IT.get_bt ret), info)
+      ((ret_sym, T.get_bt ret), info)
       (LRT.mConstraint (eq_ctz, info) LRT.I)
   in
   let ft =
     AT.mComputationals
-      [ (n_sym, IT.get_bt n, info) ]
+      [ (n_sym, T.get_bt n, info) ]
       (AT.L (LAT.mConstraint (neq_0, info) (LAT.I rt)))
   in
   ft

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -201,8 +201,7 @@ and check_struct
   return (IT.struct_ (tag, member_its) loc)
 
 
-and check_union (_loc : Locations.t) (_tag : Sym.t) (_id : Id.t) (_mv : mem_value)
-  : T.t m
+and check_union (_loc : Locations.t) (_tag : Sym.t) (_id : Id.t) (_mv : mem_value) : T.t m
   =
   Cerb_debug.error "todo: union types"
 

--- a/lib/checkPredicates.ml
+++ b/lib/checkPredicates.ml
@@ -1,5 +1,5 @@
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Req = Request
 module Loc = Locations
 module LAT = LogicalArgumentTypes
@@ -75,7 +75,7 @@ end
 (* Type of nonterminal lines in a predicate clause.
    Corresponds to packing_ft *)
 type def_line =
-  | DefineL of (Sym.t * IT.t) * Loc.info
+  | DefineL of (Sym.t * T.t) * Loc.info
   | ResourceL of (Sym.t * (Req.t * BT.t)) * Loc.info
 
 (* Takes in:
@@ -112,11 +112,11 @@ let map_from_lists f eq exps exps' =
 
 (* Match an expression with free variables against a candidate returned by the solver to
    get candidates for each of those free variables *)
-let rec get_var_cands (exp : IT.t) (candidate : IT.t)
-  : (IT.t Sym.Map.t, Pp.document) Result.t
+let rec get_var_cands (exp : T.t) (candidate : T.t)
+  : (T.t Sym.Map.t, Pp.document) Result.t
   =
   let open Pp in
-  let map_from_IT_lists = map_from_lists get_var_cands IT.equal in
+  let map_from_IT_lists = map_from_lists get_var_cands T.equal in
   let sort_by_discard_fst compare l =
     List.map snd (List.sort (fun p1 p2 -> compare (fst p1) (fst p2)) l)
   in
@@ -133,15 +133,15 @@ let rec get_var_cands (exp : IT.t) (candidate : IT.t)
   in
   let default =
     Result.unknown
-      (!^"Different CN constructors for " ^^^ IT.pp exp ^^^ !^" and " ^^^ IT.pp candidate)
+      (!^"Different CN constructors for " ^^^ T.pp exp ^^^ !^" and " ^^^ T.pp candidate)
   in
-  match (IT.get_term exp, IT.get_term candidate) with
-  | Const c, Const c' -> map_with_guard_no (IT.equal_const c c') [] []
+  match (T.get_term exp, T.get_term candidate) with
+  | Const c, Const c' -> map_with_guard_no (Terms.equal_const c c') [] []
   | Sym v, _' -> Result.return (Sym.Map.add v candidate Sym.Map.empty)
   | Unop (op, exp1), Unop (op', exp1') ->
-    map_with_guard_unknown (IT.equal_unop op op') [ exp1 ] [ exp1' ]
+    map_with_guard_unknown (Terms.equal_unop op op') [ exp1 ] [ exp1' ]
   | Binop (op, exp1, exp2), Binop (op', exp1', exp2') ->
-    map_with_guard_unknown (IT.equal_binop op op') [ exp1; exp2 ] [ exp1'; exp2' ]
+    map_with_guard_unknown (Terms.equal_binop op op') [ exp1; exp2 ] [ exp1'; exp2' ]
   | ITE (exp1, exp2, exp3), ITE (exp1', exp2', exp3') ->
     map_from_IT_lists [ exp1; exp2; exp3 ] [ exp1'; exp2'; exp3' ]
   | EachI ((z1, (v, bty), z2), exp1), EachI ((z1', (v', bty'), z2'), exp1') ->
@@ -255,7 +255,7 @@ let rec organize_lines_aux
           (lines : LAT.packing_ft)
           (defs : def_line Sym.Map.t)
           (lcs : LC.t list)
-  : IT.t * def_line Sym.Map.t * LC.t list
+  : T.t * def_line Sym.Map.t * LC.t list
   =
   match lines with
   | Define ((v, it), i, next) ->
@@ -271,7 +271,7 @@ let rec organize_lines_aux
 
 
 (* Sort lines into the returned expression, a map of variables to their defining lines, and a list of constraints *)
-let organize_lines (lines : LAT.packing_ft) : IT.t * def_line Sym.Map.t * LC.t list =
+let organize_lines (lines : LAT.packing_ft) : T.t * def_line Sym.Map.t * LC.t list =
   organize_lines_aux lines Sym.Map.empty []
 
 
@@ -289,7 +289,7 @@ let ask_solver g lcs =
       ~solver:s
       ~assumptions:(LC.Set.of_list lcs)
       ~simp_ctxt
-      (LC.T (IT.bool_ false here))
+      (LC.T (IndexTerms.bool_ false here))
   in
   let res =
     match solver_res with
@@ -305,30 +305,30 @@ let ask_solver g lcs =
   res
 
 
-let pair_to_lc (ps : IT.t * IT.t) : LogicalConstraints.t =
+let pair_to_lc (ps : T.t * T.t) : LogicalConstraints.t =
   let here = Locations.other __LOC__ in
-  LC.T (IT.eq_ (fst ps, snd ps) here)
+  LC.T (IndexTerms.eq_ (fst ps, snd ps) here)
 
 
 (* convert a list of variable assignments to equality constraints *)
-let convert_symmap_to_lcs (m : IT.t Sym.Map.t) : LogicalConstraints.t list =
+let convert_symmap_to_lcs (m : T.t Sym.Map.t) : LogicalConstraints.t list =
   let here = Locations.other __LOC__ in
   let kvs = Sym.Map.bindings m in
-  List.map (fun (k, v) -> pair_to_lc (IT.IT (IT.Sym k, IT.get_bt v, here), v)) kvs
+  List.map (fun (k, v) -> pair_to_lc (Terms.IT (Terms.Sym k, T.get_bt v, here), v)) kvs
 
 
 (* check if a candidate term could have been the output of a given predicate *)
 let rec check_pred
           (name : Sym.t)
           (def : Def.Predicate.t)
-          (candidate : IT.t)
+          (candidate : T.t)
           (ctxt : C.t)
-          (iarg_vals : IT.t list)
-          (term_vals : (IT.t * IT.t) list)
+          (iarg_vals : T.t list)
+          (term_vals : (T.t * T.t) list)
   : (LC.t list, Pp.document) Result.t
   =
   (* ensure candidate type matches output type of predicate *)
-  assert (BT.equal (IT.get_bt candidate) (snd def.oarg));
+  assert (BT.equal (T.get_bt candidate) (snd def.oarg));
   let open Pp in
   match def.clauses with
   | None -> Result.unknown (!^"Predicate" ^^^ Sym.pp name ^^^ !^"is uninterpreted. ")
@@ -347,11 +347,11 @@ let rec check_pred
 (* check if a candidate term could have been the output of a predicate clause *)
 and check_clause
       (c : Def.Clause.t)
-      (candidate : IT.t)
+      (candidate : T.t)
       (ctxt : C.t)
       (iargs : (Sym.t * BT.t) list)
-      (iarg_vals : IT.t list)
-      (term_vals : (IT.t * IT.t) list)
+      (iarg_vals : T.t list)
+      (term_vals : (T.t * T.t) list)
   =
   let open Result in
   let zipped = List.combine (List.map fst iargs) iarg_vals in
@@ -384,12 +384,12 @@ and check_clause
 
 (* get a list of constraints that are satisfiable iff candidate could have come from this clause body *)
 and get_body_constraints
-      (exp : IT.t)
+      (exp : T.t)
       (var_def_locs : def_line Sym.Map.t)
-      (candidate : IT.t)
+      (candidate : T.t)
       (ctxt : C.t)
       (iargs : (Sym.t * BT.t) list)
-      (term_vals : (IT.t * IT.t) list)
+      (term_vals : (T.t * T.t) list)
   =
   let open Result in
   let f var_cands =
@@ -414,7 +414,7 @@ and get_body_constraints
   | Error (Unknown, e) ->
     let here = Locations.other __LOC__ in
     let res =
-      match ask_solver ctxt.global [ LC.T (IT.eq_ (exp, candidate) here) ] with
+      match ask_solver ctxt.global [ LC.T (IndexTerms.eq_ (exp, candidate) here) ] with
       | Ok _ ->
         (* not using model to get var cands because it may overconstrain *)
         return ([], Sym.Map.empty)
@@ -427,12 +427,12 @@ and get_body_constraints
 
 and get_var_constraints
       (v : Sym.t)
-      (v_cand : IT.t)
-      (var_cands : IT.t Sym.Map.t)
+      (v_cand : T.t)
+      (var_cands : T.t Sym.Map.t)
       (var_def_locs : def_line Sym.Map.t)
       (ctxt : C.t)
       (iargs : (Sym.t * BT.t) list)
-      (term_vals : (IT.t * IT.t) list)
+      (term_vals : (T.t * T.t) list)
   =
   let open Pp in
   let open Result in

--- a/lib/cnprog.ml
+++ b/lib/cnprog.ml
@@ -1,9 +1,9 @@
-module IT = IndexTerms
+module T = Terms.Normal
 module Loc = Locations
 
 type load =
   { ct : Sctypes.t;
-    pointer : IndexTerms.t
+    pointer : T.t
   }
 
 (* Cnprog.t should be removed eventually
@@ -15,13 +15,13 @@ type 'a t =
 
 let rec subst f substitution = function
   | Let (loc, (name, { ct; pointer }), prog) ->
-    let pointer = IT.subst substitution pointer in
+    let pointer = T.subst substitution pointer in
     let name, prog = suitably_alpha_rename f substitution.relevant name prog in
     Let (loc, (name, { ct; pointer }), subst f substitution prog)
   | Pure (loc, x) -> Pure (loc, f substitution x)
 
 
-and alpha_rename_ f ~from ~to_ prog = (to_, subst f (IT.make_rename ~from ~to_) prog)
+and alpha_rename_ f ~from ~to_ prog = (to_, subst f (T.make_rename ~from ~to_) prog)
 
 and alpha_rename f from prog =
   let to_ = Sym.fresh_same from in
@@ -37,7 +37,7 @@ and suitably_alpha_rename f syms s prog =
 
 let rec free_vars f = function
   | Let (_, (name, { pointer; _ }), prog) ->
-    let pointer_fvs = IT.free_vars pointer in
+    let pointer_fvs = T.free_vars pointer in
     let prog_fvs = free_vars f prog in
     Sym.Set.union pointer_fvs (Sym.Set.remove name prog_fvs)
   | Pure (_, x) -> f x
@@ -56,14 +56,14 @@ let rec dtree f =
     Dnode
       ( pp_ctor "LetLoad",
         [ Dleaf (Sym.pp s);
-          IT.dtree load.pointer;
+          Terms.dtree load.pointer;
           Dleaf (Sctypes.pp load.ct);
           dtree f prog
         ] )
   | Pure (_loc, x) -> f x
 
 
-let rec get_bt (cnprog_it : IT.t t) =
+let rec get_bt (cnprog_it : T.t t) =
   match cnprog_it with
   | Let (_, _, cnprog_it) -> get_bt cnprog_it
-  | Pure (_, it) -> IT.get_bt it
+  | Pure (_, it) -> Terms.get_bt it

--- a/lib/cnstatement.ml
+++ b/lib/cnstatement.ml
@@ -43,8 +43,7 @@ let rec subst substitution = function
     (* o_s is not a (option) binder *)
     Instantiate (o_s, T.subst substitution it)
   | Split_case lc -> Split_case (LC.subst substitution lc)
-  | Extract (attrs, to_extract, it) ->
-    Extract (attrs, to_extract, T.subst substitution it)
+  | Extract (attrs, to_extract, it) -> Extract (attrs, to_extract, T.subst substitution it)
   | Unfold (fsym, args) ->
     (* fsym is a function symbol *)
     Unfold (fsym, List.map (T.subst substitution) args)
@@ -148,8 +147,7 @@ let dtree =
           dtree_of_to_extract to_extract;
           T.dtree it
         ] )
-  | Unfold (s, args) ->
-    Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map T.dtree args)
+  | Unfold (s, args) -> Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map T.dtree args)
   | Apply (s, args) -> Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.map T.dtree args)
   | Assert lc -> Dnode (pp_ctor "Assert", [ LC.dtree lc ])
   | Inline nms -> Dnode (pp_ctor "Inline", List.map (fun nm -> Dleaf (Sym.pp nm)) nms)

--- a/lib/cnstatement.ml
+++ b/lib/cnstatement.ml
@@ -1,5 +1,5 @@
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Loc = Locations
 module CF = Cerb_frontend
 module Req = Request
@@ -9,7 +9,7 @@ type have_show =
   | Have
   | Show
 
-type extract = Id.t list * (Sym.t, Sctypes.t) CF.Cn.cn_to_extract * IndexTerms.t
+type extract = Id.t list * (Sym.t, Sctypes.t) CF.Cn.cn_to_extract * T.t
 
 type predicate_or_predicate_name =
   | Predicate of Request.Predicate.t
@@ -19,14 +19,14 @@ type statement =
   | Pack_unpack of CF.Cn.pack_unpack * predicate_or_predicate_name
   | To_from_bytes of CF.Cn.to_from * Request.Predicate.t
   | Have of LogicalConstraints.t
-  | Instantiate of (Sym.t, Sctypes.t) CF.Cn.cn_to_instantiate * IndexTerms.t
+  | Instantiate of (Sym.t, Sctypes.t) CF.Cn.cn_to_instantiate * T.t
   | Split_case of LogicalConstraints.t
   | Extract of extract
-  | Unfold of Sym.t * IndexTerms.t list
-  | Apply of Sym.t * IndexTerms.t list
+  | Unfold of Sym.t * T.t list
+  | Apply of Sym.t * T.t list
   | Assert of LogicalConstraints.t
   | Inline of Sym.t list
-  | Print of IndexTerms.t
+  | Print of T.t
 
 let subst_predicate_or_predicate_name substitution = function
   | Predicate pt -> Predicate (Req.Predicate.subst substitution pt)
@@ -41,22 +41,22 @@ let rec subst substitution = function
   | Have lc -> Have (LC.subst substitution lc)
   | Instantiate (o_s, it) ->
     (* o_s is not a (option) binder *)
-    Instantiate (o_s, IT.subst substitution it)
+    Instantiate (o_s, T.subst substitution it)
   | Split_case lc -> Split_case (LC.subst substitution lc)
   | Extract (attrs, to_extract, it) ->
-    Extract (attrs, to_extract, IT.subst substitution it)
+    Extract (attrs, to_extract, T.subst substitution it)
   | Unfold (fsym, args) ->
     (* fsym is a function symbol *)
-    Unfold (fsym, List.map (IT.subst substitution) args)
+    Unfold (fsym, List.map (T.subst substitution) args)
   | Apply (fsym, args) ->
     (* fsym is a lemma symbol *)
-    Apply (fsym, List.map (IT.subst substitution) args)
+    Apply (fsym, List.map (T.subst substitution) args)
   | Assert lc -> Assert (LC.subst substitution lc)
   | Inline nms -> Inline nms
-  | Print it -> Print (IT.subst substitution it)
+  | Print it -> Print (T.subst substitution it)
 
 
-and alpha_rename_ ~from ~to_ prog = (to_, subst (IT.make_rename ~from ~to_) prog)
+and alpha_rename_ ~from ~to_ prog = (to_, subst (T.make_rename ~from ~to_) prog)
 
 and alpha_rename from prog =
   let to_ = Sym.fresh_same from in
@@ -71,28 +71,28 @@ and suitably_alpha_rename syms s prog =
 
 
 let free_vars_predicate_or_predicate_name = function
-  | Predicate pt -> IT.free_vars_list (pt.pointer :: pt.iargs)
+  | Predicate pt -> T.free_vars_list (pt.pointer :: pt.iargs)
   | PredicateName _pn -> Sym.Set.empty
 
 
 let free_vars = function
   | Pack_unpack (_pack_unpack, pt) -> free_vars_predicate_or_predicate_name pt
-  | To_from_bytes (_to_from, pt) -> IT.free_vars_list (pt.pointer :: pt.iargs)
+  | To_from_bytes (_to_from, pt) -> T.free_vars_list (pt.pointer :: pt.iargs)
   | Have lc -> LC.free_vars lc
   | Instantiate (_o_s, it) ->
     (* o_s is not a (option) binder *)
-    IT.free_vars it
+    T.free_vars it
   | Split_case lc -> LC.free_vars lc
-  | Extract (_attrs, _to_extract, it) -> IT.free_vars it
+  | Extract (_attrs, _to_extract, it) -> T.free_vars it
   | Unfold (_fsym, args) ->
     (* fsym is a function symbol *)
-    IT.free_vars_list args
+    T.free_vars_list args
   | Apply (_fsym, args) ->
     (* fsym is a lemma symbol *)
-    IT.free_vars_list args
+    T.free_vars_list args
   | Assert lc -> LC.free_vars lc
   | Inline _nms -> Sym.Set.empty
-  | Print it -> IT.free_vars it
+  | Print it -> T.free_vars it
 
 
 let free_vars_list stmts =
@@ -139,18 +139,18 @@ let dtree =
     Dnode (pp_ctor "From_bytes", [ Request.Predicate.dtree pred ])
   | Have lc -> Dnode (pp_ctor "Have", [ LC.dtree lc ])
   | Instantiate (to_instantiate, it) ->
-    Dnode (pp_ctor "Instantiate", [ dtree_of_to_instantiate to_instantiate; IT.dtree it ])
+    Dnode (pp_ctor "Instantiate", [ dtree_of_to_instantiate to_instantiate; T.dtree it ])
   | Split_case lc -> Dnode (pp_ctor "Split_case", [ LC.dtree lc ])
   | Extract (attrs, to_extract, it) ->
     Dnode
       ( pp_ctor "Extract",
         [ Dnode (pp_ctor "Attrs", List.map (fun s -> Dleaf (Id.pp s)) attrs);
           dtree_of_to_extract to_extract;
-          IT.dtree it
+          T.dtree it
         ] )
   | Unfold (s, args) ->
-    Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map IT.dtree args)
-  | Apply (s, args) -> Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.map IT.dtree args)
+    Dnode (pp_ctor "Unfold", Dleaf (Sym.pp s) :: List.map T.dtree args)
+  | Apply (s, args) -> Dnode (pp_ctor "Apply", Dleaf (Sym.pp s) :: List.map T.dtree args)
   | Assert lc -> Dnode (pp_ctor "Assert", [ LC.dtree lc ])
   | Inline nms -> Dnode (pp_ctor "Inline", List.map (fun nm -> Dleaf (Sym.pp nm)) nms)
-  | Print it -> Dnode (pp_ctor "Print", [ IT.dtree it ])
+  | Print it -> Dnode (pp_ctor "Print", [ T.dtree it ])

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -386,7 +386,8 @@ module C_vars = struct
     | ScopeExists of Locations.t * name * (bool -> 'a t)
     | Value_of_c_variable of
         Locations.t * Sym.t * name option * (Terms.Surface.t option -> 'a t)
-    | Deref of Locations.t * Terms.Surface.t * name option * (Terms.Surface.t option -> 'a t)
+    | Deref of
+        Locations.t * Terms.Surface.t * name option * (Terms.Surface.t option -> 'a t)
 
   module Monad = struct
     type nonrec 'a t = 'a t
@@ -477,8 +478,9 @@ module C_vars = struct
                     { base = Surface.proj e1;
                       ct;
                       index =
-                        IT.(let e2 = Surface.proj e2 in
-                         sub_ (int_lit_ 0 (get_bt e2) here, e2) here)
+                        IT.(
+                          let e2 = Surface.proj e2 in
+                          sub_ (int_lit_ 0 (get_bt e2) here, e2) here)
                     },
                   BT.Loc (),
                   loc ))
@@ -788,8 +790,7 @@ module C_vars = struct
                let end_pos = Option.get @@ Locations.end_pos @@ get_loc v in
                (* cursor for the first update doesn't point to '[' - oh well *)
                let cursor =
-                 Cerb_location.PointCursor
-                   (Option.get @@ Locations.start_pos @@ get_loc i)
+                 Cerb_location.PointCursor (Option.get @@ Locations.start_pos @@ get_loc i)
                in
                return
                  (IT
@@ -1120,9 +1121,11 @@ module C_vars = struct
     let qs = IT.sym_ sym_args in
     let msg_s = "Iterated predicate pointer must be array_shift<ctype>(ptr, q_var):" in
     match Terms.get_term ptr_expr with
-    | Terms.ArrayShift { base = p; ct; index = x } when Terms.equal_annot SBT.equal x qs ->
+    | Terms.ArrayShift { base = p; ct; index = x } when Terms.equal_annot SBT.equal x qs
+      ->
       return (p, ct)
-    | _ -> fail { loc; msg = Generic (!^msg_s ^^^ Terms.pp ptr_expr) [@alert "-deprecated"] }
+    | _ ->
+      fail { loc; msg = Generic (!^msg_s ^^^ Terms.pp ptr_expr) [@alert "-deprecated"] }
 
 
   (* TODO: replace 'good' with 'aligned' *)
@@ -1163,7 +1166,8 @@ module C_vars = struct
           if !BT.cnBV then
             []
           else
-            [ (LC.T (Terms.Surface.proj (IT.representable_ (ct, pointee) here)), info) ] )
+            [ (LC.T (Terms.Surface.proj (IT.representable_ (ct, pointee) here)), info) ]
+        )
       | _ -> ([], [])
     in
     return (pt, pointee_value, pointee_constrs)
@@ -1237,7 +1241,8 @@ module C_vars = struct
       let@ e2 = cn_expr (Sym.Set.singleton sym) env_with_q e2_ in
       return
         (LC.Forall
-           ((sym, SBT.proj bt), IT.impl_ (Terms.Surface.proj e1, Terms.Surface.proj e2) loc))
+           ( (sym, SBT.proj bt),
+             IT.impl_ (Terms.Surface.proj e1, Terms.Surface.proj e2) loc ))
 
 
   let cn_statement env (loc, (stmt_ : _ Cn.cn_statement_)) =
@@ -1367,7 +1372,9 @@ module Handle = struct
     match Terms.get_bt it with
     | BT.Loc (Some ct) -> return ct
     | BT.Loc None ->
-      let msg = !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (Terms.pp it) ^^ Pp.dot in
+      let msg =
+        !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (Terms.pp it) ^^ Pp.dot
+      in
       fail { loc; msg = Generic msg [@alert "-deprecated"] }
     | has ->
       let expected = "pointer" in

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -10,7 +10,7 @@ module LC = LogicalConstraints
 module Req = Request
 module Mu = Mucore
 module RT = ReturnTypes
-module STermMap = Map.Make (IndexTerms.Surface)
+module STermMap = Map.Make (Terms.Surface)
 module StringMap = Map.Make (String)
 open Pp.Infix
 
@@ -221,8 +221,8 @@ type message =
   | Cannot_convert_enum_expr of unit Cerb_frontend.AilSyntax.expression
   | Cerb_frontend of Locations.t * Cerb_frontend.Errors.cause
   | Illtyped_binary_it of
-      { left : IndexTerms.Surface.t;
-        right : IndexTerms.Surface.t;
+      { left : Terms.Surface.t;
+        right : Terms.Surface.t;
         binop : Cerb_frontend.Cn.cn_binop
       }
   | First_iarg_missing
@@ -231,7 +231,7 @@ type message =
         found_bty : BaseTypes.t
       }
   | Datatype_repeated_member of Id.t
-  | No_pointee_ctype of IndexTerms.Surface.t
+  | No_pointee_ctype of Terms.Surface.t
   | Each_quantifier_not_numeric of Sym.t * BaseTypes.Surface.t
   | Generic of Pp.document [@deprecated "Temporary, for refactor, to be deleted."]
 
@@ -267,7 +267,7 @@ let convert_enum_expr =
         else
           return BT.Integer
       in
-      return (IT.Surface.inj (IT.num_lit_ z bt loc))
+      return (Terms.Surface.inj (IT.num_lit_ z bt loc))
     | c -> fail { loc; msg = Cannot_convert_enum_const c }
   in
   let rec conv_expr_ e1 loc = function
@@ -333,12 +333,12 @@ module C_vars = struct
   (* the expression that encodes the current value of this c variable *)
   type state =
     | Value of Sym.t * SBT.t (* currently the variable is a pure value, this one *)
-    | Points_to of IT.Surface.t
+    | Points_to of Terms.Surface.t
   (* currently the variable is a pointer to memory holding this value *)
 
   type scope =
     { var_state : state Sym.Map.t;
-      pointee_values : IT.Surface.t STermMap.t
+      pointee_values : Terms.Surface.t STermMap.t
     }
 
   let empty_state = { var_state = Sym.Map.empty; pointee_values = STermMap.empty }
@@ -385,8 +385,8 @@ module C_vars = struct
     | Error of err
     | ScopeExists of Locations.t * name * (bool -> 'a t)
     | Value_of_c_variable of
-        Locations.t * Sym.t * name option * (IT.Surface.t option -> 'a t)
-    | Deref of Locations.t * IT.Surface.t * name option * (IT.Surface.t option -> 'a t)
+        Locations.t * Sym.t * name option * (Terms.Surface.t option -> 'a t)
+    | Deref of Locations.t * Terms.Surface.t * name option * (Terms.Surface.t option -> 'a t)
 
   module Monad = struct
     type nonrec 'a t = 'a t
@@ -448,7 +448,7 @@ module C_vars = struct
   (* TODO: type checks and disambiguation at this stage seems ill-advised,
      ideally would be integrated into wellTyped.ml *)
   let mk_binop loc bop (e1, e2) =
-    let open IndexTerms in
+    let open Terms in
     match (bop, get_bt e1) with
     | Cn.CN_add, (BT.Integer | Real | Bits _) ->
       return (IT (Binop (Add, e1, e2), get_bt e1, loc))
@@ -477,8 +477,8 @@ module C_vars = struct
                     { base = Surface.proj e1;
                       ct;
                       index =
-                        (let e2 = Surface.proj e2 in
-                         sub_ (int_lit_ 0 (IT.get_bt e2) here, e2) here)
+                        IT.(let e2 = Surface.proj e2 in
+                         sub_ (int_lit_ 0 (get_bt e2) here, e2) here)
                     },
                   BT.Loc (),
                   loc ))
@@ -507,7 +507,7 @@ module C_vars = struct
            !^"CN pointer equality is not the same as C's (will not warn again). Please \
               use `ptr_eq` or `is_null` (maybe `addr_eq`)."
        | _, _, _ -> ());
-      return (not_ (IT (Binop (EQ, e1, e2), BT.Bool, loc)) loc)
+      return IT.(not_ (IT (Binop (EQ, e1, e2), BT.Bool, loc)) loc)
     | CN_lt, (BT.Integer | BT.Real | BT.Bits _) ->
       return (IT (Binop (LT, e1, e2), BT.Bool, loc))
     | CN_lt, BT.Loc _ -> return (IT (Binop (LTPointer, e1, e2), BT.Bool, loc))
@@ -545,8 +545,8 @@ module C_vars = struct
 
 
   (* just copy-pasting and adapting Kayvan's older version of this code *)
-  let member_access loc env (t : IT.Surface.t) member =
-    match IT.get_bt t with
+  let member_access loc env (t : Terms.Surface.t) member =
+    match Terms.get_bt t with
     | BT.Record members ->
       let@ member_bt =
         match List.assoc_opt Id.equal member members with
@@ -559,7 +559,7 @@ module C_vars = struct
       let@ defs_ = lookup_struct loc tag env in
       let@ ty = lookup_member loc (tag, defs_) member in
       let member_bt = Memory.sbt_of_sct ty in
-      return (IT.IT (StructMember (t, member), member_bt, loc))
+      return (Terms.IT (StructMember (t, member), member_bt, loc))
     | has ->
       let expected = "struct" in
       let reason = "struct member access" in
@@ -574,11 +574,11 @@ module C_vars = struct
 
   let rec cn_pat env locally_bound (Cn.CNPat (loc, pat_), bt) =
     match pat_ with
-    | CNPat_wild -> return (env, locally_bound, IT.Pat (PWild, bt, loc))
+    | CNPat_wild -> return (env, locally_bound, Terms.Pat (PWild, bt, loc))
     | CNPat_sym s ->
       let env' = add_logical s bt env in
       let locally_bound' = Sym.Set.add s locally_bound in
-      return (env', locally_bound', IT.Pat (PSym s, bt, loc))
+      return (env', locally_bound', Terms.Pat (PSym s, bt, loc))
     | CNPat_constructor (cons, args) ->
       let@ cons_info = lookup_constr loc cons env in
       let@ env', locally_bound', args =
@@ -598,7 +598,7 @@ module C_vars = struct
           (env, locally_bound, [])
           args
       in
-      return (env', locally_bound', IT.Pat (PConstructor (cons, args), bt, loc))
+      return (env', locally_bound', Terms.Pat (PConstructor (cons, args), bt, loc))
 
 
   let check_quantified_base_type env loc sym bt =
@@ -628,7 +628,7 @@ module C_vars = struct
           (!^"annotation on"
            ^^^ !^pred_name
            ^^^ !^"suggests"
-           ^^^ IT.pp ptr
+           ^^^ Terms.pp ptr
            ^^^ !^"has type"
            ^^^ Sctypes.pp (Sctypes.Pointer annot)
            ^^^ !^"but it has type"
@@ -640,7 +640,7 @@ module C_vars = struct
     let context_str =
       match context with `RW -> "RW" | `W -> "W" | `Array_shift -> "array_shift"
     in
-    match (oty, IT.get_bt ptr) with
+    match (oty, Terms.get_bt ptr) with
     | Some annot, BT.Loc (Some inferred) ->
       let annot = Sctypes.of_ctype_unsafe loc annot in
       warn_if_ct_mismatch loc context ~annot ~inferred ~ptr;
@@ -671,14 +671,14 @@ module C_vars = struct
 
 
   let cn_expr =
-    let open IndexTerms in
+    let open Terms in
     let module BT = BaseTypes in
     let rec trans
               (evaluation_scope : string option)
               locally_bound
               env
               (Cn.CNExpr (loc, expr_))
-      : IndexTerms.Surface.t Monad.t
+      : Terms.Surface.t Monad.t
       =
       let self = trans evaluation_scope locally_bound env in
       match expr_ with
@@ -716,7 +716,7 @@ module C_vars = struct
           Option.get @@ Locations.get_region loc
         in
         let cons hd tl =
-          let hd_pos = Option.get @@ Locations.start_pos @@ IT.get_loc hd in
+          let hd_pos = Option.get @@ Locations.start_pos @@ get_loc hd in
           let loc = Locations.(region (hd_pos, nil_pos) NoCursor) in
           IT (Cons (hd, tl), BT.List item_bt, loc)
         in
@@ -734,16 +734,16 @@ module C_vars = struct
         member_access loc env e xs
       | CNExpr_record members ->
         let@ members = ListM.mapsndM self members in
-        let bts = List.map_snd IT.get_bt members in
-        return (IT (IT.Record members, BT.Record bts, loc))
+        let bts = List.map_snd get_bt members in
+        return (IT (Record members, BT.Record bts, loc))
       | CNExpr_struct (tag, members) ->
         let@ members = ListM.mapsndM self members in
-        return (IT (IT.Struct (tag, members), BT.Struct tag, loc))
+        return (IT (Struct (tag, members), BT.Struct tag, loc))
       | CNExpr_memberupdates (e, updates) ->
         let@ e = self e in
-        let bt = IT.get_bt e in
+        let bt = get_bt e in
         let end_pos = Option.get @@ Locations.end_pos loc in
-        (match IT.get_bt e with
+        (match get_bt e with
          | Struct _ ->
            let@ expr =
              ListM.fold_rightM
@@ -759,7 +759,7 @@ module C_vars = struct
            return expr
          | _ ->
            fail
-             { loc = IT.get_loc e;
+             { loc = get_loc e;
                msg =
                  WellTyped
                    (Illtyped_it
@@ -773,7 +773,7 @@ module C_vars = struct
              })
       | CNExpr_arrayindexupdates (e, updates) ->
         let@ e = self e in
-        let bt = IT.get_bt e in
+        let bt = get_bt e in
         (* start_pos points to start_pos of e ignored cursor points to '[' end_pos points
            to ']' *)
         let start_pos, end_pos, _ =
@@ -785,11 +785,11 @@ module C_vars = struct
             (fun acc (i, v) ->
                let@ i = self i in
                let@ v = self v in
-               let end_pos = Option.get @@ Locations.end_pos @@ IT.get_loc v in
+               let end_pos = Option.get @@ Locations.end_pos @@ get_loc v in
                (* cursor for the first update doesn't point to '[' - oh well *)
                let cursor =
                  Cerb_location.PointCursor
-                   (Option.get @@ Locations.start_pos @@ IT.get_loc i)
+                   (Option.get @@ Locations.start_pos @@ get_loc i)
                in
                return
                  (IT
@@ -817,10 +817,10 @@ module C_vars = struct
       | CNExpr_array_shift (base, ty_annot, index) ->
         let@ base = self base in
         let@ ct = infer_scty ~pred_loc:loc ~ptr:base `Array_shift ty_annot in
-        (match IT.get_bt base with
+        (match get_bt base with
          | Loc _ ->
            let@ index = self index in
-           (match IT.get_bt index with
+           (match get_bt index with
             | Integer | Bits _ ->
               return (IT (ArrayShift { base; ct; index }, Loc (Some ct), loc))
             | has ->
@@ -848,13 +848,13 @@ module C_vars = struct
           let@ struct_def = lookup_struct loc tag env in
           let@ member_ty = lookup_member loc (tag, struct_def) member in
           let (IT (it_, _, _)) =
-            Surface.inj (memberShift_ (Surface.proj e, tag, member) loc)
+            Surface.inj (IT.memberShift_ (Surface.proj e, tag, member) loc)
           in
           (* Surface.inj will not have produced a C-type-annotated bt. So stick that on
              now. *)
           return (IT (it_, Loc (Some member_ty), loc))
         in
-        (match (opt_tag, IT.get_bt e) with
+        (match (opt_tag, get_bt e) with
          | Some (Ctype (_, Struct tag)), Loc (Some (Struct tag')) ->
            if Sym.equal tag tag' then
              with_tag tag
@@ -880,7 +880,7 @@ module C_vars = struct
                  WellTyped
                    (Illtyped_it { it = Terms.pp e; has = SBT.pp has; expected; reason })
              })
-      | CNExpr_addr nm -> return (sym_ (nm, BT.Loc None, loc))
+      | CNExpr_addr nm -> return (IT.sym_ (nm, BT.Loc None, loc))
       | CNExpr_cast (bt, expr) ->
         let@ expr = self expr in
         let bt = base_type env bt in
@@ -905,7 +905,7 @@ module C_vars = struct
                    msg = Global (Unknown_logical_function { id = fsym; resource = false })
                  }
            in
-           return (apply_ fsym args (BaseTypes.Surface.inj bt) loc))
+           return (IT.apply_ fsym args (BaseTypes.Surface.inj bt) loc))
       | CNExpr_cons (c_nm, exprs) ->
         let@ cons_info = lookup_constr loc c_nm env in
         let@ exprs =
@@ -936,13 +936,13 @@ module C_vars = struct
           ListM.mapM
             (fun (pat, body) ->
                let@ env', locally_bound', pat =
-                 cn_pat env locally_bound (pat, IT.get_bt x)
+                 cn_pat env locally_bound (pat, get_bt x)
                in
                let@ body = trans evaluation_scope locally_bound' env' body in
                return (pat, body))
             ms
         in
-        let rbt = IT.get_bt (snd (List.hd ms)) in
+        let rbt = get_bt (snd (List.hd ms)) in
         return (IT (Match (x, ms), rbt, loc))
       | CNExpr_let (s, e, body) ->
         let@ e = self e in
@@ -950,25 +950,25 @@ module C_vars = struct
           trans
             evaluation_scope
             (Sym.Set.add s locally_bound)
-            (add_logical s (IT.get_bt e) env)
+            (add_logical s (get_bt e) env)
             body
         in
-        return (IT (Let ((s, e), body), IT.get_bt body, loc))
+        return (IT (Let ((s, e), body), get_bt body, loc))
       | CNExpr_ite (e1, e2, e3) ->
         let@ e1 = self e1 in
         let@ e2 = self e2 in
         let@ e3 = self e3 in
-        return (ite_ (e1, e2, e3) loc)
+        return (IT.ite_ (e1, e2, e3) loc)
       | CNExpr_good (ty, e) ->
         let scty = Sctypes.of_ctype_unsafe loc ty in
         let@ e = self e in
         return (IT (Good (scty, e), BT.Bool, loc))
       | CNExpr_not e ->
         let@ e = self e in
-        return (not_ e loc)
+        return (IT.not_ e loc)
       | CNExpr_bnot e ->
         let@ e = self e in
-        return (bw_compl_ e loc)
+        return (IT.bw_compl_ e loc)
       | CNExpr_negate e ->
         let@ e = self e in
         (match e with
@@ -976,7 +976,7 @@ module C_vars = struct
          | IT (Const (Bits ((sign, width), z)), _bt, _) ->
            (* this will be checked to fit in WellTyped.infer *)
            return (IT (Const (Bits ((sign, width), Z.neg z)), BT.Bits (sign, width), loc))
-         | _ -> return (negate e loc))
+         | _ -> return (IT.negate e loc))
       | CNExpr_default bt ->
         let bt = base_type env bt in
         return (IT (Const (Default (SBT.proj bt)), bt, loc))
@@ -1115,14 +1115,14 @@ module C_vars = struct
     return (pname, ptr_expr, iargs, oargs_ty)
 
 
-  let split_pointer_linear_step loc sym_args (ptr_expr : IT.Surface.t) =
+  let split_pointer_linear_step loc sym_args (ptr_expr : Terms.Surface.t) =
     let open Pp in
     let qs = IT.sym_ sym_args in
     let msg_s = "Iterated predicate pointer must be array_shift<ctype>(ptr, q_var):" in
-    match IT.get_term ptr_expr with
-    | ArrayShift { base = p; ct; index = x } when Terms.equal_annot SBT.equal x qs ->
+    match Terms.get_term ptr_expr with
+    | Terms.ArrayShift { base = p; ct; index = x } when Terms.equal_annot SBT.equal x qs ->
       return (p, ct)
-    | _ -> fail { loc; msg = Generic (!^msg_s ^^^ IT.pp ptr_expr) [@alert "-deprecated"] }
+    | _ -> fail { loc; msg = Generic (!^msg_s ^^^ Terms.pp ptr_expr) [@alert "-deprecated"] }
 
 
   (* TODO: replace 'good' with 'aligned' *)
@@ -1148,8 +1148,8 @@ module C_vars = struct
     let pt =
       ( Req.P
           { name = pname;
-            pointer = IT.Surface.proj ptr_expr;
-            iargs = List.map IT.Surface.proj iargs
+            pointer = Terms.Surface.proj ptr_expr;
+            iargs = List.map Terms.Surface.proj iargs
           },
         oargs_ty )
     in
@@ -1163,7 +1163,7 @@ module C_vars = struct
           if !BT.cnBV then
             []
           else
-            [ (LC.T (IT.Surface.proj (IT.representable_ (ct, pointee) here)), info) ] )
+            [ (LC.T (Terms.Surface.proj (IT.representable_ (ct, pointee) here)), info) ] )
       | _ -> ([], [])
     in
     return (pt, pointee_value, pointee_constrs)
@@ -1184,10 +1184,10 @@ module C_vars = struct
           { name = pname;
             q = (q, SBT.proj bt');
             q_loc = here;
-            pointer = IT.Surface.proj ptr_base;
+            pointer = Terms.Surface.proj ptr_base;
             step;
-            permission = IT.Surface.proj guard_expr;
-            iargs = List.map IT.Surface.proj iargs
+            permission = Terms.Surface.proj guard_expr;
+            iargs = List.map Terms.Surface.proj iargs
           },
         m_oargs_ty )
     in
@@ -1204,7 +1204,7 @@ module C_vars = struct
           [ ( LC.Forall
                 ( (q, SBT.proj bt'),
                   impl_
-                    ( Surface.proj guard_expr,
+                    ( Terms.Surface.proj guard_expr,
                       representable_ (ct, map_get_ oarg qt here) here )
                     here ),
               info )
@@ -1229,7 +1229,7 @@ module C_vars = struct
     match assrt with
     | Cn.CN_assert_exp e_ ->
       let@ e = cn_expr Sym.Set.empty env e_ in
-      return (LC.T (IT.Surface.proj e))
+      return (LC.T (Terms.Surface.proj e))
     | CN_assert_qexp (sym, bTy, e1_, e2_) ->
       let bt = base_type env bTy in
       let env_with_q = add_logical sym bt env in
@@ -1237,7 +1237,7 @@ module C_vars = struct
       let@ e2 = cn_expr (Sym.Set.singleton sym) env_with_q e2_ in
       return
         (LC.Forall
-           ((sym, SBT.proj bt), IT.impl_ (IT.Surface.proj e1, IT.Surface.proj e2) loc))
+           ((sym, SBT.proj bt), IT.impl_ (Terms.Surface.proj e1, Terms.Surface.proj e2) loc))
 
 
   let cn_statement env (loc, (stmt_ : _ Cn.cn_statement_)) =
@@ -1251,8 +1251,8 @@ module C_vars = struct
           ( pack_unpack,
             Predicate
               { name;
-                pointer = IT.Surface.proj pointer;
-                iargs = List.map IT.Surface.proj iargs
+                pointer = Terms.Surface.proj pointer;
+                iargs = List.map Terms.Surface.proj iargs
               } )
       in
       return stmt
@@ -1275,15 +1275,15 @@ module C_vars = struct
         (To_from_bytes
            ( to_from,
              { name;
-               pointer = IT.Surface.proj pointer;
-               iargs = List.map IT.Surface.proj iargs
+               pointer = Terms.Surface.proj pointer;
+               iargs = List.map Terms.Surface.proj iargs
              } ))
     | CN_have assrt ->
       let@ assrt = cn_assrt env (loc, assrt) in
       return (Have assrt)
     | CN_instantiate (to_instantiate, expr) ->
       let@ expr = cn_expr Sym.Set.empty env expr in
-      let expr = IT.Surface.proj expr in
+      let expr = Terms.Surface.proj expr in
       let to_instantiate =
         match to_instantiate with
         | Cn.I_Everything -> Cn.I_Everything
@@ -1296,7 +1296,7 @@ module C_vars = struct
       return (Split_case e)
     | CN_extract (attrs, to_extract, expr) ->
       let@ expr = cn_expr Sym.Set.empty env expr in
-      let expr = IT.Surface.proj expr in
+      let expr = Terms.Surface.proj expr in
       let to_extract =
         match to_extract with
         | Cn.E_Everything -> Cn.E_Everything
@@ -1309,19 +1309,19 @@ module C_vars = struct
       return (Extract (attrs, to_extract, expr))
     | CN_unfold (s, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
-      let args = List.map IT.Surface.proj args in
+      let args = List.map Terms.Surface.proj args in
       return (Unfold (s, args))
     | CN_assert_stmt e ->
       let@ e = cn_assrt env (loc, e) in
       return (Assert e)
     | CN_apply (s, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
-      let args = List.map IT.Surface.proj args in
+      let args = List.map Terms.Surface.proj args in
       return (Apply (s, args))
     | CN_inline nms -> return (Inline nms)
     | CN_print expr ->
       let@ expr = cn_expr Sym.Set.empty env expr in
-      let expr = IT.Surface.proj expr in
+      let expr = Terms.Surface.proj expr in
       return (Print expr)
 end
 
@@ -1364,16 +1364,16 @@ module Handle = struct
 
 
   let pointee_ct loc it =
-    match IT.get_bt it with
+    match Terms.get_bt it with
     | BT.Loc (Some ct) -> return ct
     | BT.Loc None ->
-      let msg = !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (IT.pp it) ^^ Pp.dot in
+      let msg = !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (Terms.pp it) ^^ Pp.dot in
       fail { loc; msg = Generic msg [@alert "-deprecated"] }
     | has ->
       let expected = "pointer" in
       let reason = "dereferencing" in
       let msg =
-        WellTyped (Illtyped_it { it = IT.pp it; has = SBT.pp has; expected; reason })
+        WellTyped (Illtyped_it { it = Terms.pp it; has = SBT.pp has; expected; reason })
       in
       fail { loc; msg }
 
@@ -1409,11 +1409,11 @@ module Handle = struct
     and load loc action_pp pointer k =
       let@ pointee_ct = pointee_ct loc pointer in
       let value_loc = loc in
-      let value_s = Sym.fresh_make_uniq (action_pp ^ "_" ^ Pp.plain (IT.pp pointer)) in
+      let value_s = Sym.fresh_make_uniq (action_pp ^ "_" ^ Pp.plain (Terms.pp pointer)) in
       let value_bt = Memory.sbt_of_sct pointee_ct in
       let value = IT.sym_ (value_s, value_bt, value_loc) in
       let@ prog = aux (k (Some value)) in
-      let load = Cnprog.{ ct = pointee_ct; pointer = IT.Surface.proj pointer } in
+      let load = Cnprog.{ ct = pointee_ct; pointer = Terms.Surface.proj pointer } in
       return (Cnprog.Let (loc, (value_s, load), prog))
     in
     aux
@@ -1428,7 +1428,7 @@ let assrt env st assrt = Handle.with_state st (C_vars.cn_assrt env assrt)
 let cn_func_body env body =
   let handle = Handle.pure "Function definitions" in
   let@ body = handle (C_vars.cn_expr Sym.Set.empty env body) in
-  return (IT.Surface.proj body)
+  return (Terms.Surface.proj body)
 
 
 let known_attrs = [ "rec"; "coq_unfold" ]
@@ -1521,15 +1521,15 @@ let cn_clause env clause =
       cn_clause_aux env' st' acc' cl
     | CN_letExpr (loc, sym, e_, cl) ->
       let@ e = Handle.with_state st (C_vars.cn_expr Sym.Set.empty env e_) in
-      let acc' z = acc (LAT.mDefine (sym, IT.Surface.proj e, (loc, None)) z) in
-      cn_clause_aux (add_logical sym (IT.get_bt e) env) st acc' cl
+      let acc' z = acc (LAT.mDefine (sym, Terms.Surface.proj e, (loc, None)) z) in
+      cn_clause_aux (add_logical sym (Terms.get_bt e) env) st acc' cl
     | CN_assert (loc, assrt, cl) ->
       let@ lc = Handle.with_state st (C_vars.cn_assrt env (loc, assrt)) in
       let acc' z = acc (LAT.mConstraint (lc, (loc, None)) z) in
       cn_clause_aux env st acc' cl
     | CN_return (_loc, e_) ->
       let@ e = Handle.with_state st (C_vars.cn_expr Sym.Set.empty env e_) in
-      let e = IT.Surface.proj e in
+      let e = Terms.Surface.proj e in
       acc (LAT.I e)
   in
   cn_clause_aux env C_vars.init (fun z -> return z) clause
@@ -1544,7 +1544,7 @@ let cn_clauses env clauses =
     | CN_if (loc, e_, cl_, clauses') ->
       let@ e = Handle.pure "Predicate guards" (C_vars.cn_expr Sym.Set.empty env e_) in
       let@ cl = cn_clause env cl_ in
-      self ({ loc; guard = IT.Surface.proj e; packing_ft = cl } :: acc) clauses'
+      self ({ loc; guard = Terms.Surface.proj e; packing_ft = cl } :: acc) clauses'
   in
   let@ xs = self [] clauses in
   return (List.rev xs)
@@ -1608,9 +1608,9 @@ let rec logical_ret_generic env st = function
   | CN_cletExpr (loc, name, expr) :: ensures ->
     let@ expr = Handle.with_state st (C_vars.cn_expr Sym.Set.empty env expr) in
     let@ lrt, env, st =
-      logical_ret_generic (add_logical name (IT.get_bt expr) env) st ensures
+      logical_ret_generic (add_logical name (Terms.get_bt expr) env) st ensures
     in
-    return (LRT.mDefine (name, IT.Surface.proj expr, (loc, None)) lrt, env, st)
+    return (LRT.mDefine (name, Terms.Surface.proj expr, (loc, None)) lrt, env, st)
   | CN_cconstr (loc, constr) :: ensures ->
     let@ lc = Handle.with_state st (C_vars.cn_assrt env (loc, constr)) in
     let@ lrt, env, st = logical_ret_generic env st ensures in

--- a/lib/compile.mli
+++ b/lib/compile.mli
@@ -32,8 +32,8 @@ type message =
   | Cannot_convert_enum_expr of unit Cerb_frontend.AilSyntax.expression
   | Cerb_frontend of Locations.t * Cerb_frontend.Errors.cause
   | Illtyped_binary_it of
-      { left : IndexTerms.Surface.t;
-        right : IndexTerms.Surface.t;
+      { left : Terms.Surface.t;
+        right : Terms.Surface.t;
         binop : Cerb_frontend.Cn.cn_binop
       }
   | First_iarg_missing
@@ -42,7 +42,7 @@ type message =
         found_bty : BaseTypes.t
       }
   | Datatype_repeated_member of Id.t
-  | No_pointee_ctype of IndexTerms.Surface.t
+  | No_pointee_ctype of Terms.Surface.t
   | Each_quantifier_not_numeric of Sym.t * BaseTypes.Surface.t
   | Generic of Pp.document [@deprecated "Temporary, for refactor, to be deleted."]
 
@@ -65,7 +65,7 @@ val add_datatypes : env -> Sym.t Cerb_frontend.Cn.cn_datatype list -> env Or_Err
 module C_vars : sig
   type state =
     | Value of Sym.t * BaseTypes.Surface.t
-    | Points_to of IndexTerms.Surface.t
+    | Points_to of Terms.Surface.t
 
   type name
 
@@ -86,7 +86,7 @@ module C_vars : sig
   val add : (Sym.t * state) list -> env -> env
 
   val add_pointee_values
-    :  (IndexTerms.Surface.t * IndexTerms.Surface.t) list ->
+    :  (Terms.Surface.t * Terms.Surface.t) list ->
     env ->
     env
 end
@@ -96,7 +96,7 @@ val expr
   env ->
   C_vars.env ->
   (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_expr ->
-  IndexTerms.Surface.t Or_Error.t
+  Terms.Surface.t Or_Error.t
 
 val let_resource
   :  env ->
@@ -104,7 +104,7 @@ val let_resource
   Sym.t * (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_resource ->
   ((Request.t * BaseTypes.Surface.t)
   * (LogicalConstraints.t * (Locations.t * string option)) list
-  * (IndexTerms.Surface.t * IndexTerms.Surface.t) list)
+  * (Terms.Surface.t * Terms.Surface.t) list)
     Or_Error.t
 
 val assrt
@@ -124,7 +124,7 @@ val ownership
   (Cerb_frontend__Symbol.sym
   * ((Request.t * BaseTypes.Surface.t)
     * (LogicalConstraints.t * (Locations.t * string option)) list)
-  * BaseTypes.Surface.t IndexTerms.annot)
+  * BaseTypes.Surface.t Terms.annot)
     Or_Error.t
 
 val allocation_token
@@ -163,4 +163,4 @@ val expr_ghost
   C_vars.named_scopes ->
   env ->
   (Sym.t, Cerb_frontend.Ctype.ctype) Cerb_frontend.Cn.cn_expr ->
-  IndexTerms.Surface.t Cnprog.t Or_Error.t
+  Terms.Surface.t Cnprog.t Or_Error.t

--- a/lib/compile.mli
+++ b/lib/compile.mli
@@ -85,10 +85,7 @@ module C_vars : sig
 
   val add : (Sym.t * state) list -> env -> env
 
-  val add_pointee_values
-    :  (Terms.Surface.t * Terms.Surface.t) list ->
-    env ->
-    env
+  val add_pointee_values : (Terms.Surface.t * Terms.Surface.t) list -> env -> env
 end
 
 val expr

--- a/lib/consistent.ml
+++ b/lib/consistent.ml
@@ -18,7 +18,7 @@ let logicalReturnTypes loc lrt =
     function
     | LogicalReturnTypes.Define ((s, it), ((loc, _) as info), lrt) ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-      let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+      let@ () = add_l s (Terms.get_bt it) (loc, lazy (Pp.string "let-var")) in
       let@ () = add_c (fst info) (LC.T (IT.def_ s it here)) in
       aux lrt
     | Resource ((s, (re, re_oa_spec)), (loc, _), lrt) ->
@@ -63,7 +63,7 @@ let logicalArgumentTypes i_welltyped i_pp kind loc at : unit Typing.t =
     function
     | LAT.Define ((s, it), info, at) ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-      let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+      let@ () = add_l s (Terms.get_bt it) (loc, lazy (Pp.string "let-var")) in
       let@ () = add_c (fst info) (LC.T (IT.def_ s it here)) in
       aux at
     | Resource ((s, (re, re_oa_spec)), (loc, _), at) ->
@@ -132,7 +132,7 @@ let logicalArguments
     function
     | Mucore.Define ((s, it), ((loc, _) as info), at) ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-      let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+      let@ () = add_l s (Terms.get_bt it) (loc, lazy (Pp.string "let-var")) in
       let@ () = add_c (fst info) (LC.T (IT.def_ s it here)) in
       aux at
     | Resource ((s, (re, re_oa_spec)), (loc, _), at) ->
@@ -237,7 +237,7 @@ let predicate pred =
                  let@ () =
                    logicalArgumentTypes
                      (fun _loc _it -> return ())
-                     IT.pp
+                     Terms.pp
                      "clause"
                      loc
                      packing_ft

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -12,9 +12,9 @@ let pp_l_info doc (l : l_info) =
 
 type basetype_or_value =
   | BaseType of BT.t
-  | Value of IndexTerms.t
+  | Value of Terms.Normal.t
 
-let bt_of = function BaseType bt -> bt | Value v -> IndexTerms.get_bt v
+let bt_of = function BaseType bt -> bt | Value v -> Terms.Normal.get_bt v
 
 let has_value = function BaseType _ -> false | Value _ -> true
 
@@ -46,7 +46,7 @@ let get_rs (ctxt : t) = ctxt.resources
 
 let pp_basetype_or_value = function
   | BaseType bt -> BaseTypes.pp bt
-  | Value it -> IndexTerms.pp it
+  | Value it -> Terms.Normal.pp it
 
 
 let pp_variable_bindings bindings =

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -4,7 +4,7 @@ val pp_l_info : Pp.document -> l_info -> Pp.document
 
 type basetype_or_value =
   | BaseType of BaseTypes.t
-  | Value of IndexTerms.t
+  | Value of Terms.Normal.t
 
 val bt_of : basetype_or_value -> BaseTypes.t
 
@@ -45,13 +45,13 @@ val add_a_binding : Sym.t -> basetype_or_value -> l_info -> t -> t
 
 val add_a : Sym.t -> BaseTypes.t -> l_info -> t -> t
 
-val add_a_value : Sym.t -> IndexTerms.t -> l_info -> t -> t
+val add_a_value : Sym.t -> Terms.Normal.t -> l_info -> t -> t
 
 val add_l_binding : Sym.t -> basetype_or_value -> l_info -> t -> t
 
 val add_l : Sym.t -> BaseTypes.t -> l_info -> t -> t
 
-val add_l_value : Sym.t -> IndexTerms.t -> l_info -> t -> t
+val add_l_value : Sym.t -> Terms.Normal.t -> l_info -> t -> t
 
 val remove_a : Sym.t -> t -> t
 

--- a/lib/core_to_mucore.ml
+++ b/lib/core_to_mucore.ml
@@ -520,7 +520,7 @@ let rec n_expr
                return ghost)
             args
         in
-        let ghost_args = List.map (Cnprog.map IT.Surface.proj) ghosts in
+        let ghost_args = List.map (Cnprog.map Terms.Surface.proj) ghosts in
         return (Some (ghost_loc, ghost_args))
     in
     return (wrap (Eccall (ct1, e2, es, ghost_args)))
@@ -666,8 +666,8 @@ let make_largs f_i =
            (Mu.mConstraints lcs lat))
     | Cn.CN_cletExpr (loc, name, expr') :: conditions ->
       let@ expr = Translate.expr Sym.Set.empty env st expr' in
-      let@ lat = aux (Translate.add_logical name (IT.get_bt expr) env) st conditions in
-      return (Mu.mDefine ((name, IT.Surface.proj expr), (loc, None)) lat)
+      let@ lat = aux (Translate.add_logical name (Terms.get_bt expr) env) st conditions in
+      return (Mu.mDefine ((name, Terms.Surface.proj expr), (loc, None)) lat)
     | Cn.CN_cconstr (loc, constr) :: conditions ->
       let@ lc = Translate.assrt env st (loc, constr) in
       let@ lat = aux env st conditions in

--- a/lib/definition.ml
+++ b/lib/definition.ml
@@ -1,15 +1,16 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LAT = LogicalArgumentTypes
 
 module Function = struct
   type body =
-    | Def of IT.t
-    | Rec_Def of IT.t
+    | Def of T.t
+    | Rec_Def of T.t
     | Uninterp
 
   let subst_body subst = function
-    | Def it -> Def (IT.subst subst it)
-    | Rec_Def it -> Rec_Def (IT.subst subst it)
+    | Def it -> Def (T.subst subst it)
+    | Rec_Def it -> Rec_Def (T.subst subst it)
     | Uninterp -> Uninterp
 
 
@@ -56,13 +57,13 @@ module Function = struct
     ^/^
     match def.body with
     | Uninterp -> !^"uninterpreted"
-    | Def t -> IT.pp t
-    | Rec_Def t -> !^"rec:" ^^^ IT.pp t
+    | Def t -> T.pp t
+    | Rec_Def t -> !^"rec:" ^^^ T.pp t
 
 
   let open_ def_args def_body args =
-    let su = IT.make_subst (List.map2 (fun (s, _) arg -> (s, arg)) def_args args) in
-    IT.subst su def_body
+    let su = T.make_subst (List.map2 (fun (s, _) arg -> (s, arg)) def_args args) in
+    T.subst su def_body
 
 
   let unroll_once def args =
@@ -85,25 +86,25 @@ end
 module Clause = struct
   type t =
     { loc : Locations.t;
-      guard : IT.t;
+      guard : T.t;
       packing_ft : LAT.packing_ft
     }
 
   let pp { loc = _; guard; packing_ft } =
     let open Pp in
-    item "condition" (IT.pp guard)
+    item "condition" (T.pp guard)
     ^^ comma
-    ^^^ item "return type" (LAT.pp IT.pp packing_ft)
+    ^^^ item "return type" (LAT.pp T.pp packing_ft)
 
 
   let subst subst { loc; guard; packing_ft } =
     { loc;
-      guard = IT.subst subst guard;
-      packing_ft = LAT.subst IT.subst subst packing_ft
+      guard = T.subst subst guard;
+      packing_ft = LAT.subst T.subst subst packing_ft
     }
 
 
-  let lrt (pred_oarg : IT.t) clause_packing_ft =
+  let lrt (pred_oarg : T.t) clause_packing_ft =
     let module LRT = LogicalReturnTypes in
     let rec aux = function
       | LAT.Define (bound, info, lat) -> LRT.Define (bound, info, aux lat)
@@ -128,7 +129,7 @@ module Clause = struct
 
 
   let free_vars (c : t) : Sym.Set.t =
-    Sym.Set.union (IT.free_vars c.guard) (LAT.free_vars IT.free_vars c.packing_ft)
+    Sym.Set.union (T.free_vars c.guard) (LAT.free_vars T.free_vars c.packing_ft)
 
 
   let free_vars_list (cs : t list) : Sym.Set.t =
@@ -171,7 +172,7 @@ module Predicate = struct
     match def.clauses with
     | Some clauses ->
       let subst =
-        IT.make_subst
+        T.make_subst
           ((def.pointer, ptr_arg)
            :: List.map2 (fun (def_ia, _) ia -> (def_ia, ia)) def.iargs iargs)
       in
@@ -198,7 +199,7 @@ module Predicate = struct
                 Pp.debug
                   5
                   (lazy
-                    (Pp.item "cannot prove or disprove clause guard" (IT.pp clause.guard)));
+                    (Pp.item "cannot prove or disprove clause guard" (T.pp clause.guard)));
                 None))
       in
       try_clauses clauses

--- a/lib/definition.ml
+++ b/lib/definition.ml
@@ -92,16 +92,11 @@ module Clause = struct
 
   let pp { loc = _; guard; packing_ft } =
     let open Pp in
-    item "condition" (T.pp guard)
-    ^^ comma
-    ^^^ item "return type" (LAT.pp T.pp packing_ft)
+    item "condition" (T.pp guard) ^^ comma ^^^ item "return type" (LAT.pp T.pp packing_ft)
 
 
   let subst subst { loc; guard; packing_ft } =
-    { loc;
-      guard = T.subst subst guard;
-      packing_ft = LAT.subst T.subst subst packing_ft
-    }
+    { loc; guard = T.subst subst guard; packing_ft = LAT.subst T.subst subst packing_ft }
 
 
   let lrt (pred_oarg : T.t) clause_packing_ft =

--- a/lib/definition.mli
+++ b/lib/definition.mli
@@ -44,7 +44,10 @@ module Clause : sig
 
   val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
-  val lrt : Terms.Normal.t -> Terms.Normal.t LogicalArgumentTypes.t -> LogicalReturnTypes.t
+  val lrt
+    :  Terms.Normal.t ->
+    Terms.Normal.t LogicalArgumentTypes.t ->
+    LogicalReturnTypes.t
 
   val explicit_negative_guards : t list -> t list
 

--- a/lib/definition.mli
+++ b/lib/definition.mli
@@ -1,10 +1,10 @@
 module Function : sig
   type body =
-    | Def of IndexTerms.t
-    | Rec_Def of IndexTerms.t
+    | Def of Terms.Normal.t
+    | Rec_Def of Terms.Normal.t
     | Uninterp
 
-  val subst_body : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> body -> body
+  val subst_body : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> body -> body
 
   type t =
     { loc : Locations.t;
@@ -24,11 +24,11 @@ module Function : sig
 
   val pp : Pp.document -> t -> Pp.document
 
-  val open_ : (Sym.t * 'a) list -> IndexTerms.t -> IndexTerms.t list -> IndexTerms.t
+  val open_ : (Sym.t * 'a) list -> Terms.Normal.t -> Terms.Normal.t list -> Terms.Normal.t
 
-  val unroll_once : t -> IndexTerms.t list -> IndexTerms.t option
+  val unroll_once : t -> Terms.Normal.t list -> Terms.Normal.t option
 
-  val try_open : t -> IndexTerms.t list -> IndexTerms.t option
+  val try_open : t -> Terms.Normal.t list -> Terms.Normal.t option
 
   val is_interesting : t -> bool
 end
@@ -36,15 +36,15 @@ end
 module Clause : sig
   type t =
     { loc : Locations.t;
-      guard : IndexTerms.t;
+      guard : Terms.Normal.t;
       packing_ft : LogicalArgumentTypes.packing_ft
     }
 
   val pp : t -> Pp.document
 
-  val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+  val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
-  val lrt : IndexTerms.t -> IndexTerms.t LogicalArgumentTypes.t -> LogicalReturnTypes.t
+  val lrt : Terms.Normal.t -> Terms.Normal.t LogicalArgumentTypes.t -> LogicalReturnTypes.t
 
   val explicit_negative_guards : t list -> t list
 
@@ -68,13 +68,13 @@ module Predicate : sig
 
   val pp : t -> Pp.document
 
-  val instantiate : t -> IndexTerms.t -> IndexTerms.t list -> Clause.t list option
+  val instantiate : t -> Terms.Normal.t -> Terms.Normal.t list -> Clause.t list option
 
   val identify_right_clause
     :  (LogicalConstraints.t -> [< `False | `True ]) ->
     t ->
-    IndexTerms.t ->
-    IndexTerms.t list ->
+    Terms.Normal.t ->
+    Terms.Normal.t list ->
     Clause.t option
 
   val given_to_solver : t -> bool

--- a/lib/diagnostics.ml
+++ b/lib/diagnostics.ml
@@ -5,7 +5,7 @@ module IT = IndexTerms
 open Effectful.Make (Typing)
 
 module BT = BaseTypes
-module ITSet = Set.Make (IT)
+module ITSet = Set.Make (Terms.Normal)
 
 type cfg =
   { model : Solver.model_with_q;

--- a/lib/eqTable.ml
+++ b/lib/eqTable.ml
@@ -47,7 +47,9 @@ let add_one_eq (tab : table) (it : T.t) =
   match T.get_term it with
   | Terms.Binop (Terms.EQ, x, y) -> add_eq_sym (None, x, y) tab
   | Binop (Implies, guard, x) ->
-    (match Terms.is_eq x with Some (y, z) -> add_eq_sym (Some guard, y, z) tab | _ -> tab)
+    (match Terms.is_eq x with
+     | Some (y, z) -> add_eq_sym (Some guard, y, z) tab
+     | _ -> tab)
   | _ -> tab
 
 

--- a/lib/eqTable.ml
+++ b/lib/eqTable.ml
@@ -1,12 +1,12 @@
-module IT = IndexTerms
-module ITMap = Map.Make (IT)
-module ITSet = Set.Make (IT)
+module T = Terms.Normal
+module ITMap = Map.Make (T)
+module ITSet = Set.Make (T)
 
 (* operations on a table of (possibly guarded) equalities *)
 
 type eq_info =
-  { guard : IT.t option;
-    rhs : IT.t
+  { guard : T.t option;
+    rhs : T.t
   }
 
 type table = eq_info list ITMap.t
@@ -22,13 +22,13 @@ let fetch_eqs (tab : table) lhs =
 let guard_implies guard1 guard2 =
   match (guard1, guard2) with
   | _, None -> true
-  | Some x, Some y -> IT.equal x y
+  | Some x, Some y -> T.equal x y
   | _ -> false
 
 
 let eq_is_known tab (guard, lhs, rhs) =
   List.exists
-    (fun info -> IT.equal rhs info.rhs && guard_implies guard info.guard)
+    (fun info -> T.equal rhs info.rhs && guard_implies guard info.guard)
     (fetch_eqs tab lhs)
 
 
@@ -43,16 +43,16 @@ let add_eq_sym (guard, lhs, rhs) tab =
   add_eq (guard, lhs, rhs) (add_eq (guard, rhs, lhs) tab)
 
 
-let add_one_eq (tab : table) (it : IT.t) =
-  match IT.get_term it with
-  | IT.Binop (IT.EQ, x, y) -> add_eq_sym (None, x, y) tab
+let add_one_eq (tab : table) (it : T.t) =
+  match T.get_term it with
+  | Terms.Binop (Terms.EQ, x, y) -> add_eq_sym (None, x, y) tab
   | Binop (Implies, guard, x) ->
-    (match IT.is_eq x with Some (y, z) -> add_eq_sym (Some guard, y, z) tab | _ -> tab)
+    (match Terms.is_eq x with Some (y, z) -> add_eq_sym (Some guard, y, z) tab | _ -> tab)
   | _ -> tab
 
 
-let add_eqs tab (it : IT.t) =
-  match IT.is_and it with
+let add_eqs tab (it : T.t) =
+  match Terms.is_and it with
   | Some (it1, it2) -> List.fold_left add_one_eq tab [ it1; it2 ]
   | _ -> add_one_eq tab it
 
@@ -71,7 +71,7 @@ let fetch_implied_eqs tab guard lhs =
 
 
 (* computing the closure of the above *)
-let get_eq_vals (tab : table) (guard : IT.t option) (x : IT.t) =
+let get_eq_vals (tab : table) (guard : T.t option) (x : T.t) =
   let rec seek known = function
     | [] -> known
     | x :: xs ->

--- a/lib/explain.ml
+++ b/lib/explain.ml
@@ -1,6 +1,6 @@
 module Rp = Report
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Def = Definition
 module Req = Request
 module Res = Resource
@@ -14,18 +14,18 @@ open Pp
 
 (* perhaps somehow unify with above *)
 type action =
-  | Read of IndexTerms.t * IndexTerms.t
-  | Write of IndexTerms.t * IndexTerms.t
-  | Create of IndexTerms.t
-  | Kill of IndexTerms.t
+  | Read of Terms.Normal.t * Terms.Normal.t
+  | Write of Terms.Normal.t * Terms.Normal.t
+  | Create of Terms.Normal.t
+  | Kill of Terms.Normal.t
   | Call of
       { fsym : Sym.t;
-        args : IndexTerms.t list;
-        gargs : IndexTerms.t list
+        args : Terms.Normal.t list;
+        gargs : Terms.Normal.t list
       }
   | Return of
-      { arg : IndexTerms.t;
-        gargs : IndexTerms.t list
+      { arg : Terms.Normal.t;
+        gargs : Terms.Normal.t list
       }
 
 type log_entry =
@@ -75,13 +75,13 @@ module ITSet = struct
 end
 
 let subterms_without_bound_variables bindings =
-  IT.fold_subterms
+  T.fold_subterms
     ~bindings
     (fun bindings acc t ->
        let pats = List.map fst bindings in
-       let bound = List.concat_map IT.bound_by_pattern pats in
+       let bound = List.concat_map T.bound_by_pattern pats in
        let bound = Sym.Set.of_list (List.map fst bound) in
-       if Sym.Set.(is_empty (inter bound (IT.free_vars t))) then
+       if Sym.Set.(is_empty (inter bound (T.free_vars t))) then
          ITSet.add t acc
        else
          acc)
@@ -91,12 +91,12 @@ let subterms_without_bound_variables bindings =
 (** Simplify a constraint in the context of a model. *)
 let simp_constraint eval lct =
   let eval_to_bool it =
-    match eval it with Some (IT.IT (Const (Bool b1), _, _)) -> Some b1 | _ -> None
+    match eval it with Some (Terms.IT (Const (Bool b1), _, _)) -> Some b1 | _ -> None
   in
   let is b it = match eval_to_bool it with Some b1 -> Bool.equal b b1 | _ -> false in
-  let rec go (IT.IT (term, bt, loc)) =
-    let mk x = IT.IT (x, bt, loc) in
-    let ands xs = IT.and_ xs loc in
+  let rec go (Terms.IT (term, bt, loc)) =
+    let mk x = Terms.IT (x, bt, loc) in
+    let ands xs = IndexTerms.and_ xs loc in
     let go1 t = ands (go t) in
     match term with
     | Const (Bool true) -> []
@@ -123,7 +123,7 @@ let rec simp_resource eval r =
     let is_true =
       match ct with
       | LC.T ct ->
-        (match eval ct with Some (IT.IT (Const (Bool b), _, _)) -> b | _ -> false)
+        (match eval ct with Some (Terms.IT (Const (Bool b), _, _)) -> b | _ -> false)
       | _ -> false
     in
     if is_true then
@@ -165,7 +165,7 @@ let state (ctxt : C.t) log model_with_q extras =
   let evaluate it = Solver.eval model it in
   (* let _mevaluate it = *)
   (*   match evaluate it with *)
-  (*   | Some v -> IT.pp v *)
+  (*   | Some v -> T.pp v *)
   (*   | None -> parens !^"not evaluated" *)
   (* in *)
   let render_constraints c =
@@ -229,7 +229,7 @@ let state (ctxt : C.t) log model_with_q extras =
   in
   let terms, vals =
     let variables =
-      let make s ls = IT.sym_ (s, ls, Locations.other __LOC__) in
+      let make s ls = IndexTerms.sym_ (s, ls, Locations.other __LOC__) in
       let basetype_binding (s, (binding, _)) =
         match binding with C.Value _ -> None | BaseType ls -> Some (make s ls)
       in
@@ -242,7 +242,7 @@ let state (ctxt : C.t) log model_with_q extras =
       match extras.unproven_constraint with
       | Some (T lc) -> subterms_without_bound_variables [] lc
       | Some (Forall ((s, bt), lc)) ->
-        let binder = IT.(Pat (PSym s, bt, Loc.other __LOC__), None) in
+        let binder = Terms.(Pat (PSym s, bt, Loc.other __LOC__), None) in
         subterms_without_bound_variables [ binder ] lc
       | None -> ITSet.empty
     in
@@ -251,7 +251,7 @@ let state (ctxt : C.t) log model_with_q extras =
       | Some (P ret) ->
         ITSet.bigunion_map (subterms_without_bound_variables []) (ret.pointer :: ret.iargs)
       | Some (Q ret) ->
-        let binder = IT.(Pat (PSym (fst ret.q), snd ret.q, Loc.other __LOC__), None) in
+        let binder = Terms.(Pat (PSym (fst ret.q), snd ret.q, Loc.other __LOC__), None) in
         ITSet.union
           (ITSet.bigunion_map (subterms_without_bound_variables []) [ ret.pointer ])
           (ITSet.bigunion_map
@@ -266,20 +266,20 @@ let state (ctxt : C.t) log model_with_q extras =
       List.filter_map
         (fun it ->
            match evaluate it with
-           | Some value when not (IT.equal value it) -> Some (it, value)
+           | Some value when not (T.equal value it) -> Some (it, value)
            | Some _ -> None
            | None -> None)
         (ITSet.elements subterms)
     in
     let pretty_printed =
       List.map
-        (fun (it, value) -> (it, Rp.{ term = IT.pp it; value = IT.pp value }))
+        (fun (it, value) -> (it, Rp.{ term = T.pp it; value = T.pp value }))
         filtered
     in
     let interesting, uninteresting =
       List.partition
         (fun (it, _entry) ->
-           match IT.get_bt it with BT.Unit -> false | BT.Loc () -> false | _ -> true)
+           match T.get_bt it with BT.Unit -> false | BT.Loc () -> false | _ -> true)
         pretty_printed
     in
     ( Rp.add_labeled
@@ -347,11 +347,11 @@ let state (ctxt : C.t) log model_with_q extras =
            | Some def, Some cand ->
              let here = Locations.other __LOC__ in
              let ptr_val = Req.get_pointer rt in
-             let ptr_def = (IT.sym_ (def.pointer, IT.get_bt ptr_val, here), ptr_val) in
+             let ptr_def = (IndexTerms.sym_ (def.pointer, T.get_bt ptr_val, here), ptr_val) in
              Some (CP.check_pred s def cand ctxt iargs (ptr_def :: vals), rt, it)
            | Some _, None ->
              Some
-               ( CP.Result.error (!^"Could not locate definition of variable" ^^^ IT.pp it),
+               ( CP.Result.error (!^"Could not locate definition of variable" ^^^ T.pp it),
                  rt,
                  it )
            | None, _ ->
@@ -367,7 +367,7 @@ let state (ctxt : C.t) log model_with_q extras =
       (* Issue #900 *)
       let pp_checked_res (p, req, cand) =
         let _ = p in
-        let rslt = Req.pp req ^^^ !^"(" ^^^ IT.pp cand ^^^ !^")" in
+        let rslt = Req.pp req ^^^ !^"(" ^^^ T.pp cand ^^^ !^")" in
         Rp.
           { original = rslt;
             (* !^"Full predicate check output: "
@@ -420,7 +420,7 @@ let trace (ctxt, log) (model_with_q : Solver.model_with_q) (extras : state_extra
        | PName pname ->
          let doc_clause (_name, (c : Def.Clause.t)) =
            Rp.
-             { cond = IT.pp c.guard; clause = LogicalArgumentTypes.pp IT.pp c.packing_ft }
+             { cond = T.pp c.guard; clause = LogicalArgumentTypes.pp T.pp c.packing_ft }
          in
          List.map doc_clause (relevant_predicate_clauses ctxt.global pname req))
   in

--- a/lib/explain.ml
+++ b/lib/explain.ml
@@ -347,7 +347,9 @@ let state (ctxt : C.t) log model_with_q extras =
            | Some def, Some cand ->
              let here = Locations.other __LOC__ in
              let ptr_val = Req.get_pointer rt in
-             let ptr_def = (IndexTerms.sym_ (def.pointer, T.get_bt ptr_val, here), ptr_val) in
+             let ptr_def =
+               (IndexTerms.sym_ (def.pointer, T.get_bt ptr_val, here), ptr_val)
+             in
              Some (CP.check_pred s def cand ctxt iargs (ptr_def :: vals), rt, it)
            | Some _, None ->
              Some
@@ -419,8 +421,7 @@ let trace (ctxt, log) (model_with_q : Solver.model_with_q) (extras : state_extra
        | Owned _ -> []
        | PName pname ->
          let doc_clause (_name, (c : Def.Clause.t)) =
-           Rp.
-             { cond = T.pp c.guard; clause = LogicalArgumentTypes.pp T.pp c.packing_ft }
+           Rp.{ cond = T.pp c.guard; clause = LogicalArgumentTypes.pp T.pp c.packing_ft }
          in
          List.map doc_clause (relevant_predicate_clauses ctxt.global pname req))
   in

--- a/lib/explain.mli
+++ b/lib/explain.mli
@@ -1,17 +1,17 @@
 (** Manipulate a resource *)
 type action =
-  | Read of IndexTerms.t * IndexTerms.t
-  | Write of IndexTerms.t * IndexTerms.t
-  | Create of IndexTerms.t
-  | Kill of IndexTerms.t
+  | Read of Terms.Normal.t * Terms.Normal.t
+  | Write of Terms.Normal.t * Terms.Normal.t
+  | Create of Terms.Normal.t
+  | Kill of Terms.Normal.t
   | Call of
       { fsym : Sym.t;
-        args : IndexTerms.t list;
-        gargs : IndexTerms.t list
+        args : Terms.Normal.t list;
+        gargs : Terms.Normal.t list
       }
   | Return of
-      { arg : IndexTerms.t;
-        gargs : IndexTerms.t list
+      { arg : Terms.Normal.t;
+        gargs : Terms.Normal.t list
       }
 
 (** Info about what happened *)

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -7,11 +7,14 @@ module C = CF.Ctype
 module BT = BaseTypes
 module IT = IndexTerms
 module T = Terms
+module TN = Terms.Normal
 module LRT = LogicalReturnTypes
 module RT = ReturnTypes
 module LAT = LogicalArgumentTypes
 module AT = ArgumentTypes
 module OE = Ownership
+
+open Terms
 
 let getter_str filename sym =
   "cn_test_get_" ^ Utils.static_prefix filename ^ "_" ^ Sym.pp_string sym
@@ -305,7 +308,7 @@ let bt_to_ail_ctype ?(pred_sym = None) t =
 let cn_to_ail_unop bt =
   let bt_typedef_str_opt = get_typedef_string (bt_to_ail_ctype bt) in
   function
-  | IT.Not -> Some "cn_bool_not"
+  | Terms.Not -> Some "cn_bool_not"
   | Negate ->
     (match bt_typedef_str_opt with
      | Some typedef_str -> Some (typedef_str ^ "_negate")
@@ -350,7 +353,7 @@ let cn_to_ail_binop bt1 bt2 =
         (__LOC__ ^ ": Incompatible CN integer types: " ^ bt1_str ^ " with " ^ bt2_str)
   in
   function
-  | IT.And -> Some "cn_bool_and"
+  | Terms.And -> Some "cn_bool_and"
   | Or -> Some "cn_bool_or"
   | Add ->
     let bt2_str =
@@ -616,7 +619,7 @@ let cn_to_ail_const const basetype =
   let wrap x = wrap_with_convert_to x basetype in
   let ail_const =
     match const with
-    | IT.Z z -> wrap (A.AilEconst (ConstantInteger (IConstant (z, Decimal, None))))
+    | Terms.Z z -> wrap (A.AilEconst (ConstantInteger (IConstant (z, Decimal, None))))
     | MemByte { alloc_id = _; value = i } ->
       wrap (A.AilEconst (ConstantInteger (IConstant (i, Decimal, None))))
     | Bits ((sgn, sz), i) ->
@@ -896,7 +899,7 @@ let rec cn_to_ail_expr_aux
     _ CF.Cn.cn_datatype list ->
     (C.union_tag * C.ctype) list ->
     spec_mode option ->
-    IT.t ->
+    TN.t ->
     a dest ->
     a
   =
@@ -969,7 +972,7 @@ let rec cn_to_ail_expr_aux
         t2
         PassBack
     in
-    let annot = cn_to_ail_binop (IT.get_bt t1) (IT.get_bt t2) bop in
+    let annot = cn_to_ail_binop (TN.get_bt t1) (TN.get_bt t2) bop in
     let str =
       match annot with
       | Some str -> str
@@ -980,7 +983,7 @@ let rec cn_to_ail_expr_aux
     in
     let ail_expr_ =
       match bop with
-      | EQ -> get_equality_fn_call (IT.get_bt t1) e1 e2
+      | EQ -> get_equality_fn_call (TN.get_bt t1) e1 e2
       | _ -> default_ail_binop
     in
     dest d spec_mode_opt (b1 @ b2, s1 @ s2, mk_expr ail_expr_)
@@ -996,7 +999,7 @@ let rec cn_to_ail_expr_aux
         t
         PassBack
     in
-    let annot = cn_to_ail_unop (IT.get_bt t) unop in
+    let annot = cn_to_ail_unop (TN.get_bt t) unop in
     let str =
       match annot with
       | Some str -> str
@@ -1016,7 +1019,7 @@ let rec cn_to_ail_expr_aux
   | ITE (t1, t2, t3) ->
     let result_sym = Sym.fresh_anon () in
     let result_ident = A.(AilEident result_sym) in
-    let result_binding = create_binding result_sym (bt_to_ail_ctype (IT.get_bt t2)) in
+    let result_binding = create_binding result_sym (bt_to_ail_ctype (TN.get_bt t2)) in
     let result_decl = A.(AilSdeclaration [ (result_sym, None) ]) in
     let b1, s1, e1 =
       cn_to_ail_expr_aux
@@ -1087,12 +1090,12 @@ let rec cn_to_ail_expr_aux
     
     assign/return/assert/passback b
     *)
-    let mk_int_const n = IT.(IT (Const (Z (Z.of_int n)), bt', Cerb_location.unknown)) in
+    let mk_int_const n = (IT (Const (Z (Z.of_int n)), bt', Cerb_location.unknown)) in
     let start_const_it = mk_int_const r_start in
     let end_const_it = mk_int_const r_end in
     let end_sym = Sym.fresh_anon () in
     let end_it = IT.sym_ (end_sym, bt', Cerb_location.unknown) in
-    let incr_var = IT.(IT (Sym sym, bt', Cerb_location.unknown)) in
+    let incr_var = (IT (Sym sym, bt', Cerb_location.unknown)) in
     let _, _, start_int_const =
       cn_to_ail_expr_aux
         filename
@@ -1116,7 +1119,7 @@ let rec cn_to_ail_expr_aux
         PassBack
     in
     let while_cond_it =
-      IT.(IT (Binop (LT, incr_var, end_it), bt', Cerb_location.unknown))
+      (IT (Binop (LT, incr_var, end_it), bt', Cerb_location.unknown))
     in
     let _, _, while_cond =
       cn_to_ail_expr_aux
@@ -1213,7 +1216,7 @@ let rec cn_to_ail_expr_aux
     dest d spec_mode_opt (b, s, mk_expr ail_expr_)
   | StructUpdate ((struct_term, m), new_val) ->
     let struct_tag =
-      match IT.get_bt struct_term with
+      match TN.get_bt struct_term with
       | BT.Struct tag -> tag
       | _ -> failwith (__LOC__ ^ ": Cannot do StructUpdate on non-struct term")
     in
@@ -1299,7 +1302,7 @@ let rec cn_to_ail_expr_aux
       let assign_stat = A.(AilSexpr (mk_expr (AilEassign (mk_expr ail_memberof, e)))) in
       (b, s, assign_stat)
     in
-    let transformed_ms = List.map (fun (id, it) -> (id, IT.get_bt it)) ms in
+    let transformed_ms = List.map (fun (id, it) -> (id, TN.get_bt it)) ms in
     let sym_name = lookup_records_map_with_default (BT.Record transformed_ms) in
     let ctype_ = C.(Pointer (C.no_qualifiers, mk_ctype (Struct sym_name))) in
     let res_binding = create_binding res_sym (mk_ctype ctype_) in
@@ -1503,10 +1506,10 @@ let rec cn_to_ail_expr_aux
         PassBack
     in
     let key_term =
-      if IT.get_bt key == BT.Integer then
+      if TN.get_bt key == BT.Integer then
         key
       else
-        IT.IT (Cast (BT.Integer, key), BT.Integer, Cerb_location.unknown)
+        IT (Cast (BT.Integer, key), BT.Integer, Cerb_location.unknown)
     in
     let b2, s2, e2 =
       cn_to_ail_expr_aux
@@ -1531,7 +1534,7 @@ let rec cn_to_ail_expr_aux
         PassBack
     in
     let new_map_sym = Sym.fresh_anon () in
-    let new_map_binding = create_binding new_map_sym (bt_to_ail_ctype (IT.get_bt m)) in
+    let new_map_binding = create_binding new_map_sym (bt_to_ail_ctype (TN.get_bt m)) in
     let map_deep_copy_fcall =
       A.(AilEcall (mk_expr (AilEident (Sym.fresh "cn_map_deep_copy")), [ e1 ]))
     in
@@ -1564,10 +1567,10 @@ let rec cn_to_ail_expr_aux
         PassBack
     in
     let key_term =
-      if IT.get_bt key == BT.Integer then
+      if TN.get_bt key == BT.Integer then
         key
       else
-        IT.IT (Cast (BT.Integer, key), BT.Integer, Cerb_location.unknown)
+        IT (Cast (BT.Integer, key), BT.Integer, Cerb_location.unknown)
     in
     let b2, s2, e2 =
       cn_to_ail_expr_aux
@@ -1581,7 +1584,7 @@ let rec cn_to_ail_expr_aux
         PassBack
     in
     let is_record =
-      match BT.map_bt (IT.get_bt m) with _, Record _ -> true | _ -> false
+      match BT.map_bt (TN.get_bt m) with _, Record _ -> true | _ -> false
     in
     let cntype_str_opt = get_underscored_typedef_string_from_bt ~is_record basetype in
     let map_get_str =
@@ -1592,7 +1595,7 @@ let rec cn_to_ail_expr_aux
     let map_get_fcall =
       A.(AilEcall (mk_expr (AilEident (Sym.fresh map_get_str)), [ e1; e2 ]))
     in
-    let _, val_bt = BT.map_bt (IT.get_bt m) in
+    let _, val_bt = BT.map_bt (TN.get_bt m) in
     let ctype = bt_to_ail_ctype val_bt in
     let cast_expr_ = A.(AilEcast (C.no_qualifiers, ctype, mk_expr map_get_fcall)) in
     dest d spec_mode_opt (b1 @ b2, s1 @ s2, mk_expr cast_expr_)
@@ -1628,7 +1631,7 @@ let rec cn_to_ail_expr_aux
         t1
         PassBack
     in
-    let ctype = bt_to_ail_ctype (IT.get_bt t1) in
+    let ctype = bt_to_ail_ctype (TN.get_bt t1) in
     let binding = create_binding var ctype in
     let ail_assign = A.(AilSdeclaration [ (var, Some e1) ]) in
     prefix
@@ -1642,7 +1645,7 @@ let rec cn_to_ail_expr_aux
       match ps with
       | T.(Pat (PSym sym', p_bt, pt_loc)) :: ps' ->
         ( mk_pattern T.PWild p_bt pt_loc :: ps',
-          T.(IT (Let ((sym', t1), t2), IT.get_bt t2, pt_loc)) )
+          T.(IT (Let ((sym', t1), t2), TN.get_bt t2, pt_loc)) )
       | p :: ps' -> (p :: ps', t2)
       | [] -> assert false
     in
@@ -1669,8 +1672,8 @@ let rec cn_to_ail_expr_aux
     (* Matrix algorithm for pattern compilation *)
     let rec translate
       : int ->
-      IT.t list ->
-      (BT.t IT.pattern list * IT.t) list ->
+      TN.t list ->
+      (BT.t pattern list * TN.t) list ->
       Sym.t option ->
       A.bindings * _ A.statement_ list
       =
@@ -1729,7 +1732,7 @@ let rec cn_to_ail_expr_aux
           let bindings', stats' = translate count vs cases res_sym_opt in
           (bindings', stats'))
         else (
-          match IT.get_bt term with
+          match TN.get_bt term with
           | BT.Datatype sym ->
             let cn_dt = List.filter (fun dt -> Sym.equal sym dt.cn_dt_name) dts in
             (match cn_dt with
@@ -1771,7 +1774,7 @@ let rec cn_to_ail_expr_aux
                  let ids, ts = List.split (List.rev members_with_types) in
                  let bts = List.map cn_base_type_to_bt ts in
                  let new_constr_it =
-                   IT.IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown)
+                   IT (Sym count_sym, BT.Struct lc_sym, Cerb_location.unknown)
                  in
                  let vars' =
                    List.map (fun id -> T.StructMember (new_constr_it, id)) ids
@@ -1830,7 +1833,7 @@ let rec cn_to_ail_expr_aux
                (b1, s1 @ [ switch ]))
           | _ ->
             (* Cannot have non-variable, non-wildcard pattern besides struct *)
-            let bt_string_opt = get_typedef_string (bt_to_ail_ctype (IT.get_bt term)) in
+            let bt_string_opt = get_typedef_string (bt_to_ail_ctype (TN.get_bt term)) in
             let bt_string =
               match bt_string_opt with
               | Some str -> str
@@ -1840,7 +1843,7 @@ let rec cn_to_ail_expr_aux
             failwith (__LOC__ ^ err_msg))
     in
     let translate_real
-      : type a. IT.t list -> (BT.t IT.pattern list * IT.t) list -> a dest -> a
+      : type a. TN.t list -> (BT.t pattern list * TN.t) list -> a dest -> a
       =
       fun vars cases d ->
       match d with
@@ -1883,7 +1886,7 @@ let rec cn_to_ail_expr_aux
         let ail_expr_ =
           match
             ( get_typedef_string (bt_to_ail_ctype bt),
-              get_typedef_string (bt_to_ail_ctype (IT.get_bt t)) )
+              get_typedef_string (bt_to_ail_ctype (TN.get_bt t)) )
           with
           | Some cast_type_str, Some original_type_str ->
             let fn_name = "cast_" ^ original_type_str ^ "_to_" ^ cast_type_str in
@@ -1905,7 +1908,7 @@ let cn_to_ail_expr
     _ CF.Cn.cn_datatype list ->
     (C.union_tag * C.ctype) list ->
     spec_mode option ->
-    IT.t ->
+    TN.t ->
     a dest ->
     a
   =
@@ -1919,7 +1922,7 @@ let cn_to_ail_expr_toplevel
       (globals : (C.union_tag * C.ctype) list)
       (pred_sym_opt : Sym.t option)
       (spec_mode_opt : spec_mode option)
-      (it : IT.t)
+      (it : TN.t)
   : A.bindings
     * CF.GenTypes.genTypeCategory A.statement_ list
     * CF.GenTypes.genTypeCategory A.expression
@@ -1934,7 +1937,7 @@ let cn_to_ail_expr_with_pred_name
     _ CF.Cn.cn_datatype list ->
     (C.union_tag * C.ctype) list ->
     spec_mode option ->
-    IT.t ->
+    TN.t ->
     a dest ->
     a
   =
@@ -2147,27 +2150,27 @@ let generate_datatype_equality_function (filename : string) (cn_datatype : _ cn_
           Ne,
           mk_expr (AilEmemberofptr (mk_expr (AilEident param2_sym), id_tag)) ))
   in
-  let false_it = IT.(IT (Const (Z (Z.of_int 0)), BT.Bool, Cerb_location.unknown)) in
+  let false_it = (IT (Const (Z (Z.of_int 0)), BT.Bool, Cerb_location.unknown)) in
   (* Adds conversion function *)
   let _, _, e1 = cn_to_ail_expr filename [] [] None false_it PassBack in
   let return_false = A.(AilSreturn e1) in
   let rec generate_equality_expr members sym1 sym2 =
     match members with
-    | [] -> IT.(IT (Const (Z (Z.of_int 1)), BT.Bool, Cerb_location.unknown))
+    | [] -> (IT (Const (Z (Z.of_int 1)), BT.Bool, Cerb_location.unknown))
     | (id, cn_bt) :: ms ->
-      let sym1_it = IT.(IT (Sym sym1, BT.(Loc ()), Cerb_location.unknown)) in
-      let sym2_it = IT.(IT (Sym sym2, BT.(Loc ()), Cerb_location.unknown)) in
+      let sym1_it = (IT (Sym sym1, BT.(Loc ()), Cerb_location.unknown)) in
+      let sym2_it = (IT (Sym sym2, BT.(Loc ()), Cerb_location.unknown)) in
       let lhs =
-        IT.(
+        (
           IT (StructMember (sym1_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown))
       in
       let rhs =
-        IT.(
+        (
           IT (StructMember (sym2_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown))
       in
-      let eq_it = IT.(IT (Binop (EQ, lhs, rhs), BT.Bool, Cerb_location.unknown)) in
+      let eq_it = (IT (Binop (EQ, lhs, rhs), BT.Bool, Cerb_location.unknown)) in
       let remaining = generate_equality_expr ms sym1 sym2 in
-      IT.(IT (Binop (And, eq_it, remaining), BT.Bool, Cerb_location.unknown))
+      (IT (Binop (And, eq_it, remaining), BT.Bool, Cerb_location.unknown))
   in
   let create_case (constructor, members) =
     let enum_str =
@@ -2912,7 +2915,7 @@ let cn_to_ail_struct ((sym, (loc, attrs, tag_def)) : A.sigma_tag_definition)
 
 let get_while_bounds_and_cond (i_sym, i_bt) it =
   (* Translation of q.pointer *)
-  let i_it = IT.IT (IT.(Sym i_sym), i_bt, Cerb_location.unknown) in
+  let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
   (* Start of range *)
   let lower_bound =
     if BT.equal_sign (fst (Option.get (BT.is_bits_bt i_bt))) BT.Unsigned then
@@ -2928,14 +2931,14 @@ let get_while_bounds_and_cond (i_sym, i_bt) it =
                  plain
                    (Pp.item
                       "Cannot infer lower bound for permission"
-                      (squotes (IT.pp it) ^^^ !^"at" ^^^ Locations.pp (IT.get_loc it)))))
+                      (squotes (TN.pp it) ^^^ !^"at" ^^^ Locations.pp (TN.get_loc it)))))
           ();
         exit 2)
   in
   let start_expr =
-    IT.IT
-      ( IT.Cast (IT.get_bt lower_bound, lower_bound),
-        IT.get_bt lower_bound,
+    IT
+      ( Cast (TN.get_bt lower_bound, lower_bound),
+        TN.get_bt lower_bound,
         Cerb_location.unknown )
   in
   let _start_cond =
@@ -2957,13 +2960,13 @@ let get_while_bounds_and_cond (i_sym, i_bt) it =
                plain
                  (Pp.item
                     "Cannot infer upper bound for permission"
-                    (squotes (IT.pp it) ^^^ !^"at" ^^^ Locations.pp (IT.get_loc it)))))
+                    (squotes (TN.pp it) ^^^ !^"at" ^^^ Locations.pp (TN.get_loc it)))))
         ();
       exit 2
   in
   (* end_sym will be set to end_expr' at call site after this function *)
   let end_sym = Sym.fresh_anon () in
-  let end_it = IT.sym_ (end_sym, IT.get_bt upper_bound, Cerb_location.unknown) in
+  let end_it = IT.sym_ (end_sym, TN.get_bt upper_bound, Cerb_location.unknown) in
   let end_expr, end_cond =
     match upper_bound with
     | IT (Binop (Sub, end_expr', IT (Const (Bits (_, n)), _, _)), _, _)
@@ -2974,7 +2977,7 @@ let get_while_bounds_and_cond (i_sym, i_bt) it =
       let one_const =
         match BT.is_bits_bt i_bt with
         | Some (sign, n) ->
-          IT.(
+          (
             IT
               ( Const (Bits ((sign, n), Z.of_int 1)),
                 BT.(Bits (sign, n)),
@@ -3053,7 +3056,7 @@ let cn_to_ail_resource
     fn_prefix ^ ct_str
   in
   let enum_sym = sym_of_spec_mode_opt spec_mode_opt in
-  let it_zero_const = IT.(IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown)) in
+  let it_zero_const = (IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown)) in
   let ail_zero_const_expr_ =
     A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None))))
   in
@@ -3067,15 +3070,15 @@ let cn_to_ail_resource
         ownership_ctypes := Sctypes.to_ctype sct :: !ownership_ctypes;
         let owned_fn_name = generate_owned_fn_name ~without_ownership_checking sct in
         (* Hack with enum as sym *)
-        let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let enum_val_get = (IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
         let loop_ownership_arg =
           match loop_ownership_sym_opt with
           | Some loop_ownership_sym ->
-            IT.(IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+            (IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
           | None -> it_zero_const
         in
         let fn_call_it =
-          IT.IT
+          IT
             ( Apply
                 (Sym.fresh owned_fn_name, [ p.pointer; enum_val_get; loop_ownership_arg ]),
               BT.of_sct Memory.is_signed_integer_type Memory.size_of_integer_type sct,
@@ -3171,7 +3174,7 @@ let cn_to_ail_resource
     let end_assign = A.(AilSdeclaration [ (end_sym, Some e_end) ]) in
     let return_ctype, _return_bt = calculate_resource_return_type preds loc q.name in
     (* Translation of q.pointer *)
-    let i_it = IT.IT (IT.(Sym i_sym), i_bt, Cerb_location.unknown) in
+    let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
     let value_it =
       IT.arrayShift_ ~base:q.pointer ~index:i_it q.step Cerb_location.unknown
     in
@@ -3195,17 +3198,17 @@ let cn_to_ail_resource
         let owned_or_deref_fn_name =
           generate_owned_fn_name ~without_ownership_checking:permission_only_bounds sct
         in
-        let ptr_add_it = IT.(IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
+        let ptr_add_it = (IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
         (* Hack with enum as sym *)
-        let enum_val_get = IT.(IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let enum_val_get = (IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
         let loop_ownership_arg =
           match loop_ownership_sym_opt with
           | Some loop_ownership_sym ->
-            IT.(IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+            (IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
           | None -> it_zero_const
         in
         let fn_call_it =
-          IT.IT
+          IT
             ( Apply
                 ( Sym.fresh owned_or_deref_fn_name,
                   [ ptr_add_it; enum_val_get; loop_ownership_arg ] ),
@@ -3453,11 +3456,11 @@ let cn_to_ail_logical_constraint_aux
   | LogicalConstraints.T it -> cn_to_ail_expr filename dts globals spec_mode_opt it d
   | LogicalConstraints.Forall ((sym, bt), it) ->
     let cond_it, t =
-      match IT.get_term it with
+      match TN.get_term it with
       | Binop (Implies, it, it') -> (it, it')
       | _ -> failwith "Incorrect form of forall logical constraint term"
     in
-    (match IT.get_term t with
+    (match TN.get_term t with
      | Good _ -> dest d spec_mode_opt ([], [], cn_bool_true_expr)
      | _ ->
        (* Assume cond_it is of a particular form *)
@@ -3724,7 +3727,7 @@ let rec cn_to_ail_lat
           without_ownership_checking
   = function
   | LAT.Define ((name, it), _info, lat) ->
-    let ctype = bt_to_ail_ctype (IT.get_bt it) in
+    let ctype = bt_to_ail_ctype (TN.get_bt it) in
     let binding = create_binding name ctype in
     let decl = A.(AilSdeclaration [ (name, None) ]) in
     let b1, s1 =
@@ -3752,7 +3755,7 @@ let rec cn_to_ail_lat
   | LAT.Resource ((name, (ret, _bt)), (loc, _str_opt), lat) ->
     let upd_s = generate_error_msg_info_update_stats ~cn_source_loc_opt:(Some loc) () in
     let pop_s = generate_cn_pop_msg_info in
-    let free_vars_in_rest = LAT.free_vars IT.free_vars lat in
+    let free_vars_in_rest = LAT.free_vars TN.free_vars lat in
     let is_used = Sym.Set.mem name free_vars_in_rest in
     let b1, s1 =
       cn_to_ail_resource
@@ -3956,9 +3959,9 @@ let rec cn_to_ail_post_aux
   | LRT.Define ((name, it), (_loc, _), t) ->
     let new_name = generate_sym_with_suffix ~suffix:"_cn" name in
     let new_lrt =
-      LogicalReturnTypes.subst (ESE.sym_subst (name, IT.get_bt it, new_name)) t
+      LogicalReturnTypes.subst (ESE.sym_subst (name, TN.get_bt it, new_name)) t
     in
-    let binding = create_binding new_name (bt_to_ail_ctype (IT.get_bt it)) in
+    let binding = create_binding new_name (bt_to_ail_ctype (TN.get_bt it)) in
     let decl = A.(AilSdeclaration [ (new_name, None) ]) in
     let b1, s1 =
       cn_to_ail_expr filename dts globals spec_mode_opt it (AssignVar new_name)
@@ -4076,7 +4079,7 @@ let cn_to_ail_cnstatement
           dts
           globals
           spec_mode_opt
-          (IT.IT (Apply (fsym, args), BT.Unit, Locations.other __LOC__))
+          (IT (Apply (fsym, args), BT.Unit, Locations.other __LOC__))
           d,
         false ) (* fsym is a lemma symbol *)
   | Assert lc ->
@@ -4321,7 +4324,7 @@ let rec cn_to_ail_lat_internal_loop
           spec_mode_opt
   = function
   | LAT.Define ((name, it), _info, lat) ->
-    let ctype = bt_to_ail_ctype (IT.get_bt it) in
+    let ctype = bt_to_ail_ctype (TN.get_bt it) in
     let binding = create_binding name ctype in
     let decl = A.(AilSdeclaration [ (name, None) ]) in
     let b1, s1 = cn_to_ail_expr filename dts globals spec_mode_opt it (AssignVar name) in
@@ -4644,10 +4647,10 @@ let rec cn_to_ail_lat_2
   = function
   | LAT.Define ((name, it), _info, lat) ->
     let spec_mode_opt = Some Pre in
-    let ctype = bt_to_ail_ctype (IT.get_bt it) in
+    let ctype = bt_to_ail_ctype (TN.get_bt it) in
     let new_name = generate_sym_with_suffix ~suffix:"_cn" name in
     let new_lat =
-      ESE.fn_largs_and_body_subst (ESE.sym_subst (name, IT.get_bt it, new_name)) lat
+      ESE.fn_largs_and_body_subst (ESE.sym_subst (name, TN.get_bt it, new_name)) lat
     in
     let binding = create_binding new_name ctype in
     let decl = A.(AilSdeclaration [ (new_name, None) ]) in
@@ -5300,7 +5303,7 @@ let cn_to_ail_assume_resource
         in
         (* Hack with enum as sym *)
         let fn_call_it =
-          IT.IT
+          IT
             ( Apply
                 ( Sym.fresh owned_fn_name,
                   [ p.pointer;
@@ -5395,7 +5398,7 @@ let cn_to_ail_assume_resource
     let end_assign = A.(AilSdeclaration [ (end_sym, Some e_end) ]) in
     let return_ctype, _return_bt = calculate_return_type q.name in
     (* Translation of q.pointer *)
-    let i_it = IT.IT (IT.(Sym i_sym), i_bt, Cerb_location.unknown) in
+    let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
     let value_it =
       IT.arrayShift_ ~base:q.pointer ~index:i_it q.step Cerb_location.unknown
     in
@@ -5413,10 +5416,10 @@ let cn_to_ail_assume_resource
         let owned_fn_name =
           "assume_" ^ generate_owned_fn_name ~without_ownership_checking sct
         in
-        let ptr_add_it = IT.(IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
+        let ptr_add_it = (IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
         (* Hack with enum as sym *)
         let fn_call_it =
-          IT.IT
+          IT
             ( Apply
                 ( Sym.fresh owned_fn_name,
                   [ ptr_add_it;
@@ -5563,7 +5566,7 @@ let rec cn_to_ail_assume_lat
           without_ownership_checking
   = function
   | LAT.Define ((name, it), _info, lat) ->
-    let ctype = bt_to_ail_ctype (IT.get_bt it) in
+    let ctype = bt_to_ail_ctype (TN.get_bt it) in
     let binding = create_binding name ctype in
     let decl = A.(AilSdeclaration [ (name, None) ]) in
     let b1, s1 =
@@ -5627,7 +5630,7 @@ let rec cn_to_ail_assume_lat
     in
     (b2, s2)
   | LAT.I it ->
-    if BT.equal (IT.get_bt it) BT.Unit then
+    if BT.equal (TN.get_bt it) BT.Unit then
       ([], [ A.AilSreturnVoid ])
     else (
       let bs, ss =
@@ -5764,7 +5767,7 @@ let rec cn_to_ail_assume_lat_2
           without_ownership_checking
   = function
   | LAT.Define ((name, it), _info, lat) ->
-    let ctype = bt_to_ail_ctype (IT.get_bt it) in
+    let ctype = bt_to_ail_ctype (TN.get_bt it) in
     let binding = create_binding name ctype in
     let decl = A.(AilSdeclaration [ (name, None) ]) in
     let b1, s1 =
@@ -5868,7 +5871,7 @@ let cn_to_ail_assume_pre
   let lat =
     LAT.subst
       (fun _ x -> x)
-      (IT.make_subst
+      (TN.make_subst
          (List.map
             (fun (x, y) ->
                (x, IT.sym_ (y, fst (List.assoc Sym.equal x args), Locations.other __LOC__)))

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -13,7 +13,6 @@ module RT = ReturnTypes
 module LAT = LogicalArgumentTypes
 module AT = ArgumentTypes
 module OE = Ownership
-
 open Terms
 
 let getter_str filename sym =
@@ -1090,12 +1089,12 @@ let rec cn_to_ail_expr_aux
     
     assign/return/assert/passback b
     *)
-    let mk_int_const n = (IT (Const (Z (Z.of_int n)), bt', Cerb_location.unknown)) in
+    let mk_int_const n = IT (Const (Z (Z.of_int n)), bt', Cerb_location.unknown) in
     let start_const_it = mk_int_const r_start in
     let end_const_it = mk_int_const r_end in
     let end_sym = Sym.fresh_anon () in
     let end_it = IT.sym_ (end_sym, bt', Cerb_location.unknown) in
-    let incr_var = (IT (Sym sym, bt', Cerb_location.unknown)) in
+    let incr_var = IT (Sym sym, bt', Cerb_location.unknown) in
     let _, _, start_int_const =
       cn_to_ail_expr_aux
         filename
@@ -1118,9 +1117,7 @@ let rec cn_to_ail_expr_aux
         end_const_it
         PassBack
     in
-    let while_cond_it =
-      (IT (Binop (LT, incr_var, end_it), bt', Cerb_location.unknown))
-    in
+    let while_cond_it = IT (Binop (LT, incr_var, end_it), bt', Cerb_location.unknown) in
     let _, _, while_cond =
       cn_to_ail_expr_aux
         filename
@@ -2150,27 +2147,25 @@ let generate_datatype_equality_function (filename : string) (cn_datatype : _ cn_
           Ne,
           mk_expr (AilEmemberofptr (mk_expr (AilEident param2_sym), id_tag)) ))
   in
-  let false_it = (IT (Const (Z (Z.of_int 0)), BT.Bool, Cerb_location.unknown)) in
+  let false_it = IT (Const (Z (Z.of_int 0)), BT.Bool, Cerb_location.unknown) in
   (* Adds conversion function *)
   let _, _, e1 = cn_to_ail_expr filename [] [] None false_it PassBack in
   let return_false = A.(AilSreturn e1) in
   let rec generate_equality_expr members sym1 sym2 =
     match members with
-    | [] -> (IT (Const (Z (Z.of_int 1)), BT.Bool, Cerb_location.unknown))
+    | [] -> IT (Const (Z (Z.of_int 1)), BT.Bool, Cerb_location.unknown)
     | (id, cn_bt) :: ms ->
-      let sym1_it = (IT (Sym sym1, BT.(Loc ()), Cerb_location.unknown)) in
-      let sym2_it = (IT (Sym sym2, BT.(Loc ()), Cerb_location.unknown)) in
+      let sym1_it = IT (Sym sym1, BT.(Loc ()), Cerb_location.unknown) in
+      let sym2_it = IT (Sym sym2, BT.(Loc ()), Cerb_location.unknown) in
       let lhs =
-        (
-          IT (StructMember (sym1_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown))
+        IT (StructMember (sym1_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown)
       in
       let rhs =
-        (
-          IT (StructMember (sym2_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown))
+        IT (StructMember (sym2_it, id), cn_base_type_to_bt cn_bt, Cerb_location.unknown)
       in
-      let eq_it = (IT (Binop (EQ, lhs, rhs), BT.Bool, Cerb_location.unknown)) in
+      let eq_it = IT (Binop (EQ, lhs, rhs), BT.Bool, Cerb_location.unknown) in
       let remaining = generate_equality_expr ms sym1 sym2 in
-      (IT (Binop (And, eq_it, remaining), BT.Bool, Cerb_location.unknown))
+      IT (Binop (And, eq_it, remaining), BT.Bool, Cerb_location.unknown)
   in
   let create_case (constructor, members) =
     let enum_str =
@@ -2915,7 +2910,7 @@ let cn_to_ail_struct ((sym, (loc, attrs, tag_def)) : A.sigma_tag_definition)
 
 let get_while_bounds_and_cond (i_sym, i_bt) it =
   (* Translation of q.pointer *)
-  let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
+  let i_it = IT (Sym i_sym, i_bt, Cerb_location.unknown) in
   (* Start of range *)
   let lower_bound =
     if BT.equal_sign (fst (Option.get (BT.is_bits_bt i_bt))) BT.Unsigned then
@@ -2977,11 +2972,10 @@ let get_while_bounds_and_cond (i_sym, i_bt) it =
       let one_const =
         match BT.is_bits_bt i_bt with
         | Some (sign, n) ->
-          (
-            IT
-              ( Const (Bits ((sign, n), Z.of_int 1)),
-                BT.(Bits (sign, n)),
-                Cerb_location.unknown ))
+          IT
+            ( Const (Bits ((sign, n), Z.of_int 1)),
+              BT.(Bits (sign, n)),
+              Cerb_location.unknown )
         | None -> IT.int_ 1 Cerb_location.unknown
       in
       (* need to make it an explicit < check rather than <= for optimisation that asserts ownership over contiguous memory in one go -- assumes particular shape of bounds *)
@@ -3056,7 +3050,7 @@ let cn_to_ail_resource
     fn_prefix ^ ct_str
   in
   let enum_sym = sym_of_spec_mode_opt spec_mode_opt in
-  let it_zero_const = (IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown)) in
+  let it_zero_const = IT (Const (Z (Z.of_int 0)), BT.Unit, Cerb_location.unknown) in
   let ail_zero_const_expr_ =
     A.(AilEconst (ConstantInteger (IConstant (Z.of_int 0, Decimal, None))))
   in
@@ -3070,11 +3064,11 @@ let cn_to_ail_resource
         ownership_ctypes := Sctypes.to_ctype sct :: !ownership_ctypes;
         let owned_fn_name = generate_owned_fn_name ~without_ownership_checking sct in
         (* Hack with enum as sym *)
-        let enum_val_get = (IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let enum_val_get = IT (Sym enum_sym, BT.Integer, Cerb_location.unknown) in
         let loop_ownership_arg =
           match loop_ownership_sym_opt with
           | Some loop_ownership_sym ->
-            (IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+            IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown)
           | None -> it_zero_const
         in
         let fn_call_it =
@@ -3174,7 +3168,7 @@ let cn_to_ail_resource
     let end_assign = A.(AilSdeclaration [ (end_sym, Some e_end) ]) in
     let return_ctype, _return_bt = calculate_resource_return_type preds loc q.name in
     (* Translation of q.pointer *)
-    let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
+    let i_it = IT (Sym i_sym, i_bt, Cerb_location.unknown) in
     let value_it =
       IT.arrayShift_ ~base:q.pointer ~index:i_it q.step Cerb_location.unknown
     in
@@ -3198,13 +3192,13 @@ let cn_to_ail_resource
         let owned_or_deref_fn_name =
           generate_owned_fn_name ~without_ownership_checking:permission_only_bounds sct
         in
-        let ptr_add_it = (IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
+        let ptr_add_it = IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown) in
         (* Hack with enum as sym *)
-        let enum_val_get = (IT (Sym enum_sym, BT.Integer, Cerb_location.unknown)) in
+        let enum_val_get = IT (Sym enum_sym, BT.Integer, Cerb_location.unknown) in
         let loop_ownership_arg =
           match loop_ownership_sym_opt with
           | Some loop_ownership_sym ->
-            (IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown))
+            IT (Sym loop_ownership_sym, BT.Integer, Cerb_location.unknown)
           | None -> it_zero_const
         in
         let fn_call_it =
@@ -5398,7 +5392,7 @@ let cn_to_ail_assume_resource
     let end_assign = A.(AilSdeclaration [ (end_sym, Some e_end) ]) in
     let return_ctype, _return_bt = calculate_return_type q.name in
     (* Translation of q.pointer *)
-    let i_it = IT ((Sym i_sym), i_bt, Cerb_location.unknown) in
+    let i_it = IT (Sym i_sym, i_bt, Cerb_location.unknown) in
     let value_it =
       IT.arrayShift_ ~base:q.pointer ~index:i_it q.step Cerb_location.unknown
     in
@@ -5416,7 +5410,7 @@ let cn_to_ail_assume_resource
         let owned_fn_name =
           "assume_" ^ generate_owned_fn_name ~without_ownership_checking sct
         in
-        let ptr_add_it = (IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown)) in
+        let ptr_add_it = IT (Sym ptr_add_sym, BT.(Loc ()), Cerb_location.unknown) in
         (* Hack with enum as sym *)
         let fn_call_it =
           IT

--- a/lib/fulminate/cn_to_ail.mli
+++ b/lib/fulminate/cn_to_ail.mli
@@ -166,7 +166,7 @@ val cn_to_ail_expr_toplevel
   (Ctype.union_tag * Ctype.ctype) list ->
   Sym.t option ->
   spec_mode option ->
-  IndexTerms.t ->
+  Terms.Normal.t ->
   AilSyntax.bindings
   * GenTypes.genTypeCategory AilSyntax.statement_ list
   * GenTypes.genTypeCategory AilSyntax.expression
@@ -269,7 +269,7 @@ val cn_to_ail_assume_pre
 
 val cn_to_ail_ghost_enum
   :  unit BaseTypes.t_gen list list ->
-  IndexTerms.t Cnprog.t list list ->
+  Terms.Normal.t Cnprog.t list list ->
   AilSyntax.sigma_tag_definition
 
 val cn_to_ail_cnprog_ghost_args
@@ -277,5 +277,5 @@ val cn_to_ail_cnprog_ghost_args
   AilSyntax.sigma_cn_datatype list ->
   (Sym.t * Ctype.ctype) list ->
   spec_mode option ->
-  IndexTerms.t Cnprog.t list ->
+  Terms.Normal.t Cnprog.t list ->
   AilSyntax.bindings * GenTypes.genTypeCategory AilSyntax.statement_ list

--- a/lib/fulminate/extract.ml
+++ b/lib/fulminate/extract.ml
@@ -62,7 +62,7 @@ type instrumentation =
 (* replace `s_replace` of basetype `bt` with `s_with` *)
 let sym_subst (s_replace, bt, s_with) =
   let module IT = IndexTerms in
-  IT.make_subst [ (s_replace, IT.sym_ (s_with, bt, Cerb_location.unknown)) ]
+  Terms.Normal.make_subst [ (s_replace, IT.sym_ (s_with, bt, Cerb_location.unknown)) ]
 
 
 let rec stmts_in_expr (Mucore.Expr (loc, _, _, e_)) =

--- a/lib/fulminate/extract.mli
+++ b/lib/fulminate/extract.mli
@@ -17,17 +17,17 @@ type fn_largs_and_body = (ReturnTypes.t * fn_body) LogicalArgumentTypes.t
 
 val sym_subst
   :  Sym.t * BaseTypes.t * Sym.t ->
-  [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t
+  [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t
 
-val loop_subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> loop -> loop
+val loop_subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> loop -> loop
 
 val fn_args_and_body_subst
-  :  [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t ->
+  :  [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t ->
   fn_args_and_body ->
   fn_args_and_body
 
 val fn_largs_and_body_subst
-  :  [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t ->
+  :  [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t ->
   fn_largs_and_body ->
   fn_largs_and_body
 
@@ -48,4 +48,4 @@ val args_and_body_list_of_mucore : 'a Mucore.file -> 'a Mucore.args_and_body lis
 
 val ghost_args_and_their_call_locs
   :  unit Mucore.file ->
-  (Cerb_location.t * IndexTerms.t Cnprog.t list) list
+  (Cerb_location.t * Terms.Normal.t Cnprog.t list) list

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -1,13 +1,13 @@
 module CF = Cerb_frontend
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module LRT = LogicalReturnTypes
 module LAT = LogicalArgumentTypes
 module AT = ArgumentTypes
 
 let rec add_records_to_map_from_it it =
-  match IT.get_term it with
-  | IT.Sym _s -> ()
+  match T.get_term it with
+  | Terms.Sym _s -> ()
   | Const c -> (match c with Default bt -> Cn_to_ail.augment_record_map bt | _ -> ())
   | Unop (_uop, t1) -> add_records_to_map_from_it t1
   | Binop (_bop, t1, t2) -> List.iter add_records_to_map_from_it [ t1; t2 ]
@@ -21,7 +21,7 @@ let rec add_records_to_map_from_it it =
   | StructUpdate ((t1, _member), t2) -> List.iter add_records_to_map_from_it [ t1; t2 ]
   | Record members ->
     (* Anonymous record instantiation -> add to records map *)
-    Cn_to_ail.augment_record_map (IT.get_bt it);
+    Cn_to_ail.augment_record_map (T.get_bt it);
     List.iter (fun (_, it') -> add_records_to_map_from_it it') members
   | RecordMember (t, _member) -> add_records_to_map_from_it t
   | RecordUpdate ((t1, _member), t2) -> List.iter add_records_to_map_from_it [ t1; t2 ]

--- a/lib/indexTerms.ml
+++ b/lib/indexTerms.ml
@@ -1,5 +1,4 @@
 module BT = BaseTypes
-
 open Terms
 open Terms.Normal
 
@@ -517,171 +516,169 @@ let representable = value_check `Representable
 
 let good_pointer = value_check_pointer `Good
 
-
-
-  module Bounds = struct
-    let get_lower_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
-      let rec aux (it : t) : t option =
-	match it with
-	| IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
-	| IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
-	  if Sym.equal x x' then Some tm2 else None
-	| IT (Binop (LE, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' -> Some it'
-	| IT (Binop (LT, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' ->
-	  Some
-	    (IT
-	       ( Binop (Add, it', num_lit_ Z.one bt Cerb_location.unknown),
-		 bt,
-		 Cerb_location.unknown ))
-	| IT (Binop (And, tm1, tm2), _, _) ->
-	  (match (aux tm1, aux tm2) with
-	   | None, None -> None
-	   | None, it' | it', None -> it'
-	   | Some tm1, Some tm2 ->
-	     Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
-	| IT (Binop (Or, tm1, tm2), _, _) ->
-	  (match (aux tm1, aux tm2) with
-	   | None, None | None, _ | _, None -> None
-	   | Some tm1, Some tm2 ->
-	     Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
-	| _ -> None
-      in
-      aux it
-
-
-    let get_lower_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
-      let min =
-	match bt with
-	| Bits (sign, sz) -> fst (BaseTypes.bits_range (sign, sz))
-	| _ ->
-	  Cerb_colour.with_colour
-	    (fun () ->
-	       print_endline
-		 Pp.(
-		   plain
-		     (!^"unsupported type"
-		      ^^^ squotes (BaseTypes.pp bt)
-		      ^^^ !^"in permission"
-		      ^^^ squotes (pp it)
-		      ^^^ !^"at"
-		      ^^^ Locations.pp (get_loc it))))
-	    ();
-	  exit 2
-      in
-      get_lower_bound_opt (x, bt) it
-      |> Option.value ~default:(num_lit_ min bt Cerb_location.unknown)
-
-
-    let get_upper_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
-      let rec aux (it : t) : t option =
-	match it with
-	| IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
-	| IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
-	  if Sym.equal x x' then Some tm2 else None
-	| IT (Binop (LE, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' -> Some it'
-	| IT (Binop (LT, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' ->
-	  Some
-	    (IT
-	       ( Binop (Sub, it', num_lit_ Z.one bt Cerb_location.unknown),
-		 bt,
-		 Cerb_location.unknown ))
-	| IT (Binop (And, tm1, tm2), _, _) ->
-	  (match (aux tm1, aux tm2) with
-	   | None, None -> None
-	   | None, it' | it', None -> it'
-	   | Some tm1, Some tm2 ->
-	     Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
-	| IT (Binop (Or, tm1, tm2), _, _) ->
-	  (match (aux tm1, aux tm2) with
-	   | None, None | None, _ | _, None -> None
-	   | Some tm1, Some tm2 ->
-	     Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
-	| _ -> None
-      in
-      aux it
-
-
-    let get_upper_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
-      let max =
-	match bt with
-	| Bits (sign, sz) -> snd (BaseTypes.bits_range (sign, sz))
-	| _ ->
-	  Cerb_colour.with_colour
-	    (fun () ->
-	       print_endline
-		 Pp.(
-		   plain
-		     (!^"unsupported type"
-		      ^^^ squotes (BaseTypes.pp bt)
-		      ^^^ !^"in permission"
-		      ^^^ squotes (pp it)
-		      ^^^ !^"at"
-		      ^^^ Locations.pp (get_loc it))))
-	    ();
-	  exit 2
-      in
-      get_upper_bound_opt (x, bt) it
-      |> Option.value ~default:(num_lit_ max bt Cerb_location.unknown)
-
-
-    (* used for Fulminate optimisation *)
-    let is_eq_bound ((x_sym, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+module Bounds = struct
+  let get_lower_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
+    let rec aux (it : t) : t option =
       match it with
-      | IT (Binop (EQ, IT (Sym x_sym', _, _), _), _, _)
-      | IT (Binop (EQ, _, IT (Sym x_sym', _, _)), _, _) ->
-	Sym.equal x_sym x_sym'
-      | _ -> false
+      | IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
+      | IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
+        if Sym.equal x x' then Some tm2 else None
+      | IT (Binop (LE, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' -> Some it'
+      | IT (Binop (LT, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' ->
+        Some
+          (IT
+             ( Binop (Add, it', num_lit_ Z.one bt Cerb_location.unknown),
+               bt,
+               Cerb_location.unknown ))
+      | IT (Binop (And, tm1, tm2), _, _) ->
+        (match (aux tm1, aux tm2) with
+         | None, None -> None
+         | None, it' | it', None -> it'
+         | Some tm1, Some tm2 ->
+           Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
+      | IT (Binop (Or, tm1, tm2), _, _) ->
+        (match (aux tm1, aux tm2) with
+         | None, None | None, _ | _, None -> None
+         | Some tm1, Some tm2 ->
+           Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
+      | _ -> None
+    in
+    aux it
 
 
-    let is_lower_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+  let get_lower_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
+    let min =
+      match bt with
+      | Bits (sign, sz) -> fst (BaseTypes.bits_range (sign, sz))
+      | _ ->
+        Cerb_colour.with_colour
+          (fun () ->
+             print_endline
+               Pp.(
+                 plain
+                   (!^"unsupported type"
+                    ^^^ squotes (BaseTypes.pp bt)
+                    ^^^ !^"in permission"
+                    ^^^ squotes (pp it)
+                    ^^^ !^"at"
+                    ^^^ Locations.pp (get_loc it))))
+          ();
+        exit 2
+    in
+    get_lower_bound_opt (x, bt) it
+    |> Option.value ~default:(num_lit_ min bt Cerb_location.unknown)
+
+
+  let get_upper_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
+    let rec aux (it : t) : t option =
       match it with
-      | IT (Binop (LE, _, IT (Sym x', _, _)), _, _)
-      | IT (Binop (LT, _, IT (Sym x', _, _)), _, _) ->
-	Sym.equal x x'
-      | _ -> false
+      | IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
+      | IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
+        if Sym.equal x x' then Some tm2 else None
+      | IT (Binop (LE, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' -> Some it'
+      | IT (Binop (LT, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' ->
+        Some
+          (IT
+             ( Binop (Sub, it', num_lit_ Z.one bt Cerb_location.unknown),
+               bt,
+               Cerb_location.unknown ))
+      | IT (Binop (And, tm1, tm2), _, _) ->
+        (match (aux tm1, aux tm2) with
+         | None, None -> None
+         | None, it' | it', None -> it'
+         | Some tm1, Some tm2 ->
+           Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
+      | IT (Binop (Or, tm1, tm2), _, _) ->
+        (match (aux tm1, aux tm2) with
+         | None, None | None, _ | _, None -> None
+         | Some tm1, Some tm2 ->
+           Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
+      | _ -> None
+    in
+    aux it
 
 
-    let is_upper_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+  let get_upper_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
+    let max =
+      match bt with
+      | Bits (sign, sz) -> snd (BaseTypes.bits_range (sign, sz))
+      | _ ->
+        Cerb_colour.with_colour
+          (fun () ->
+             print_endline
+               Pp.(
+                 plain
+                   (!^"unsupported type"
+                    ^^^ squotes (BaseTypes.pp bt)
+                    ^^^ !^"in permission"
+                    ^^^ squotes (pp it)
+                    ^^^ !^"at"
+                    ^^^ Locations.pp (get_loc it))))
+          ();
+        exit 2
+    in
+    get_upper_bound_opt (x, bt) it
+    |> Option.value ~default:(num_lit_ max bt Cerb_location.unknown)
+
+
+  (* used for Fulminate optimisation *)
+  let is_eq_bound ((x_sym, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+    match it with
+    | IT (Binop (EQ, IT (Sym x_sym', _, _), _), _, _)
+    | IT (Binop (EQ, _, IT (Sym x_sym', _, _)), _, _) ->
+      Sym.equal x_sym x_sym'
+    | _ -> false
+
+
+  let is_lower_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+    match it with
+    | IT (Binop (LE, _, IT (Sym x', _, _)), _, _)
+    | IT (Binop (LT, _, IT (Sym x', _, _)), _, _) ->
+      Sym.equal x x'
+    | _ -> false
+
+
+  let is_upper_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
+    match it with
+    | IT (Binop (LE, IT (Sym x', _, _), _), _, _)
+    | IT (Binop (LT, IT (Sym x', _, _), _), _, _) ->
+      Sym.equal x x'
+    | _ -> false
+
+
+  let is_bound (x : Sym.t * BaseTypes.t) (it : t) : bool =
+    is_eq_bound x it || is_lower_bound x it || is_upper_bound x it
+
+
+  let it_only_bounds (x : Sym.t * BaseTypes.t) (it : t) : bool =
+    match it with
+    | IT (Binop (EQ, IT (Sym _, _, _), _), _, _) -> is_eq_bound x it
+    | IT (Binop (And, tm1, tm2), _, _) -> is_lower_bound x tm1 && is_upper_bound x tm2
+    | _ -> false
+
+
+  let it_non_bounds (x : Sym.t * BaseTypes.t) (it : t) : t =
+    let true_const = bool_ true Cerb_location.unknown in
+    let rec aux it =
       match it with
-      | IT (Binop (LE, IT (Sym x', _, _), _), _, _)
-      | IT (Binop (LT, IT (Sym x', _, _), _), _, _) ->
-	Sym.equal x x'
-      | _ -> false
+      | IT (Binop (And, tm1, tm2), bt, loc) ->
+        if is_bound x tm1 && is_bound x tm2 then
+          true_const
+        else if is_bound x tm1 then
+          aux tm2
+        else if is_bound x tm2 then
+          aux tm1
+        else
+          IT (Binop (And, aux tm1, aux tm2), bt, loc)
+      | _ -> it
+    in
+    aux it
 
 
-    let is_bound (x : Sym.t * BaseTypes.t) (it : t) : bool =
-      is_eq_bound x it || is_lower_bound x it || is_upper_bound x it
+  let get_bounds_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option * t option =
+    (get_lower_bound_opt (x, bt) it, get_upper_bound_opt (x, bt) it)
 
 
-    let it_only_bounds (x : Sym.t * BaseTypes.t) (it : t) : bool =
-      match it with
-      | IT (Binop (EQ, IT (Sym _, _, _), _), _, _) -> is_eq_bound x it
-      | IT (Binop (And, tm1, tm2), _, _) -> is_lower_bound x tm1 && is_upper_bound x tm2
-      | _ -> false
-
-
-    let it_non_bounds (x : Sym.t * BaseTypes.t) (it : t) : t =
-      let true_const = bool_ true Cerb_location.unknown in
-      let rec aux it =
-	match it with
-	| IT (Binop (And, tm1, tm2), bt, loc) ->
-	  if is_bound x tm1 && is_bound x tm2 then
-	    true_const
-	  else if is_bound x tm1 then
-	    aux tm2
-	  else if is_bound x tm2 then
-	    aux tm1
-	  else
-	    IT (Binop (And, aux tm1, aux tm2), bt, loc)
-	| _ -> it
-      in
-      aux it
-
-
-    let get_bounds_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option * t option =
-      (get_lower_bound_opt (x, bt) it, get_upper_bound_opt (x, bt) it)
-
-
-    let get_bounds ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t * t =
-      (get_lower_bound (x, bt) it, get_upper_bound (x, bt) it)
-  end
+  let get_bounds ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t * t =
+    (get_lower_bound (x, bt) it, get_upper_bound (x, bt) it)
+end

--- a/lib/indexTerms.ml
+++ b/lib/indexTerms.ml
@@ -1,118 +1,7 @@
 module BT = BaseTypes
-module CF = Cerb_frontend
-include Terms
 
-let equal = equal_annot BT.equal
-
-let compare = compare_annot BT.compare
-
-type t' = BT.t term
-
-type t = BT.t annot
-
-module Surface = struct
-  type t' = BaseTypes.Surface.t term
-
-  type t = BaseTypes.Surface.t annot
-
-  let compare = compare_annot BaseTypes.Surface.compare
-
-  let proj = map_annot BaseTypes.Surface.proj
-
-  let inj x = map_annot BaseTypes.Surface.inj x
-end
-
-let pp ?(prec = 0) = pp ~prec
-
-let pp_with_typf f it = Pp.typ (pp it) (f (get_bt it))
-
-let pp_with_typ = pp_with_typf BT.pp
-
-let is_call (f : Sym.t) (IT (it_, _bt, _loc)) =
-  match it_ with Apply (f', _) when Sym.equal f f' -> true | _ -> false
-
-
-let is_good (ct : Sctypes.t) (IT (it_, _bt, _loc)) =
-  match it_ with Good (ct', _) when Sctypes.equal ct ct' -> true | _ -> false
-
-
-let mentions_call f = fold_subterms (fun _binders acc it -> acc || is_call f it) false
-
-let mentions_good ct = fold_subterms (fun _binders acc it -> acc || is_good ct it) false
-
-let preds_of t =
-  let add_p s = function IT (Apply (id, _), _, _) -> Sym.Set.add id s | _ -> s in
-  fold_subterms (fun _ -> add_p) Sym.Set.empty t
-
-
-let json it : Yojson.Safe.t = `String (Pp.plain (pp it))
-
-let subst = subst BT.equal
-
-let alpha_rename = alpha_rename BT.equal
-
-let suitably_alpha_rename = suitably_alpha_rename BT.equal
-
-let make_subst = make_subst BT.equal
-
-let make_rename = make_rename BT.equal
-
-let free_vars_bts = free_vars_bts BT.equal
-
-let free_vars_bts_list = free_vars_bts_list BT.equal
-
-let free_vars = free_vars BT.equal
-
-let free_vars_list = free_vars_list BT.equal
-
-let free_vars_with_rename = free_vars_with_rename BT.equal
-
-let is_const = function
-  | IT (Const const, bt, _loc) -> Option.Some (const, bt)
-  | _ -> None
-
-
-let is_z = function IT (Const (Z z), _bt, _loc) -> Option.Some z | _ -> None
-
-let is_z_ it = Option.is_some (is_z it)
-
-let get_num_z it =
-  match get_term it with
-  | Const (Z _) -> is_z it
-  | Const (Bits (info, z)) -> Some (BT.normalise_to_range info z)
-  | _ -> None
-
-
-let is_bits_const = function
-  | IT (Const (Bits (info, n)), _, _) -> Some (info, n)
-  | _ -> None
-
-
-let is_pointer = function
-  | IT (Const (Pointer { alloc_id; addr }), _bt, _) -> Some (alloc_id, addr)
-  | _ -> None
-
-
-let is_alloc_id = function
-  | IT (Const (Alloc_id alloc_id), _bt, _) -> Some alloc_id
-  | _ -> None
-
-
-let is_sym = function IT (Sym sym, bt, _) -> Some (sym, bt) | _ -> None
-
-let is_bool = function IT (Const (Bool b), _, _) -> Some b | _ -> None
-
-let is_true = function IT (Const (Bool true), _, _) -> true | _ -> false
-
-let is_false = function IT (Const (Bool false), _, _) -> true | _ -> false
-
-let is_eq = function IT (Binop (EQ, lhs, rhs), _, _) -> Some (lhs, rhs) | _ -> None
-
-let is_and = function IT (Binop (And, it, it'), _, _) -> Some (it, it') | _ -> None
-
-let is_pred_ = function IT (Apply (name, args), _, _) -> Some (name, args) | _ -> None
-
-let is_ctype_const = function IT (Const (CType_const ct), _, _) -> Some ct | _ -> None
+open Terms
+open Terms.Normal
 
 (* shorthands *)
 
@@ -628,169 +517,171 @@ let representable = value_check `Representable
 
 let good_pointer = value_check_pointer `Good
 
-module Bounds = struct
-  let get_lower_bound_opt ((x, bt) : Sym.t * BT.t) (it : t) : t option =
-    let rec aux (it : t) : t option =
+
+
+  module Bounds = struct
+    let get_lower_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
+      let rec aux (it : t) : t option =
+	match it with
+	| IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
+	| IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
+	  if Sym.equal x x' then Some tm2 else None
+	| IT (Binop (LE, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' -> Some it'
+	| IT (Binop (LT, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' ->
+	  Some
+	    (IT
+	       ( Binop (Add, it', num_lit_ Z.one bt Cerb_location.unknown),
+		 bt,
+		 Cerb_location.unknown ))
+	| IT (Binop (And, tm1, tm2), _, _) ->
+	  (match (aux tm1, aux tm2) with
+	   | None, None -> None
+	   | None, it' | it', None -> it'
+	   | Some tm1, Some tm2 ->
+	     Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
+	| IT (Binop (Or, tm1, tm2), _, _) ->
+	  (match (aux tm1, aux tm2) with
+	   | None, None | None, _ | _, None -> None
+	   | Some tm1, Some tm2 ->
+	     Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
+	| _ -> None
+      in
+      aux it
+
+
+    let get_lower_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
+      let min =
+	match bt with
+	| Bits (sign, sz) -> fst (BaseTypes.bits_range (sign, sz))
+	| _ ->
+	  Cerb_colour.with_colour
+	    (fun () ->
+	       print_endline
+		 Pp.(
+		   plain
+		     (!^"unsupported type"
+		      ^^^ squotes (BaseTypes.pp bt)
+		      ^^^ !^"in permission"
+		      ^^^ squotes (pp it)
+		      ^^^ !^"at"
+		      ^^^ Locations.pp (get_loc it))))
+	    ();
+	  exit 2
+      in
+      get_lower_bound_opt (x, bt) it
+      |> Option.value ~default:(num_lit_ min bt Cerb_location.unknown)
+
+
+    let get_upper_bound_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option =
+      let rec aux (it : t) : t option =
+	match it with
+	| IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
+	| IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
+	  if Sym.equal x x' then Some tm2 else None
+	| IT (Binop (LE, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' -> Some it'
+	| IT (Binop (LT, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' ->
+	  Some
+	    (IT
+	       ( Binop (Sub, it', num_lit_ Z.one bt Cerb_location.unknown),
+		 bt,
+		 Cerb_location.unknown ))
+	| IT (Binop (And, tm1, tm2), _, _) ->
+	  (match (aux tm1, aux tm2) with
+	   | None, None -> None
+	   | None, it' | it', None -> it'
+	   | Some tm1, Some tm2 ->
+	     Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
+	| IT (Binop (Or, tm1, tm2), _, _) ->
+	  (match (aux tm1, aux tm2) with
+	   | None, None | None, _ | _, None -> None
+	   | Some tm1, Some tm2 ->
+	     Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
+	| _ -> None
+      in
+      aux it
+
+
+    let get_upper_bound ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t =
+      let max =
+	match bt with
+	| Bits (sign, sz) -> snd (BaseTypes.bits_range (sign, sz))
+	| _ ->
+	  Cerb_colour.with_colour
+	    (fun () ->
+	       print_endline
+		 Pp.(
+		   plain
+		     (!^"unsupported type"
+		      ^^^ squotes (BaseTypes.pp bt)
+		      ^^^ !^"in permission"
+		      ^^^ squotes (pp it)
+		      ^^^ !^"at"
+		      ^^^ Locations.pp (get_loc it))))
+	    ();
+	  exit 2
+      in
+      get_upper_bound_opt (x, bt) it
+      |> Option.value ~default:(num_lit_ max bt Cerb_location.unknown)
+
+
+    (* used for Fulminate optimisation *)
+    let is_eq_bound ((x_sym, _) : Sym.t * BaseTypes.t) (it : t) : bool =
       match it with
-      | IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
-      | IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
-        if Sym.equal x x' then Some tm2 else None
-      | IT (Binop (LE, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' -> Some it'
-      | IT (Binop (LT, it', IT (Sym x', _, _)), _, _) when Sym.equal x x' ->
-        Some
-          (IT
-             ( Binop (Add, it', num_lit_ Z.one bt Cerb_location.unknown),
-               bt,
-               Cerb_location.unknown ))
-      | IT (Binop (And, tm1, tm2), _, _) ->
-        (match (aux tm1, aux tm2) with
-         | None, None -> None
-         | None, it' | it', None -> it'
-         | Some tm1, Some tm2 ->
-           Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
-      | IT (Binop (Or, tm1, tm2), _, _) ->
-        (match (aux tm1, aux tm2) with
-         | None, None | None, _ | _, None -> None
-         | Some tm1, Some tm2 ->
-           Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
-      | _ -> None
-    in
-    aux it
+      | IT (Binop (EQ, IT (Sym x_sym', _, _), _), _, _)
+      | IT (Binop (EQ, _, IT (Sym x_sym', _, _)), _, _) ->
+	Sym.equal x_sym x_sym'
+      | _ -> false
 
 
-  let get_lower_bound ((x, bt) : Sym.t * BT.t) (it : t) : t =
-    let min =
-      match bt with
-      | Bits (sign, sz) -> fst (BT.bits_range (sign, sz))
-      | _ ->
-        Cerb_colour.with_colour
-          (fun () ->
-             print_endline
-               Pp.(
-                 plain
-                   (!^"unsupported type"
-                    ^^^ squotes (BT.pp bt)
-                    ^^^ !^"in permission"
-                    ^^^ squotes (pp it)
-                    ^^^ !^"at"
-                    ^^^ Locations.pp (get_loc it))))
-          ();
-        exit 2
-    in
-    get_lower_bound_opt (x, bt) it
-    |> Option.value ~default:(num_lit_ min bt Cerb_location.unknown)
-
-
-  let get_upper_bound_opt ((x, bt) : Sym.t * BT.t) (it : t) : t option =
-    let rec aux (it : t) : t option =
+    let is_lower_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
       match it with
-      | IT (Binop (EQ, IT (Sym x', _, _), tm2), _, _)
-      | IT (Binop (EQ, tm2, IT (Sym x', _, _)), _, _) ->
-        if Sym.equal x x' then Some tm2 else None
-      | IT (Binop (LE, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' -> Some it'
-      | IT (Binop (LT, IT (Sym x', _, _), it'), _, _) when Sym.equal x x' ->
-        Some
-          (IT
-             ( Binop (Sub, it', num_lit_ Z.one bt Cerb_location.unknown),
-               bt,
-               Cerb_location.unknown ))
-      | IT (Binop (And, tm1, tm2), _, _) ->
-        (match (aux tm1, aux tm2) with
-         | None, None -> None
-         | None, it' | it', None -> it'
-         | Some tm1, Some tm2 ->
-           Some (IT (Binop (Min, tm1, tm2), bt, Cerb_location.unknown)))
-      | IT (Binop (Or, tm1, tm2), _, _) ->
-        (match (aux tm1, aux tm2) with
-         | None, None | None, _ | _, None -> None
-         | Some tm1, Some tm2 ->
-           Some (IT (Binop (Max, tm1, tm2), bt, Cerb_location.unknown)))
-      | _ -> None
-    in
-    aux it
+      | IT (Binop (LE, _, IT (Sym x', _, _)), _, _)
+      | IT (Binop (LT, _, IT (Sym x', _, _)), _, _) ->
+	Sym.equal x x'
+      | _ -> false
 
 
-  let get_upper_bound ((x, bt) : Sym.t * BT.t) (it : t) : t =
-    let max =
-      match bt with
-      | Bits (sign, sz) -> snd (BT.bits_range (sign, sz))
-      | _ ->
-        Cerb_colour.with_colour
-          (fun () ->
-             print_endline
-               Pp.(
-                 plain
-                   (!^"unsupported type"
-                    ^^^ squotes (BT.pp bt)
-                    ^^^ !^"in permission"
-                    ^^^ squotes (pp it)
-                    ^^^ !^"at"
-                    ^^^ Locations.pp (get_loc it))))
-          ();
-        exit 2
-    in
-    get_upper_bound_opt (x, bt) it
-    |> Option.value ~default:(num_lit_ max bt Cerb_location.unknown)
-
-
-  (* used for Fulminate optimisation *)
-  let is_eq_bound ((x_sym, _) : Sym.t * BT.t) (it : t) : bool =
-    match it with
-    | IT (Binop (EQ, IT (Sym x_sym', _, _), _), _, _)
-    | IT (Binop (EQ, _, IT (Sym x_sym', _, _)), _, _) ->
-      Sym.equal x_sym x_sym'
-    | _ -> false
-
-
-  let is_lower_bound ((x, _) : Sym.t * BT.t) (it : t) : bool =
-    match it with
-    | IT (Binop (LE, _, IT (Sym x', _, _)), _, _)
-    | IT (Binop (LT, _, IT (Sym x', _, _)), _, _) ->
-      Sym.equal x x'
-    | _ -> false
-
-
-  let is_upper_bound ((x, _) : Sym.t * BT.t) (it : t) : bool =
-    match it with
-    | IT (Binop (LE, IT (Sym x', _, _), _), _, _)
-    | IT (Binop (LT, IT (Sym x', _, _), _), _, _) ->
-      Sym.equal x x'
-    | _ -> false
-
-
-  let is_bound (x : Sym.t * BT.t) (it : t) : bool =
-    is_eq_bound x it || is_lower_bound x it || is_upper_bound x it
-
-
-  let it_only_bounds (x : Sym.t * BT.t) (it : t) : bool =
-    match it with
-    | IT (Binop (EQ, IT (Sym _, _, _), _), _, _) -> is_eq_bound x it
-    | IT (Binop (And, tm1, tm2), _, _) -> is_lower_bound x tm1 && is_upper_bound x tm2
-    | _ -> false
-
-
-  let it_non_bounds (x : Sym.t * BT.t) (it : t) : t =
-    let true_const = bool_ true Cerb_location.unknown in
-    let rec aux it =
+    let is_upper_bound ((x, _) : Sym.t * BaseTypes.t) (it : t) : bool =
       match it with
-      | IT (Binop (And, tm1, tm2), bt, loc) ->
-        if is_bound x tm1 && is_bound x tm2 then
-          true_const
-        else if is_bound x tm1 then
-          aux tm2
-        else if is_bound x tm2 then
-          aux tm1
-        else
-          IT (Binop (And, aux tm1, aux tm2), bt, loc)
-      | _ -> it
-    in
-    aux it
+      | IT (Binop (LE, IT (Sym x', _, _), _), _, _)
+      | IT (Binop (LT, IT (Sym x', _, _), _), _, _) ->
+	Sym.equal x x'
+      | _ -> false
 
 
-  let get_bounds_opt ((x, bt) : Sym.t * BT.t) (it : t) : t option * t option =
-    (get_lower_bound_opt (x, bt) it, get_upper_bound_opt (x, bt) it)
+    let is_bound (x : Sym.t * BaseTypes.t) (it : t) : bool =
+      is_eq_bound x it || is_lower_bound x it || is_upper_bound x it
 
 
-  let get_bounds ((x, bt) : Sym.t * BT.t) (it : t) : t * t =
-    (get_lower_bound (x, bt) it, get_upper_bound (x, bt) it)
-end
+    let it_only_bounds (x : Sym.t * BaseTypes.t) (it : t) : bool =
+      match it with
+      | IT (Binop (EQ, IT (Sym _, _, _), _), _, _) -> is_eq_bound x it
+      | IT (Binop (And, tm1, tm2), _, _) -> is_lower_bound x tm1 && is_upper_bound x tm2
+      | _ -> false
+
+
+    let it_non_bounds (x : Sym.t * BaseTypes.t) (it : t) : t =
+      let true_const = bool_ true Cerb_location.unknown in
+      let rec aux it =
+	match it with
+	| IT (Binop (And, tm1, tm2), bt, loc) ->
+	  if is_bound x tm1 && is_bound x tm2 then
+	    true_const
+	  else if is_bound x tm1 then
+	    aux tm2
+	  else if is_bound x tm2 then
+	    aux tm1
+	  else
+	    IT (Binop (And, aux tm1, aux tm2), bt, loc)
+	| _ -> it
+      in
+      aux it
+
+
+    let get_bounds_opt ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t option * t option =
+      (get_lower_bound_opt (x, bt) it, get_upper_bound_opt (x, bt) it)
+
+
+    let get_bounds ((x, bt) : Sym.t * BaseTypes.t) (it : t) : t * t =
+      (get_lower_bound (x, bt) it, get_upper_bound (x, bt) it)
+  end

--- a/lib/interval.ml
+++ b/lib/interval.ml
@@ -183,19 +183,20 @@ module Intervals = struct
 end
 
 module Solver = struct
+  module T = Terms.Normal
   module IT = IndexTerms
   module RT = Request
   open Terms
   open BaseTypes
 
-  let interval_for (eval : IT.t -> IT.t option) q tyi =
-    let is_q i = match IT.get_term i with Sym y -> Sym.equal q y | _ -> false in
+  let interval_for (eval : T.t -> T.t option) q tyi =
+    let is_q i = match T.get_term i with Sym y -> Sym.equal q y | _ -> false in
     let eval_k e =
-      if Sym.Set.mem q (IT.free_vars e) then
+      if Sym.Set.mem q (T.free_vars e) then
         None
       else
         Option.bind (eval e) (fun v ->
-          match IT.get_term v with
+          match T.get_term v with
           | Const (Z z) -> Some z
           | Const (Bits (_, z)) -> Some z
           | _ -> None)
@@ -214,7 +215,7 @@ module Solver = struct
     let do_compl i = mkI (Intervals.complement i) in
     let do_impl i j = Intervals.union (do_compl i) j in
     let rec interval p =
-      match IT.get_term p with
+      match T.get_term p with
       | Const (Bool true) -> Some tyi
       | Const (Bool false) -> Some (Intervals.of_interval Interval.empty)
       | Unop (Not, term) -> Option.map do_compl (interval term)
@@ -233,7 +234,7 @@ module Solver = struct
     interval
 
 
-  let supported_type loc ty : (Interval.t * (Z.t -> IT.t)) option =
+  let supported_type loc ty : (Interval.t * (Z.t -> T.t)) option =
     let yes i k = Some (i, fun v -> IT (Const (k v), ty, loc)) in
     match ty with
     | Integer -> yes Interval.int (fun v -> Z v)
@@ -249,7 +250,7 @@ module Solver = struct
     | RT.P _ -> rt
     | RT.Q qpred ->
       let x, t = qpred.q in
-      let loc = IT.get_loc qpred.permission in
+      let loc = T.get_loc qpred.permission in
       (match supported_type loc t with
        | None -> rt
        | Some (tyi, k) ->

--- a/lib/interval.mli
+++ b/lib/interval.mli
@@ -97,9 +97,9 @@ module Intervals : sig
 end
 
 module Solver : sig
-  module IT = IndexTerms
+  module T = Terms.Normal
   module RT = Request
 
   (** Try to simplify a resource type *)
-  val simp_rt : (IT.t -> IT.t option) -> RT.t -> RT.t
+  val simp_rt : (T.t -> T.t option) -> RT.t -> RT.t
 end

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -31,7 +31,7 @@ module PrevDefs = struct
   type t =
     { present : Sym.t list StringListMap.t;
       defs : Pp.document list IntMap.t;
-      dt_params : (IT.t * Id.t * Sym.t) list;
+      dt_params : (Terms.Normal.t * Id.t * Sym.t) list;
       failures : TypeErrors.t list
     }
 
@@ -71,7 +71,7 @@ module PrevDefsMonad = struct
     bind get (fun st ->
       return
         (List.find_opt
-           (fun (it2, m2, _sym) -> IT.equal it it2 && Id.equal m_nm m2)
+           (fun (it2, m2, _sym) -> Terms.Normal.equal it it2 && Id.equal m_nm m2)
            st.dt_params
          |> Option.map (fun (_, _, sym) -> sym)))
 
@@ -84,7 +84,7 @@ module PrevDefsMonad = struct
           (Pp.item
              "dt params available"
              (Pp.brackets
-                (Pp.list (fun (it, m, _) -> Pp.typ (IT.pp it) (Id.pp m)) st.dt_params))));
+                (Pp.list (fun (it, m, _) -> Pp.typ (Terms.pp it) (Id.pp m)) st.dt_params))));
       return ())
 end
 
@@ -166,7 +166,7 @@ let try_coerce_res (ftyp : AT.lemmat) =
       let arg_name, arg_re = r in
       if Request.alpha_equivalent arg_re re then (
         Pp.debug 2 (lazy (Pp.item "erasing" (Sym.pp name)));
-        LRT.subst (IT.make_subst [ (name, IT.sym_ (arg_name, bt, loc)) ]) t)
+        LRT.subst (Terms.Normal.make_subst [ (name, IT.sym_ (arg_name, bt, loc)) ]) t)
       else
         LRT.Resource ((name, (re, bt)), info, erase_res r t)
     | LRT.I ->
@@ -366,7 +366,7 @@ let rec new_nm s nms i =
 
 
 let alpha_rename_if_pp_same s body =
-  let vs = IT.free_vars body in
+  let vs = Terms.Normal.free_vars body in
   let other_nms =
     List.filter (fun sym -> not (Sym.equal sym s)) (Sym.Set.elements vs)
     |> List.map Sym.pp_string
@@ -379,31 +379,31 @@ let alpha_rename_if_pp_same s body =
            "doing rename"
            (Pp.typ (Sym.pp s) (Pp.braces (Pp.list Pp.string other_nms)))));
     let s2 = Sym.fresh (new_nm (Sym.pp_string s) other_nms 0) in
-    let body = IT.subst (IT.make_rename ~from:s ~to_:s2) body in
-    (s2, body, IT.free_vars body))
+    let body = Terms.Normal.subst (Terms.Normal.make_rename ~from:s ~to_:s2) body in
+    (s2, body, Terms.Normal.free_vars body))
   else
     (s, body, vs)
 
 
 let it_adjust (global : Global.t) it =
   let rec f t =
-    let loc = IT.get_loc t in
-    match IT.get_term t with
-    | IT.Binop (And, x1, x2) ->
-      let xs = List.map f [ x1; x2 ] |> List.partition IT.is_true |> snd in
+    let loc = Terms.Normal.get_loc t in
+    match Terms.Normal.get_term t with
+    | Terms.Binop (And, x1, x2) ->
+      let xs = List.map f [ x1; x2 ] |> List.partition Terms.is_true |> snd in
       IT.and_ xs loc
-    | IT.Binop (Or, x1, x2) ->
-      let xs = List.map f [ x1; x2 ] |> List.partition IT.is_false |> snd in
+    | Terms.Binop (Or, x1, x2) ->
+      let xs = List.map f [ x1; x2 ] |> List.partition Terms.is_false |> snd in
       IT.or_ xs loc
-    | IT.Binop (EQ, x, y) ->
+    | Terms.Binop (EQ, x, y) ->
       let x = f x in
       let y = f y in
-      if IT.equal x y then IT.bool_ true loc else IT.eq__ x y loc
-    | IT.Binop (Implies, x, y) ->
+      if Terms.Normal.equal x y then IT.bool_ true loc else IT.eq__ x y loc
+    | Terms.Binop (Implies, x, y) ->
       let x = f x in
       let y = f y in
-      if IT.is_false x || IT.is_true y then IT.bool_ true loc else IT.impl_ (x, y) loc
-    | IT.EachI ((i1, (s, bt), i2), x) ->
+      if Terms.is_false x || Terms.is_true y then IT.bool_ true loc else IT.impl_ (x, y) loc
+    | Terms.EachI ((i1, (s, bt), i2), x) ->
       let x = f x in
       let s, x, vs = alpha_rename_if_pp_same s x in
       if not (Sym.Set.mem s vs) then (
@@ -411,13 +411,13 @@ let it_adjust (global : Global.t) it =
         x)
       else
         IT.eachI_ (i1, (s, bt), i2) x loc
-    | IT.Apply (name, args) ->
+    | Terms.Apply (name, args) ->
       let open Definition.Function in
       let def = Sym.Map.find name global.logical_functions in
       (match (def.body, def.emit_coq) with
        | Def body, false -> f (open_ def.args body args)
        | _ -> t)
-    | IT.Good (ct, t2) ->
+    | Terms.Good (ct, t2) ->
       if Option.is_some (Sctypes.is_struct_ctype ct) then
         t
       else
@@ -427,13 +427,13 @@ let it_adjust (global : Global.t) it =
         t
       else
         f (IT.representable global.struct_decls ct t2 loc)
-    | Aligned t -> f (IT.divisible_ (IT.addr_ t.t loc, t.align) loc)
-    | IT.Let ((nm, x), y) ->
+    | Terms.Aligned t -> f (IT.divisible_ (IT.addr_ t.t loc, t.align) loc)
+    | Terms.Let ((nm, x), y) ->
       let x = f x in
       let y = f y in
       let nm, y, vs = alpha_rename_if_pp_same nm y in
-      if Option.is_some (IT.is_sym x) then
-        IT.subst (IT.make_subst [ (nm, x) ]) y
+      if Option.is_some (Terms.is_sym x) then
+        Terms.Normal.subst (Terms.Normal.make_subst [ (nm, x) ]) y
       else if not (Sym.Set.mem nm vs) then
         y
       else
@@ -441,7 +441,7 @@ let it_adjust (global : Global.t) it =
     | _ -> t
   in
   let res = f it in
-  Pp.debug 9 (lazy (Pp.item "it_adjust" (binop "->" (IT.pp it) (IT.pp res))));
+  Pp.debug 9 (lazy (Pp.item "it_adjust" (binop "->" (Terms.Normal.pp it) (Terms.Normal.pp res))));
   f it
 
 
@@ -854,10 +854,9 @@ let ensure_struct_mem is_good global list_mono loc ct aux =
 
 
 let rec unfold_if_possible global it =
-  let open IT in
   let open Definition.Function in
   match it with
-  | IT (IT.Apply (name, args), _, _) ->
+  | Terms.IT (Terms.Apply (name, args), _, _) ->
     let def = Option.get (Global.get_logical_function_def global name) in
     (match def.body with
      | Rec_Def _ -> it
@@ -917,7 +916,7 @@ let it_to_coq loc global list_mono it =
   in
   let rec f comp_bool t =
     let do_fail msg =
-      fail_m_d loc (Pp.item ("it_to_coq: unsupported " ^ msg) (IT.pp t))
+      fail_m_d loc (Pp.item ("it_to_coq: unsupported " ^ msg) (Terms.Normal.pp t))
     in
     let fail_on_prop () =
       match comp_bool with
@@ -930,13 +929,13 @@ let it_to_coq loc global list_mono it =
              "it_to_coq: unsupported in computational (non-Prop) mode"
              (Pp.flow
                 (Pp.comma ^^ Pp.break 1)
-                [ IT.pp t; !^reason; !^"context:"; IT.pp ctxt ]))
+                [ Terms.Normal.pp t; !^reason; !^"context:"; Terms.Normal.pp ctxt ]))
     in
     let aux t = f comp_bool t in
     let abinop s x y = parensM (build [ aux x; rets s; aux y ]) in
     let enc_prop = Option.is_none comp_bool in
     let with_is_true x =
-      if enc_prop && BaseTypes.equal (IT.get_bt t) BaseTypes.Bool then
+      if enc_prop && BaseTypes.equal (Terms.Normal.get_bt t) BaseTypes.Bool then
         f_appM "Is_true" [ x ]
       else
         x
@@ -950,31 +949,31 @@ let it_to_coq loc global list_mono it =
     let check_pos _t f =
       (* FIXME turning this off for now to test stuff
          let t = unfold_if_possible global t in
-         match IT.is_z t with
+         match Terms.Normal.is_z t with
          | Some i when Z.gt i Z.zero -> f
          | _ -> do_fail "divisor (not positive const)"
       *)
       f
     in
-    match IT.get_term t with
-    | IT.Sym sym -> return (Sym.pp sym)
-    | IT.Const l ->
+    match Terms.Normal.get_term t with
+    | Terms.Sym sym -> return (Sym.pp sym)
+    | Terms.Const l ->
       (match l with
-       | IT.Bool b -> with_is_true (rets (if b then "true" else "false"))
-       | IT.Z z -> enc_z z
-       | IT.Bits (info, z) -> enc_z (BT.normalise_to_range info z)
+       | Terms.Bool b -> with_is_true (rets (if b then "true" else "false"))
+       | Terms.Z z -> enc_z z
+       | Terms.Bits (info, z) -> enc_z (BT.normalise_to_range info z)
        | _ -> do_fail "const")
-    | IT.Unop (op, x) ->
+    | Terms.Unop (op, x) ->
       norm_bv_op
-        (IT.get_bt t)
+        (Terms.Normal.get_bt t)
         (match op with
-         | IT.Not -> f_appM (if enc_prop then "~" else "negb") [ aux x ]
-         | IT.BW_FFS_NoSMT -> f_appM "CN_Lib.find_first_set_z" [ aux x ]
-         | IT.BW_CTZ_NoSMT -> f_appM "CN_Lib.count_trailing_zeroes_z" [ aux x ]
+         | Terms.Not -> f_appM (if enc_prop then "~" else "negb") [ aux x ]
+         | Terms.BW_FFS_NoSMT -> f_appM "CN_Lib.find_first_set_z" [ aux x ]
+         | Terms.BW_CTZ_NoSMT -> f_appM "CN_Lib.count_trailing_zeroes_z" [ aux x ]
          | _ -> do_fail "unary op")
-    | IT.Binop (op, x, y) ->
+    | Terms.Binop (op, x, y) ->
       norm_bv_op
-        (IT.get_bt t)
+        (Terms.Normal.get_bt t)
         (match op with
          | Add -> abinop "+" x y
          | Sub -> abinop "-" x y
@@ -1004,16 +1003,16 @@ let it_to_coq loc global list_mono it =
          | Or -> abinop (if enc_prop then "\\/" else "||") x y
          | Implies -> abinop (if enc_prop then "->" else "implb") x y
          | _ -> do_fail "arith op")
-    | IT.Match (x, cases) ->
+    | Terms.Match (x, cases) ->
       let comp = Some (t, "case-discriminant") in
       let br (pat, rhs) = build [ rets "|"; pat_to_coq pat; rets "=>"; aux rhs ] in
       parensM
         (build
            ([ rets "match"; f comp x; rets "with" ] @ List.map br cases @ [ rets "end" ]))
-    | IT.ITE (sw, x, y) ->
+    | Terms.ITE (sw, x, y) ->
       let comp = Some (t, "if-condition") in
       parensM (build [ rets "if"; f comp sw; rets "then"; aux x; rets "else"; aux y ])
-    | IT.EachI ((i1, (s, _), i2), x) ->
+    | Terms.EachI ((i1, (s, _), i2), x) ->
       let@ () = fail_on_prop () in
       let@ x = aux x in
       let@ enc =
@@ -1032,32 +1031,32 @@ let it_to_coq loc global list_mono it =
              x)
       in
       return (parens enc)
-    | IT.MapSet (m, x, y) ->
+    | Terms.MapSet (m, x, y) ->
       let@ () = ensure_fun_upd () in
-      let@ e = eq_of (IT.get_bt x) in
+      let@ e = eq_of (Terms.Normal.get_bt x) in
       f_appM "fun_upd" [ return e; aux m; aux x; aux y ]
-    | IT.MapGet (m, x) -> parensM (build [ aux m; aux x ])
-    | IT.RecordMember (t, m) ->
-      let flds = BT.record_bt (IT.get_bt t) in
+    | Terms.MapGet (m, x) -> parensM (build [ aux m; aux x ])
+    | Terms.RecordMember (t, m) ->
+      let flds = BT.record_bt (Terms.Normal.get_bt t) in
       if List.length flds == 1 then
         aux t
       else (
         let ix = find_tuple_element Id.equal m Id.pp (List.map fst flds) in
         let@ op_nm = ensure_tuple_op false (Id.get_string m) ix in
         parensM (build [ rets op_nm; aux t ]))
-    | IT.RecordUpdate ((t, m), x) ->
-      let flds = BT.record_bt (IT.get_bt t) in
+    | Terms.RecordUpdate ((t, m), x) ->
+      let flds = BT.record_bt (Terms.Normal.get_bt t) in
       if List.length flds == 1 then
         aux x
       else (
         let ix = find_tuple_element Id.equal m Id.pp (List.map fst flds) in
         let@ op_nm = ensure_tuple_op true (Id.get_string m) ix in
         parensM (build [ rets op_nm; aux t; aux x ]))
-    | IT.Record mems ->
+    | Terms.Record mems ->
       let@ xs = ListM.mapM aux (List.map snd mems) in
       parensM (return (flow (comma ^^ break 1) xs))
-    | IT.StructMember (t, m) ->
-      let tag = BaseTypes.struct_bt (IT.get_bt t) in
+    | Terms.StructMember (t, m) ->
+      let tag = BaseTypes.struct_bt (Terms.Normal.get_bt t) in
       let mems, _bts = get_struct_xs global.struct_decls tag in
       let ix = find_tuple_element Id.equal m Id.pp mems in
       if List.length mems == 1 then
@@ -1065,8 +1064,8 @@ let it_to_coq loc global list_mono it =
       else
         let@ op_nm = ensure_tuple_op false (Id.get_string m) ix in
         parensM (build [ rets op_nm; aux t ])
-    | IT.StructUpdate ((t, m), x) ->
-      let tag = BaseTypes.struct_bt (IT.get_bt t) in
+    | Terms.StructUpdate ((t, m), x) ->
+      let tag = BaseTypes.struct_bt (Terms.Normal.get_bt t) in
       let mems, _bts = get_struct_xs global.struct_decls tag in
       let ix = find_tuple_element Id.equal m Id.pp mems in
       if List.length mems == 1 then
@@ -1074,45 +1073,45 @@ let it_to_coq loc global list_mono it =
       else
         let@ op_nm = ensure_tuple_op true (Id.get_string m) ix in
         parensM (build [ rets op_nm; aux t; aux x ])
-    | IT.Cast (cbt, t) ->
-      (match (IT.get_bt t, cbt) with
+    | Terms.Cast (cbt, t) ->
+      (match (Terms.Normal.get_bt t, cbt) with
        | Integer, Loc () -> aux t
        | Loc (), Integer -> aux t
        | source, target ->
          let source = Pp.plain (BT.pp source) in
          let target = Pp.plain (BT.pp target) in
          do_fail ("cast from " ^ source ^ " to " ^ target))
-    | IT.Apply (name, args) ->
+    | Terms.Apply (name, args) ->
       let prop_ret = fun_prop_ret global name in
       let body_aux = f (if prop_ret then None else Some (t, "fun-arg")) in
       let@ () = ensure_pred global list_mono loc name body_aux in
       let@ r = parensM (build ([ return (Sym.pp name) ] @ List.map body_aux args)) in
       if prop_ret then return r else with_is_true (return r)
-    | IT.Good (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
+    | Terms.Good (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
       let@ () = fail_on_prop () in
       let@ op_nm = ensure_struct_mem true global list_mono loc ct aux in
       parensM (build [ rets op_nm; aux t2 ])
-    | IT.Representable (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
+    | Terms.Representable (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
       let@ () = fail_on_prop () in
       (* FIXME: the 'true' looks strange -- fix *)
       let@ op_nm = ensure_struct_mem true global list_mono loc ct aux in
       parensM (build [ rets op_nm; aux t2 ])
-    | IT.Constructor (nm, id_args) ->
+    | Terms.Constructor (nm, id_args) ->
       let info = Sym.Map.find nm global.datatype_constrs in
       let comp = Some (t, "datatype contents") in
       let@ () = ensure_datatype global list_mono loc info.datatype_tag in
       (* assuming here that the id's are in canonical order *)
       parensM (build ([ return (Sym.pp nm) ] @ List.map (f comp) (List.map snd id_args)))
-    | IT.WrapI (ity, arg) ->
+    | Terms.WrapI (ity, arg) ->
       assert (not (Sctypes.IntegerTypes.equal ity Sctypes.IntegerTypes.Bool));
       let maxInt = Memory.max_integer_type ity in
       let minInt = Memory.min_integer_type ity in
       f_appM "CN_Lib.wrapI" [ enc_z minInt; enc_z maxInt; aux arg ]
-    | IT.Let ((nm, x), y) ->
+    | Terms.Let ((nm, x), y) ->
       let@ x = aux x in
       let@ y = aux y in
       parensM (return (mk_let nm x y))
-    | IT.ArrayShift { base; ct; index } ->
+    | Terms.ArrayShift { base; ct; index } ->
       let size_of_ct = Z.of_int @@ Memory.size_of_ctype ct in
       f_appM "CN_Lib.array_shift" [ aux base; enc_z size_of_ct; aux index ]
     | _ -> do_fail "term kind"
@@ -1123,14 +1122,14 @@ let it_to_coq loc global list_mono it =
 let lc_to_coq_check_triv loc global list_mono = function
   | LC.T it ->
     let it = it_adjust global it in
-    if IT.is_true it then
+    if Terms.is_true it then
       return None
     else
       let@ v = it_to_coq loc global list_mono it in
       return (Some v)
   | LC.Forall ((sym, bt), it) ->
     let it = it_adjust global it in
-    if IT.is_true it then
+    if Terms.is_true it then
       return None
     else
       let@ v = it_to_coq loc global list_mono it in

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -402,7 +402,10 @@ let it_adjust (global : Global.t) it =
     | Terms.Binop (Implies, x, y) ->
       let x = f x in
       let y = f y in
-      if Terms.is_false x || Terms.is_true y then IT.bool_ true loc else IT.impl_ (x, y) loc
+      if Terms.is_false x || Terms.is_true y then
+        IT.bool_ true loc
+      else
+        IT.impl_ (x, y) loc
     | Terms.EachI ((i1, (s, bt), i2), x) ->
       let x = f x in
       let s, x, vs = alpha_rename_if_pp_same s x in
@@ -441,7 +444,9 @@ let it_adjust (global : Global.t) it =
     | _ -> t
   in
   let res = f it in
-  Pp.debug 9 (lazy (Pp.item "it_adjust" (binop "->" (Terms.Normal.pp it) (Terms.Normal.pp res))));
+  Pp.debug
+    9
+    (lazy (Pp.item "it_adjust" (binop "->" (Terms.Normal.pp it) (Terms.Normal.pp res))));
   f it
 
 

--- a/lib/logicalArgumentTypes.ml
+++ b/lib/logicalArgumentTypes.ml
@@ -1,11 +1,11 @@
 open Locations
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Req = Request
 module LC = LogicalConstraints
 
 type 'i t =
-  | Define of (Sym.t * IT.t) * info * 'i t
+  | Define of (Sym.t * T.t) * info * 'i t
   | Resource of (Sym.t * (Req.t * BT.t)) * info * 'i t
   | Constraint of LC.t * info * 'i t
   | I of 'i
@@ -26,7 +26,7 @@ let rec subst i_subst =
   let rec aux (substitution : _ Subst.t) at =
     match at with
     | Define ((name, it), info, t) ->
-      let it = IT.subst substitution it in
+      let it = T.subst substitution it in
       let name, t = suitably_alpha_rename i_subst substitution.relevant name t in
       Define ((name, it), info, aux substitution t)
     | Resource ((name, (re, bt)), info, t) ->
@@ -47,7 +47,7 @@ let rec subst i_subst =
 
 and alpha_rename i_subst s t =
   let s' = Sym.fresh_same s in
-  (s', subst i_subst (IT.make_rename ~from:s ~to_:s') t)
+  (s', subst i_subst (T.make_rename ~from:s ~to_:s') t)
 
 
 and suitably_alpha_rename i_subst syms s t =
@@ -65,7 +65,7 @@ let free_vars_bts i_free_vars_bts =
   in
   let rec aux = function
     | Define ((s, it), _info, t) ->
-      let it_vars = IT.free_vars_bts it in
+      let it_vars = T.free_vars_bts it in
       let t_vars = Sym.Map.remove s (aux t) in
       union it_vars t_vars
     | Resource ((s, (re, _bt)), _info, t) ->
@@ -84,7 +84,7 @@ let free_vars_bts i_free_vars_bts =
 let free_vars i_free_vars =
   let rec aux = function
     | Define ((s, it), _info, t) ->
-      let it_vars = IT.free_vars it in
+      let it_vars = T.free_vars it in
       let t_vars = Sym.Set.remove s (aux t) in
       Sym.Set.union it_vars t_vars
     | Resource ((s, (re, _bt)), _info, t) ->
@@ -124,7 +124,7 @@ open Pp
 
 let rec pp_aux i_pp = function
   | Define ((name, it), _info, t) ->
-    group (!^"let" ^^^ Sym.pp name ^^^ equals ^^^ IT.pp it ^^ semi) :: pp_aux i_pp t
+    group (!^"let" ^^^ Sym.pp name ^^^ equals ^^^ T.pp it ^^ semi) :: pp_aux i_pp t
   | Resource ((name, (re, _bt)), _info, t) ->
     group (!^"take" ^^^ Sym.pp name ^^^ equals ^^^ Req.pp re ^^ semi) :: pp_aux i_pp t
   | Constraint (lc, _info, t) ->
@@ -168,7 +168,7 @@ let binders i_binders i_subst =
   let rec aux = function
     | Define ((s, it), _, t) ->
       let s, t = alpha_rename i_subst s t in
-      (Id.make here (Sym.pp_string s), IT.get_bt it) :: aux t
+      (Id.make here (Sym.pp_string s), T.get_bt it) :: aux t
     | Resource ((s, (_, bt)), _, t) ->
       let s, t = alpha_rename i_subst s t in
       (Id.make here (Sym.pp_string s), bt) :: aux t
@@ -202,7 +202,7 @@ let rec r_resource_requests r =
   | I _ -> []
 
 
-type packing_ft = IT.t t
+type packing_ft = T.t t
 
 type lft = LogicalReturnTypes.t t
 
@@ -219,7 +219,7 @@ open Cerb_frontend.Pp_ast
 let dtree dtree_i =
   let rec aux = function
     | Define ((s, it), _, t) ->
-      Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); IT.dtree it; aux t ])
+      Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); T.dtree it; aux t ])
     | Resource ((s, (rt, bt)), _, t) ->
       Dnode
         (pp_ctor "Resource", [ Dleaf (Sym.pp s); Req.dtree rt; Dleaf (BT.pp bt); aux t ])

--- a/lib/logicalConstraints.ml
+++ b/lib/logicalConstraints.ml
@@ -1,10 +1,11 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 open Pp
 
 type t =
-  | T of IT.t
-  | Forall of (Sym.t * BT.t) * IT.t
+  | T of T.t
+  | Forall of (Sym.t * BT.t) * T.t
 [@@deriving eq, ord]
 
 module Set = Set.Make (struct
@@ -14,45 +15,45 @@ module Set = Set.Make (struct
   end)
 
 let pp = function
-  | T it -> IT.pp it
-  | Forall ((s, bt), it) -> Pp.c_app !^"forall" [ Sym.pp s; BT.pp bt ] ^^ dot ^^^ IT.pp it
+  | T it -> T.pp it
+  | Forall ((s, bt), it) -> Pp.c_app !^"forall" [ Sym.pp s; BT.pp bt ] ^^ dot ^^^ T.pp it
 
 
 let json c : Yojson.Safe.t = `String (Pp.plain (pp c))
 
 let subst su c =
   match c with
-  | T it -> T (IT.subst su it)
+  | T it -> T (T.subst su it)
   | Forall ((s, bt), body) ->
-    let s, body = IT.suitably_alpha_rename su.relevant s body in
-    Forall ((s, bt), IT.subst su body)
+    let s, body = T.suitably_alpha_rename su.relevant s body in
+    Forall ((s, bt), T.subst su body)
 
 
-let subst_ su c = subst (IT.make_subst su) c
+let subst_ su c = subst (T.make_subst su) c
 
 let free_vars_bts = function
-  | T c -> IT.free_vars_bts c
-  | Forall ((s, _), body) -> Sym.Map.remove s (IT.free_vars_bts body)
+  | T c -> T.free_vars_bts c
+  | Forall ((s, _), body) -> Sym.Map.remove s (T.free_vars_bts body)
 
 
 let free_vars = function
-  | T c -> IT.free_vars c
-  | Forall ((s, _), body) -> Sym.Set.remove s (IT.free_vars body)
+  | T c -> T.free_vars c
+  | Forall ((s, _), body) -> Sym.Set.remove s (T.free_vars body)
 
 
 let alpha_equivalent lc lc' =
   match (lc, lc') with
-  | T c, T c' -> IT.equal c c'
+  | T c, T c' -> T.equal c c'
   | Forall ((s, bt), c), Forall ((s', bt'), c') ->
     BT.equal bt bt'
     &&
     if Sym.equal s s' then
-      IT.equal c c'
+      T.equal c c'
     else (
       let new_s = Sym.fresh_same s in
-      let c = IT.subst (IT.make_rename ~from:s ~to_:new_s) c in
-      let c' = IT.subst (IT.make_rename ~from:s' ~to_:new_s) c' in
-      IT.equal c c')
+      let c = T.subst (T.make_rename ~from:s ~to_:new_s) c in
+      let c' = T.subst (T.make_rename ~from:s' ~to_:new_s) c' in
+      T.equal c c')
   | _ -> false
 
 
@@ -60,16 +61,16 @@ let forall_ (s, bt) it = Forall ((s, bt), it)
 
 let is_sym_lhs_equality = function
   | T t ->
-    (match IT.is_eq t with
+    (match Terms.is_eq t with
      | Some (lhs, rhs) ->
-       (match IT.is_sym lhs with Some (s, _) -> Some (s, rhs) | _ -> None)
+       (match Terms.is_sym lhs with Some (s, _) -> Some (s, rhs) | _ -> None)
      | _ -> None)
   | _ -> None
 
 
 let is_sym_equality t =
   match is_sym_lhs_equality t with
-  | Some (s, rhs) -> (match IT.is_sym rhs with Some (s', _) -> Some (s, s') | _ -> None)
+  | Some (s, rhs) -> (match Terms.is_sym rhs with Some (s', _) -> Some (s, s') | _ -> None)
   | _ -> None
 
 
@@ -85,8 +86,8 @@ let is_equality = function
 let equates_to it2 = function
   | T it ->
     (match it with
-     | IT (Binop (EQ, a, b), _, _) when IT.equal a it2 -> Some b
-     | IT (Binop (EQ, a, b), _, _) when IT.equal b it2 -> Some a
+     | IT (Binop (EQ, a, b), _, _) when T.equal a it2 -> Some b
+     | IT (Binop (EQ, a, b), _, _) when T.equal b it2 -> Some a
      | _ -> None)
   | _ -> None
 
@@ -94,8 +95,8 @@ let equates_to it2 = function
 let dtree =
   let open Cerb_frontend.Pp_ast in
   function
-  | T it -> Dnode (pp_ctor "T", [ IT.dtree it ])
-  | Forall ((s, _bt), t) -> Dnode (pp_ctor "Forall", [ Dleaf (Sym.pp s); IT.dtree t ])
+  | T it -> Dnode (pp_ctor "T", [ T.dtree it ])
+  | Forall ((s, _bt), t) -> Dnode (pp_ctor "Forall", [ Dleaf (Sym.pp s); T.dtree t ])
 
 
 let is_forall : t -> bool = fun c -> match c with T _ -> false | Forall _ -> true
@@ -110,13 +111,13 @@ let is_interesting : t -> bool =
 
 
 (** make `lc` conditional on `it` *)
-let impl loc (it : IT.t) (lc : t) : t =
+let impl loc (it : T.t) (lc : t) : t =
   match lc with
   | T t -> T (IT.impl_ (it, t) loc)
   | Forall ((s, bt), t) ->
-    let s, t = IT.alpha_rename s t in
+    let s, t = T.alpha_rename s t in
     Forall ((s, bt), IT.impl_ (it, t) loc)
 
 
 let preds_of (lc : t) : Sym.Set.t =
-  match lc with T it | Forall (_, it) -> IT.preds_of it
+  match lc with T it | Forall (_, it) -> Terms.preds_of it

--- a/lib/logicalConstraints.ml
+++ b/lib/logicalConstraints.ml
@@ -70,7 +70,8 @@ let is_sym_lhs_equality = function
 
 let is_sym_equality t =
   match is_sym_lhs_equality t with
-  | Some (s, rhs) -> (match Terms.is_sym rhs with Some (s', _) -> Some (s, s') | _ -> None)
+  | Some (s, rhs) ->
+    (match Terms.is_sym rhs with Some (s', _) -> Some (s, s') | _ -> None)
   | _ -> None
 
 

--- a/lib/logicalConstraints.mli
+++ b/lib/logicalConstraints.mli
@@ -1,6 +1,6 @@
 type t =
-  | T of IndexTerms.t
-  | Forall of (Sym.t * BaseTypes.t) * IndexTerms.t
+  | T of Terms.Normal.t
+  | Forall of (Sym.t * BaseTypes.t) * Terms.Normal.t
 
 val equal : t -> t -> bool
 
@@ -12,9 +12,9 @@ val pp : t -> Pp.document
 
 val json : t -> Yojson.Safe.t
 
-val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
-val subst_ : (Sym.t * IndexTerms.t) list -> t -> t
+val subst_ : (Sym.t * Terms.Normal.t) list -> t -> t
 
 val free_vars_bts : t -> BaseTypes.t Sym.Map.t
 
@@ -24,15 +24,15 @@ val preds_of : t -> Sym.Set.t
 
 val alpha_equivalent : t -> t -> bool
 
-val forall_ : Sym.t * BaseTypes.t -> IndexTerms.t -> t
+val forall_ : Sym.t * BaseTypes.t -> Terms.Normal.t -> t
 
-val is_sym_lhs_equality : t -> (Sym.t * IndexTerms.t) option
+val is_sym_lhs_equality : t -> (Sym.t * Terms.Normal.t) option
 
 val is_sym_equality : t -> (Sym.t * Sym.t) option
 
-val is_equality : t -> ((IndexTerms.t * IndexTerms.t) * bool) option
+val is_equality : t -> ((Terms.Normal.t * Terms.Normal.t) * bool) option
 
-val equates_to : IndexTerms.t -> t -> IndexTerms.t option
+val equates_to : Terms.Normal.t -> t -> Terms.Normal.t option
 
 val dtree : t -> Cerb_frontend.Pp_ast.doc_tree
 
@@ -40,4 +40,4 @@ val is_forall : t -> bool
 
 val is_interesting : t -> bool
 
-val impl : Locations.t -> IndexTerms.t -> t -> t
+val impl : Locations.t -> Terms.Normal.t -> t -> t

--- a/lib/logicalReturnTypes.ml
+++ b/lib/logicalReturnTypes.ml
@@ -1,11 +1,11 @@
 open Locations
 module BT = BaseTypes
 module RT = Request
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 
 type t =
-  | Define of (Sym.t * IT.t) * info * t
+  | Define of (Sym.t * T.t) * info * t
   | Resource of (Sym.t * (RT.t * BT.t)) * info * t
   | Constraint of LogicalConstraints.t * info * t
   | I
@@ -25,7 +25,7 @@ let mConstraints = List.fold_right mConstraint
 let rec subst (substitution : _ Subst.t) lrt =
   match lrt with
   | Define ((name, it), info, t) ->
-    let it = IT.subst substitution it in
+    let it = T.subst substitution it in
     let name, t = suitably_alpha_rename substitution.relevant name t in
     Define ((name, it), info, subst substitution t)
   | Resource ((name, (re, bt)), info, t) ->
@@ -45,7 +45,7 @@ and alpha_rename_ ~from ~to_ t =
     if Sym.equal from to_ then
       t
     else
-      subst (IT.make_rename ~from ~to_) t )
+      subst (T.make_rename ~from ~to_) t )
 
 
 and alpha_rename from t =
@@ -88,7 +88,7 @@ let binders =
   let rec aux = function
     | Define ((s, it), _, t) ->
       let s, t = alpha_rename s t in
-      (Id.make here (Sym.pp_string s), IT.get_bt it) :: aux t
+      (Id.make here (Sym.pp_string s), T.get_bt it) :: aux t
     | Resource ((s, (_, bt)), _, t) ->
       let s, t = alpha_rename s t in
       (Id.make here (Sym.pp_string s), bt) :: aux t
@@ -100,7 +100,7 @@ let binders =
 
 let free_vars lrt =
   let rec f = function
-    | Define ((nm, it), _, t) -> Sym.Set.union (IT.free_vars it) (Sym.Set.remove nm (f t))
+    | Define ((nm, it), _, t) -> Sym.Set.union (T.free_vars it) (Sym.Set.remove nm (f t))
     | Resource ((nm, (re, _)), _, t) ->
       Sym.Set.union (RT.free_vars re) (Sym.Set.remove nm (f t))
     | Constraint (lc, _, t) -> Sym.Set.union (LogicalConstraints.free_vars lc) (f t)
@@ -131,7 +131,7 @@ let rec pp_aux lrt =
   let open Pp in
   match lrt with
   | Define ((name, it), _info, t) ->
-    group (!^"let" ^^^ Sym.pp name ^^^ equals ^^^ IT.pp it ^^ semi) :: pp_aux t
+    group (!^"let" ^^^ Sym.pp name ^^^ equals ^^^ T.pp it ^^ semi) :: pp_aux t
   | Resource ((name, (re, _bt)), _info, t) ->
     group (!^"take" ^^^ Sym.pp name ^^^ equals ^^^ RT.pp re ^^ semi) :: pp_aux t
   | Constraint (lc, _info, t) ->
@@ -148,7 +148,7 @@ let rec alpha_equivalent lrt lrt' =
     let new_s = if Sym.equal s s' then s else Sym.fresh_same s in
     let _, lrt = alpha_rename_ ~to_:new_s ~from:s lrt in
     let _, lrt' = alpha_rename_ ~to_:new_s ~from:s' lrt' in
-    IT.equal it it' && alpha_equivalent lrt lrt'
+    T.equal it it' && alpha_equivalent lrt lrt'
   | Resource ((s, (re, bt)), _, lrt), Resource ((s', (re', bt')), _, lrt') ->
     let new_s = if Sym.equal s s' then s else Sym.fresh_same s in
     let _, lrt = alpha_rename_ ~to_:new_s ~from:s lrt in
@@ -165,7 +165,7 @@ open Pp
 
 let rec dtree = function
   | Define ((s, it), _, t) ->
-    Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); IT.dtree it; dtree t ])
+    Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); T.dtree it; dtree t ])
   | Resource ((s, (rt, bt)), _, t) ->
     Dnode
       (pp_ctor "Resource", [ Dleaf (Sym.pp s); RT.dtree rt; Dleaf (BT.pp bt); dtree t ])

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -171,7 +171,7 @@ type 'TY expr_ =
   | Eaction of 'TY paction
   | Eskip
   | Eccall of
-      act * 'TY pexpr * 'TY pexpr list * (Locations.t * IndexTerms.t Cnprog.t list) option
+      act * 'TY pexpr * 'TY pexpr list * (Locations.t * Terms.Normal.t Cnprog.t list) option
   | Eproc of Sym.t generic_name * 'TY pexpr list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
@@ -200,7 +200,7 @@ type 'TY globs =
   | GlobalDecl of Sctypes.t
 
 type 'i arguments_l =
-  | Define of (Sym.t * IndexTerms.t) * Locations.info * 'i arguments_l
+  | Define of (Sym.t * Terms.Normal.t) * Locations.info * 'i arguments_l
   | Resource of (Sym.t * (Request.t * BaseTypes.t)) * Locations.info * 'i arguments_l
   | Constraint of LogicalConstraints.t * Locations.info * 'i arguments_l
   | I of 'i
@@ -223,11 +223,10 @@ type 'i arguments =
 let mComputational (bound, info) t = Computational (bound, info, t)
 
 let dtree_of_arguments_l dtree_i =
-  let module IT = IndexTerms in
   let open Cerb_frontend.Pp_ast in
   let rec aux = function
     | Define ((s, it), _, t) ->
-      Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); IT.dtree it; aux t ])
+      Dnode (pp_ctor "Define", [ Dleaf (Sym.pp s); Terms.dtree it; aux t ])
     | Resource ((s, (rt, bt)), _, t) ->
       Dnode
         ( pp_ctor "Resource",

--- a/lib/mucore.ml
+++ b/lib/mucore.ml
@@ -171,7 +171,10 @@ type 'TY expr_ =
   | Eaction of 'TY paction
   | Eskip
   | Eccall of
-      act * 'TY pexpr * 'TY pexpr list * (Locations.t * Terms.Normal.t Cnprog.t list) option
+      act
+      * 'TY pexpr
+      * 'TY pexpr list
+      * (Locations.t * Terms.Normal.t Cnprog.t list) option
   | Eproc of Sym.t generic_name * 'TY pexpr list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -149,7 +149,7 @@ type 'TY expr_ =
   | Eaction of 'TY paction
   | Eskip
   | Eccall of
-      act * 'TY pexpr * 'TY pexpr list * (Locations.t * IndexTerms.t Cnprog.t list) option
+      act * 'TY pexpr * 'TY pexpr list * (Locations.t * Terms.Normal.t Cnprog.t list) option
   | Eproc of Sym.t generic_name * 'TY pexpr list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
@@ -176,12 +176,12 @@ type 'TY globs =
   | GlobalDecl of Sctypes.t
 
 type 'i arguments_l =
-  | Define of (Sym.t * IndexTerms.t) * Locations.info * 'i arguments_l
+  | Define of (Sym.t * Terms.Normal.t) * Locations.info * 'i arguments_l
   | Resource of (Sym.t * (Request.t * BaseTypes.t)) * Locations.info * 'i arguments_l
   | Constraint of LogicalConstraints.t * Locations.info * 'i arguments_l
   | I of 'i
 
-val mDefine : (Sym.t * IndexTerms.t) * Locations.info -> 'a arguments_l -> 'a arguments_l
+val mDefine : (Sym.t * Terms.Normal.t) * Locations.info -> 'a arguments_l -> 'a arguments_l
 
 val mConstraint
   :  LogicalConstraints.t * Locations.info ->

--- a/lib/mucore.mli
+++ b/lib/mucore.mli
@@ -149,7 +149,10 @@ type 'TY expr_ =
   | Eaction of 'TY paction
   | Eskip
   | Eccall of
-      act * 'TY pexpr * 'TY pexpr list * (Locations.t * Terms.Normal.t Cnprog.t list) option
+      act
+      * 'TY pexpr
+      * 'TY pexpr list
+      * (Locations.t * Terms.Normal.t Cnprog.t list) option
   | Eproc of Sym.t generic_name * 'TY pexpr list
   | Elet of 'TY pattern * 'TY pexpr * 'TY expr
   | Eunseq of 'TY expr list
@@ -181,7 +184,10 @@ type 'i arguments_l =
   | Constraint of LogicalConstraints.t * Locations.info * 'i arguments_l
   | I of 'i
 
-val mDefine : (Sym.t * Terms.Normal.t) * Locations.info -> 'a arguments_l -> 'a arguments_l
+val mDefine
+  :  (Sym.t * Terms.Normal.t) * Locations.info ->
+  'a arguments_l ->
+  'a arguments_l
 
 val mConstraint
   :  LogicalConstraints.t * Locations.info ->

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -2,6 +2,7 @@ open Request
 open Resource
 open Definition
 open Memory
+module T = Terms.Normal
 module IT = IndexTerms
 module LAT = LogicalArgumentTypes
 module LRT = LogicalReturnTypes
@@ -28,7 +29,7 @@ let unfolded_array loc init (ict, olength) pointer =
   Q
     { name = Owned (ict, init);
       pointer;
-      q = (q_s, IT.get_bt q);
+      q = (q_s, T.get_bt q);
       q_loc = loc;
       step = ict;
       iargs = [];
@@ -48,7 +49,7 @@ let packing_ft ~full loc global provable ret =
      | Owned ((Array (ict, olength) as ct), init) ->
        let qpred = unfolded_array loc init (ict, olength) ret.pointer in
        let o_s, o = IT.fresh_named (Memory.bt_of_sct ct) "value" loc in
-       let at = LAT.Resource ((o_s, (qpred, IT.get_bt o)), (loc, None), LAT.I o) in
+       let at = LAT.Resource ((o_s, (qpred, T.get_bt o)), (loc, None), LAT.I o) in
        Some at
      | Owned (Struct tag, init) ->
        let layout = Sym.Map.find tag global.Global.struct_decls in
@@ -68,7 +69,7 @@ let packing_ft ~full loc global provable ret =
                   IT.fresh_named (Memory.bt_of_sct mct) (Id.get_string member) loc
                 in
                 ( LRT.Resource
-                    ((m_value_s, (request, IT.get_bt m_value)), (loc, None), lrt),
+                    ((m_value_s, (request, T.get_bt m_value)), (loc, None), lrt),
                   (member, m_value) :: value )
               | None ->
                 let padding_ct = Sctypes.Array (Sctypes.char_ct, Some size) in
@@ -86,7 +87,7 @@ let packing_ft ~full loc global provable ret =
                   IT.fresh_named (Memory.bt_of_sct padding_ct) "padding" loc
                 in
                 ( LRT.Resource
-                    ((padding_s, (request, IT.get_bt padding)), (loc, None), lrt),
+                    ((padding_s, (request, T.get_bt padding)), (loc, None), lrt),
                   value ))
            layout
            (LRT.I, [])
@@ -167,9 +168,9 @@ let extractable_one (* global *) provable (predicate_name, index) (ret, O o) =
   match ret with
   | Q ret
     when Request.equal_name predicate_name ret.name
-         && BT.equal (IT.get_bt index) (snd ret.q) ->
-    let su = IT.make_subst [ (fst ret.q, index) ] in
-    let index_permission = IT.subst su ret.permission in
+         && BT.equal (T.get_bt index) (snd ret.q) ->
+    let su = T.make_subst [ (fst ret.q, index) ] in
+    let index_permission = T.subst su ret.permission in
     (match provable (LC.T index_permission) with
      | `True ->
        let loc = Cerb_location.other __LOC__ in
@@ -177,7 +178,7 @@ let extractable_one (* global *) provable (predicate_name, index) (ret, O o) =
          ( P
              { name = ret.name;
                pointer = IT.(arrayShift_ ~base:ret.pointer ~index ret.step loc);
-               iargs = List.map (IT.subst su) ret.iargs
+               iargs = List.map (T.subst su) ret.iargs
              },
            O (IT.map_get_ o index loc) )
        in
@@ -190,7 +191,7 @@ let extractable_one (* global *) provable (predicate_name, index) (ret, O o) =
                  loc)
          }
        in
-       (* tmsg "successfully extracted" (lazy (IT.pp index)); *)
+       (* tmsg "successfully extracted" (lazy (T.pp index)); *)
        Some ((Q ret_reduced, O o), at_index)
      | `False -> None)
   | _ -> None

--- a/lib/pack.ml
+++ b/lib/pack.ml
@@ -68,8 +68,7 @@ let packing_ft ~full loc global provable ret =
                 let m_value_s, m_value =
                   IT.fresh_named (Memory.bt_of_sct mct) (Id.get_string member) loc
                 in
-                ( LRT.Resource
-                    ((m_value_s, (request, T.get_bt m_value)), (loc, None), lrt),
+                ( LRT.Resource ((m_value_s, (request, T.get_bt m_value)), (loc, None), lrt),
                   (member, m_value) :: value )
               | None ->
                 let padding_ct = Sctypes.Array (Sctypes.char_ct, Some size) in
@@ -86,8 +85,7 @@ let packing_ft ~full loc global provable ret =
                 let padding_s, padding =
                   IT.fresh_named (Memory.bt_of_sct padding_ct) "padding" loc
                 in
-                ( LRT.Resource
-                    ((padding_s, (request, T.get_bt padding)), (loc, None), lrt),
+                ( LRT.Resource ((padding_s, (request, T.get_bt padding)), (loc, None), lrt),
                   value ))
            layout
            (LRT.I, [])

--- a/lib/pp_mucore.ml
+++ b/lib/pp_mucore.ml
@@ -538,7 +538,7 @@ module Make (Config : CONFIG) = struct
              ^^ Pp.parens
                   (Cn_Pp.list
                      Pp_ast.pp_doc_tree
-                     (List.map (Cnprog.dtree IndexTerms.dtree) ghost_args))
+                     (List.map (Cnprog.dtree Terms.dtree) ghost_args))
            | Eproc (fn, args) ->
              let fn = match fn with Sym s -> Sym.pp s | Impl i -> pp_impl i in
              Cn_Pp.c_app fn (List.map pp_pexpr args)
@@ -621,7 +621,7 @@ module Make (Config : CONFIG) = struct
 
   let rec pp_arguments_l ppf = function
     | Define ((s, it), _info, l) ->
-      Pp.parens (!^"let" ^^^ pp_symbol s ^^^ Pp.equals ^^^ IndexTerms.pp it)
+      Pp.parens (!^"let" ^^^ pp_symbol s ^^^ Pp.equals ^^^ Terms.Normal.pp it)
       ^^^ pp_arguments_l ppf l
     | Resource ((s, (re, _bt)), _info, l) ->
       Pp.parens (!^"let" ^^^ pp_symbol s ^^^ Pp.equals ^^^ Request.pp re)

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1168,14 +1168,14 @@ let pp_const = function
   | Terms.Default bt -> pp_constructor "Terms.Default" [ pp_basetype pp_unit bt ]
 
 
-let rec pp_index_term (IndexTerms.IT (term, bt, loc)) =
+let rec pp_index_term (Terms.IT (term, bt, loc)) =
   pp_constructor1
     "IT"
     [ pp_index_term_content term; pp_basetype pp_unit bt; pp_location loc ]
 
 
 and pp_index_term_content = function
-  | IndexTerms.Const c -> pp_constructor1 "Const" [ pp_const c ]
+  | Terms.Const c -> pp_constructor1 "Const" [ pp_const c ]
   | Sym s -> pp_constructor1 "Sym" [ pp_symbol s ]
   | Unop (op, t) -> pp_constructor1 "Unop" [ pp_unop op; pp_index_term t ]
   | Binop (op, t1, t2) ->

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -64,8 +64,7 @@ module Predicate = struct
     let open Cerb_frontend.Pp_ast in
     Dnode
       ( pp_ctor "pred",
-        dtree_of_name pred.name :: T.dtree pred.pointer :: List.map T.dtree pred.iargs
-      )
+        dtree_of_name pred.name :: T.dtree pred.pointer :: List.map T.dtree pred.iargs )
 end
 
 let make_alloc pointer = Predicate.{ name = alloc; pointer; iargs = [] }

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -1,7 +1,7 @@
 open Pp.Infix
-module IT = IndexTerms
+module T = Terms.Normal
 
-let pp_maybe_oargs = function None -> Pp.empty | Some oargs -> Pp.parens (IT.pp oargs)
+let pp_maybe_oargs = function None -> Pp.empty | Some oargs -> Pp.parens (T.pp oargs)
 
 type init =
   | Init
@@ -43,20 +43,20 @@ module Predicate = struct
 
   type t =
     { name : name;
-      pointer : IT.t; (* I *)
-      iargs : IT.t list (* I *)
+      pointer : T.t; (* I *)
+      iargs : T.t list (* I *)
     }
   [@@deriving eq, ord]
 
   let pp_aux (p : t) oargs =
-    let args = List.map IT.pp (p.pointer :: p.iargs) in
+    let args = List.map T.pp (p.pointer :: p.iargs) in
     Pp.c_app (pp_name p.name) args ^^ pp_maybe_oargs oargs
 
 
   let subst substitution (p : t) =
     { name = p.name;
-      pointer = IT.subst substitution p.pointer;
-      iargs = List.map (IT.subst substitution) p.iargs
+      pointer = T.subst substitution p.pointer;
+      iargs = List.map (T.subst substitution) p.iargs
     }
 
 
@@ -64,7 +64,7 @@ module Predicate = struct
     let open Cerb_frontend.Pp_ast in
     Dnode
       ( pp_ctor "pred",
-        dtree_of_name pred.name :: IT.dtree pred.pointer :: List.map IT.dtree pred.iargs
+        dtree_of_name pred.name :: T.dtree pred.pointer :: List.map T.dtree pred.iargs
       )
 end
 
@@ -73,36 +73,36 @@ let make_alloc pointer = Predicate.{ name = alloc; pointer; iargs = [] }
 module QPredicate = struct
   type t =
     { name : name;
-      pointer : IT.t; (* I *)
+      pointer : T.t; (* I *)
       q : Sym.t * BaseTypes.t;
       q_loc : Locations.t; [@equal fun _ _ -> true] [@compare fun _ _ -> 0]
       step : Sctypes.ctype;
-      permission : IT.t; (* I, function of q *)
-      iargs : IT.t list (* I, function of q *)
+      permission : T.t; (* I, function of q *)
+      iargs : T.t list (* I, function of q *)
     }
   [@@deriving eq, ord]
 
   let pp_aux (p : t) oargs =
     let open Pp in
     let pointer =
-      IT.pp p.pointer ^^^ plus ^^^ Sym.pp (fst p.q) ^^^ at ^^^ Sctypes.pp p.step
+      T.pp p.pointer ^^^ plus ^^^ Sym.pp (fst p.q) ^^^ at ^^^ Sctypes.pp p.step
     in
-    let args = pointer :: List.map IT.pp p.iargs in
+    let args = pointer :: List.map T.pp p.iargs in
     !^"each"
-    ^^ parens (BaseTypes.pp (snd p.q) ^^^ Sym.pp (fst p.q) ^^ semi ^^^ IT.pp p.permission)
+    ^^ parens (BaseTypes.pp (snd p.q) ^^^ Sym.pp (fst p.q) ^^ semi ^^^ T.pp p.permission)
     ^/^ braces (c_app (pp_name p.name) args)
     ^^ pp_maybe_oargs oargs
 
 
   let alpha_rename_ (q' : Sym.t) (qp : t) =
-    let subst = IT.make_rename ~from:(fst qp.q) ~to_:q' in
+    let subst = T.make_rename ~from:(fst qp.q) ~to_:q' in
     { name = qp.name;
       pointer = qp.pointer;
       q = (q', snd qp.q);
       q_loc = qp.q_loc;
       step = qp.step;
-      permission = IT.subst subst qp.permission;
-      iargs = List.map (IT.subst subst) qp.iargs
+      permission = T.subst subst qp.permission;
+      iargs = List.map (T.subst subst) qp.iargs
     }
 
 
@@ -116,12 +116,12 @@ module QPredicate = struct
         qp
     in
     { name = qp.name;
-      pointer = IT.subst substitution qp.pointer;
+      pointer = T.subst substitution qp.pointer;
       q = qp.q;
       q_loc = qp.q_loc;
       step = qp.step;
-      permission = IT.subst substitution qp.permission;
-      iargs = List.map (IT.subst substitution) qp.iargs
+      permission = T.subst substitution qp.permission;
+      iargs = List.map (T.subst substitution) qp.iargs
     }
 
 
@@ -131,21 +131,21 @@ module QPredicate = struct
       ( pp_ctor "qpred",
         Dleaf (Pp.parens (Pp.typ (Sym.pp (fst qpred.q)) (BaseTypes.pp (snd qpred.q))))
         :: Dleaf (Sctypes.pp qpred.step)
-        :: IT.dtree qpred.permission
+        :: T.dtree qpred.permission
         :: dtree_of_name qpred.name
-        :: IT.dtree qpred.pointer
-        :: List.map IT.dtree qpred.iargs )
+        :: T.dtree qpred.pointer
+        :: List.map T.dtree qpred.iargs )
 
 
-  let get_lower_bound (qpred : t) : IT.t =
+  let get_lower_bound (qpred : t) : T.t =
     IndexTerms.Bounds.get_lower_bound qpred.q qpred.permission
 
 
-  let get_upper_bound (qpred : t) : IT.t =
+  let get_upper_bound (qpred : t) : T.t =
     IndexTerms.Bounds.get_upper_bound qpred.q qpred.permission
 
 
-  let get_bounds (qpred : t) : IT.t * IT.t = (get_lower_bound qpred, get_upper_bound qpred)
+  let get_bounds (qpred : t) : T.t * T.t = (get_lower_bound qpred, get_upper_bound qpred)
 end
 
 type t =
@@ -173,22 +173,22 @@ let subst (substitution : _ Subst.t) = function
 
 
 let free_vars_bts = function
-  | P p -> IT.free_vars_bts_list (p.pointer :: p.iargs)
+  | P p -> T.free_vars_bts_list (p.pointer :: p.iargs)
   | Q p ->
     Sym.Map.union
       (fun _ bt1 bt2 ->
          assert (BaseTypes.equal bt1 bt2);
          Some bt1)
-      (IT.free_vars_bts_list [ p.pointer ])
-      (Sym.Map.remove (fst p.q) (IT.free_vars_bts_list (p.permission :: p.iargs)))
+      (T.free_vars_bts_list [ p.pointer ])
+      (Sym.Map.remove (fst p.q) (T.free_vars_bts_list (p.permission :: p.iargs)))
 
 
 let free_vars = function
-  | P p -> IT.free_vars_list (p.pointer :: p.iargs)
+  | P p -> T.free_vars_list (p.pointer :: p.iargs)
   | Q p ->
     Sym.Set.union
-      (IT.free_vars p.pointer)
-      (Sym.Set.remove (fst p.q) (IT.free_vars_list (p.permission :: p.iargs)))
+      (T.free_vars p.pointer)
+      (Sym.Set.remove (fst p.q) (T.free_vars_list (p.permission :: p.iargs)))
 
 
 let alpha_equivalent r1 r2 =

--- a/lib/request.mli
+++ b/lib/request.mli
@@ -18,43 +18,43 @@ val subsumed : name -> name -> bool
 module Predicate : sig
   type t =
     { name : name;
-      pointer : IndexTerms.t;
-      iargs : IndexTerms.t list
+      pointer : Terms.Normal.t;
+      iargs : Terms.Normal.t list
     }
 
   val alloc : name
 
-  val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+  val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
   val dtree : t -> Cerb_frontend.Pp_ast.doc_tree
 end
 
-val make_alloc : IndexTerms.t -> Predicate.t
+val make_alloc : Terms.Normal.t -> Predicate.t
 
 module QPredicate : sig
   type t =
     { name : name;
-      pointer : IndexTerms.t;
+      pointer : Terms.Normal.t;
       q : Sym.t * BaseTypes.t;
       q_loc : Locations.t;
       step : Sctypes.ctype;
-      permission : IndexTerms.t;
-      iargs : IndexTerms.t list
+      permission : Terms.Normal.t;
+      iargs : Terms.Normal.t list
     }
 
   val alpha_rename_ : Sym.t -> t -> t
 
   val alpha_rename : t -> t
 
-  val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+  val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
   val dtree : t -> Cerb_frontend.Pp_ast.doc_tree
 
-  val get_lower_bound : t -> IndexTerms.t
+  val get_lower_bound : t -> Terms.Normal.t
 
-  val get_upper_bound : t -> IndexTerms.t
+  val get_upper_bound : t -> Terms.Normal.t
 
-  val get_bounds : t -> IndexTerms.t * IndexTerms.t
+  val get_bounds : t -> Terms.Normal.t * Terms.Normal.t
 end
 
 type t =
@@ -75,9 +75,9 @@ val pp : t -> Pp.document
 
 val json : t -> Yojson.Safe.t
 
-val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
-val free_vars_bts : t -> IndexTerms.BT.t Sym.Map.t
+val free_vars_bts : t -> Terms.Normal.BT.t Sym.Map.t
 
 val free_vars : t -> Sym.Set.t
 
@@ -85,4 +85,4 @@ val alpha_equivalent : t -> t -> bool
 
 val dtree : t -> Cerb_frontend.Pp_ast.doc_tree
 
-val get_pointer : t -> IndexTerms.t
+val get_pointer : t -> Terms.Normal.t

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -1,9 +1,10 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module Req = Request
 
-type output = O of IT.t [@@ocaml.unboxed] [@@deriving eq]
+type output = O of T.t [@@ocaml.unboxed] [@@deriving eq]
 
-let pp_output (O t) = IT.pp t
+let pp_output (O t) = T.pp t
 
 type predicate = Req.Predicate.t * output
 
@@ -16,10 +17,10 @@ let pp (r, O output) = Req.pp_aux r (Some output)
 let json re : Yojson.Safe.t = `String (Pp.plain (pp re))
 
 let subst substitution ((r, O oargs) : t) =
-  (Req.subst substitution r, O (IT.subst substitution oargs))
+  (Req.subst substitution r, O (T.subst substitution oargs))
 
 
-let free_vars (r, O oargs) = Sym.Set.union (Req.free_vars r) (IT.free_vars oargs)
+let free_vars (r, O oargs) = Sym.Set.union (Req.free_vars r) (T.free_vars oargs)
 
 (* assumption: the resource is owned *)
 let derived_lc1 ((resource : Req.t), O output) =

--- a/lib/resource.mli
+++ b/lib/resource.mli
@@ -1,4 +1,4 @@
-type output = O of IndexTerms.t [@@unboxed]
+type output = O of Terms.Normal.t [@@unboxed]
 
 val pp_output : output -> Pp.document
 
@@ -14,14 +14,14 @@ val pp : Request.t * output -> Pp.document
 
 val json : Request.t * output -> Yojson.Safe.t
 
-val subst : [ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> t -> t
+val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
 val free_vars : t -> Sym.Set.t
 
-val derived_lc1 : t -> IndexTerms.t list
+val derived_lc1 : t -> Terms.Normal.t list
 
-val derived_lc2 : t -> t -> IndexTerms.t list
+val derived_lc2 : t -> t -> Terms.Normal.t list
 
 val disable_resource_derived_constraints : bool ref
 
-val pointer_facts : new_resource:t -> old_resources:t list -> IndexTerms.t list
+val pointer_facts : new_resource:t -> old_resources:t list -> Terms.Normal.t list

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -16,15 +16,15 @@ let debug_constraint_failure_diagnostics
 (* if !Pp.print_level == 0 then *)
 (*   () *)
 (* else ( *)
-(*   let pp_f = IT.pp_with_eval (Solver.eval model) in *)
+(*   let pp_f = Terms.Normal.pp_with_eval (Solver.eval model) in *)
 (*   let diag msg c = *)
 (*     match (c, model_with_q) with *)
 (*     | LC.T tm, _ -> *)
-(*       Pp.debug lvl (lazy (Pp.item msg (IT.pp tm))); *)
+(*       Pp.debug lvl (lazy (Pp.item msg (Terms.Normal.pp tm))); *)
 (*       Pp.debug lvl (lazy (pp_f tm)) *)
 (*     | LC.Forall ((sym, _bt), tm), (_, [ (sym', _bt') ]) -> *)
-(*       let tm' = IT.subst (IT.make_rename ~from:sym ~to_:sym') tm in *)
-(*       Pp.debug lvl (lazy (Pp.item ("quantified " ^ msg) (IT.pp tm))); *)
+(*       let tm' = Terms.Normal.subst (Terms.Normal.make_rename ~from:sym ~to_:sym') tm in *)
+(*       Pp.debug lvl (lazy (Pp.item ("quantified " ^ msg) (Terms.Normal.pp tm))); *)
 (*       Pp.debug lvl (lazy (pp_f tm')) *)
 (*     | _ -> *)
 (*       Pp.warn *)
@@ -40,13 +40,13 @@ let debug_constraint_failure_diagnostics
 
 module General = struct
   type one =
-    { one_index : IT.t;
-      value : IT.t
+    { one_index : Terms.Normal.t;
+      value : Terms.Normal.t
     }
 
   type many =
-    { many_guard : IT.t;
-      value : IT.t
+    { many_guard : Terms.Normal.t;
+      value : Terms.Normal.t
     }
 
   type uiinfo = Error_common.situation * TypeErrors.RequestChain.t
@@ -140,10 +140,10 @@ module General = struct
        | Some ((re, Resource.O oargs), l) ->
          assert (Request.equal re resource);
          let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
-         return (LAT.subst rt_subst (IT.make_subst [ (s, oargs) ]) ftyp, l))
+         return (LAT.subst rt_subst (Terms.Normal.make_subst [ (s, oargs) ]) ftyp, l))
     | Define ((s, it), _info, ftyp) ->
       let it = Simplify.IndexTerms.simp simp_ctxt it in
-      return (LAT.subst rt_subst (IT.make_subst [ (s, it) ]) ftyp, [])
+      return (LAT.subst rt_subst (Terms.Normal.make_subst [ (s, it) ]) ftyp, [])
     | Constraint (c, info, ftyp) ->
       let@ provable = provable loc in
       Pp.(debug 9 (lazy (item "checking constraint" (LC.pp c))));
@@ -175,7 +175,7 @@ module General = struct
     let@ simp_ctxt = simp_ctxt () in
     let provable_simp lc =
       match Simplify.LogicalConstraints.simp simp_ctxt lc with
-      | LC.T t when IT.is_true t -> `True
+      | LC.T t when Terms.is_true t -> `True
       | _ -> `False
     in
     let resource_scan fast_path re ((needed : bool), oargs) =
@@ -206,7 +206,7 @@ module General = struct
              Pp.debug 9 (lazy (Pp.item "used resource" (Req.pp (fst re))));
              (if fast_path then Pp.(debug 9 (lazy !^"syntactic match")));
              (if not fast_path then
-                Pp.(debug 9 (lazy (item "solver match" (IT.pp (IT.and_ eqs here))))));
+                Pp.(debug 9 (lazy (item "solver match" (Terms.Normal.pp (IT.and_ eqs here))))));
              (Deleted, (false, p'_oarg))
            | `False ->
              if not fast_path then (
@@ -262,7 +262,7 @@ module General = struct
         loc
         (fun re (needed, oarg) ->
            let continue = (Unchanged, (needed, oarg)) in
-           if IT.is_false needed then
+           if Terms.is_false needed then
              continue
            else (
              match re with
@@ -321,12 +321,12 @@ module General = struct
         (fun (predicate_name, index) (needed, oarg, l) ->
            let continue = return (needed, oarg, l) in
            if
-             (not (IT.is_false needed))
+             (not (Terms.is_false needed))
              && Req.subsumed requested.name predicate_name
-             && BaseTypes.equal (snd requested.q) (IT.get_bt index)
+             && BaseTypes.equal (snd requested.q) (Terms.Normal.get_bt index)
            then (
-             let su = IT.make_subst [ (fst requested.q, index) ] in
-             let needed_at_index = IT.subst su needed in
+             let su = Terms.Normal.make_subst [ (fst requested.q, index) ] in
+             let needed_at_index = Terms.Normal.subst su needed in
              match provable (LC.T needed_at_index) with
              | `False -> continue
              | `True ->
@@ -337,7 +337,7 @@ module General = struct
                let sub_req : Req.Predicate.t =
                  { name = requested.name;
                    pointer;
-                   iargs = List.map (IT.subst su) requested.iargs
+                   iargs = List.map (Terms.Normal.subst su) requested.iargs
                  }
                in
                let@ o_re_index = predicate_request loc uiinfo sub_req in
@@ -386,7 +386,7 @@ module General = struct
         let@ ftyp, l' =
           parametric_ftyp_args_request_step
             (resource_request ~simplify_prooflog:true)
-            IT.subst
+            Terms.Normal.subst
             loc
             uiinfo
             original_resources
@@ -520,7 +520,7 @@ module Special = struct
       type t =
         | Found
         | No_res
-        | Model of (Solver.model_with_q * IT.t)
+        | Model of (Solver.model_with_q * Terms.Normal.t)
     end
     in
     let here = Locations.other __LOC__ in

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -206,7 +206,10 @@ module General = struct
              Pp.debug 9 (lazy (Pp.item "used resource" (Req.pp (fst re))));
              (if fast_path then Pp.(debug 9 (lazy !^"syntactic match")));
              (if not fast_path then
-                Pp.(debug 9 (lazy (item "solver match" (Terms.Normal.pp (IT.and_ eqs here))))));
+                Pp.(
+                  debug
+                    9
+                    (lazy (item "solver match" (Terms.Normal.pp (IT.and_ eqs here))))));
              (Deleted, (false, p'_oarg))
            | `False ->
              if not fast_path then (

--- a/lib/resourceInference.mli
+++ b/lib/resourceInference.mli
@@ -9,7 +9,7 @@ module General : sig
   type uiinfo = Error_common.situation * TypeErrors.RequestChain.t
 
   val ftyp_args_request_step
-    :  ([ `Rename of Sym.t | `Term of IndexTerms.t ] Subst.t -> 'a -> 'a) ->
+    :  ([ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> 'a -> 'a) ->
     Locations.t ->
     uiinfo ->
     'b ->
@@ -26,7 +26,7 @@ module Special : sig
   val check_live_alloc
     :  [ `Copy_alloc_id | `Ptr_cmp | `Ptr_diff | `ISO_array_shift | `ISO_member_shift ] ->
     Locations.t ->
-    IndexTerms.t ->
+    Terms.Normal.t ->
     unit Typing.m
 
   val predicate_request

--- a/lib/returnTypes.ml
+++ b/lib/returnTypes.ml
@@ -1,5 +1,5 @@
 open Locations
-module IT = IndexTerms
+module T = Terms.Normal
 module LRT = LogicalReturnTypes
 
 type t = Computational of (Sym.t * BaseTypes.t) * info * LRT.t
@@ -13,7 +13,7 @@ let rec subst (substitution : _ Subst.t) at =
     Computational ((name, bt), info, LRT.subst substitution t)
 
 
-and alpha_rename_ ~from ~to_ t = (to_, subst (IT.make_rename ~from ~to_) t)
+and alpha_rename_ ~from ~to_ t = (to_, subst (T.make_rename ~from ~to_) t)
 
 and alpha_rename from t =
   let to_ = Sym.fresh_same from in

--- a/lib/simplify.ml
+++ b/lib/simplify.ml
@@ -1,10 +1,11 @@
 module LC = LogicalConstraints
+module T = Terms.Normal
 module IT = IndexTerms
 open IndexTerms
 open Terms
 
 module ITPair = struct
-  type it_pair = IT.t * IT.t [@@deriving eq, ord]
+  type it_pair = T.t * T.t [@@deriving eq, ord]
 
   type t = it_pair
 
@@ -14,12 +15,12 @@ module ITPair = struct
 end
 
 module ITPairMap = Map.Make (ITPair)
-module ITSet = Set.Make (IT)
+module ITSet = Set.Make (T)
 
 type simp_ctxt =
   { global : Global.t;
-    values : IT.t Sym.Map.t;
-    simp_hook : IT.t -> IT.t option
+    values : T.t Sym.Map.t;
+    simp_hook : T.t -> T.t option
   }
 
 let default global = { global; values = Sym.Map.empty; simp_hook = (fun _ -> None) }
@@ -55,17 +56,17 @@ module IndexTerms = struct
 
 
   let rec dest_int_addition ts it =
-    let loc = IT.get_loc it in
-    match IT.get_term it with
+    let loc = T.get_loc it in
+    match T.get_term it with
     | Const (Z i1) ->
       if fst ts || ITSet.mem z1 (snd ts) then ([ (z1, i1) ], z0) else ([], it)
     | Binop (Add, a, b) ->
       let a_xs, a_r = dest_int_addition ts a in
       let b_xs, b_r = dest_int_addition ts b in
       ( a_xs @ b_xs,
-        if IT.equal a_r z0 then
+        if T.equal a_r z0 then
           b_r
-        else if IT.equal b_r z0 then
+        else if T.equal b_r z0 then
           a_r
         else
           add_ (a_r, b_r) loc )
@@ -73,15 +74,15 @@ module IndexTerms = struct
       let a_xs, a_r = dest_int_addition ts a in
       let b_xs, b_r = dest_int_addition ts b in
       let b_xs_neg = List.map (fun (it, i) -> (it, Z.sub Z.zero i)) b_xs in
-      (a_xs @ b_xs_neg, if IT.equal b_r z0 then a_r else sub_ (a_r, b_r) loc)
+      (a_xs @ b_xs_neg, if T.equal b_r z0 then a_r else sub_ (a_r, b_r) loc)
     | Binop (Mul, a, IT (Const (Z b_i), _, z_loc)) ->
       let a_xs, a_r = dest_int_addition ts a in
       let a_xs_mul = List.map (fun (it, i) -> (it, Z.mul i b_i)) a_xs in
-      (a_xs_mul, if IT.equal a_r z0 then z0 else mul_ (a_r, z_ b_i z_loc) loc)
+      (a_xs_mul, if T.equal a_r z0 then z0 else mul_ (a_r, z_ b_i z_loc) loc)
     | Binop (Mul, IT (Const (Z a_i), _, _z_loc), b) ->
       let b_xs, b_r = dest_int_addition ts b in
       let b_xs_mul = List.map (fun (it, i) -> (it, Z.mul i a_i)) b_xs in
-      (b_xs_mul, if IT.equal b_r z0 then z0 else mul_ (z_ a_i loc, b_r) loc)
+      (b_xs_mul, if T.equal b_r z0 then z0 else mul_ (z_ a_i loc, b_r) loc)
     | _ -> if fst ts || ITSet.mem it (snd ts) then ([ (it, Z.of_int 1) ], z0) else ([], it)
 
 
@@ -100,8 +101,8 @@ module IndexTerms = struct
     let a_elems = dest_int_addition (true, ITSet.empty) a |> fst |> List.map fst in
     let b_elems = dest_int_addition (true, ITSet.empty) b |> fst |> List.map fst in
     let repeated =
-      List.sort IT.compare (a_elems @ b_elems)
-      |> group IT.equal
+      List.sort T.compare (a_elems @ b_elems)
+      |> group T.equal
       |> List.filter (fun xs -> List.length xs >= 2)
       |> List.map List.hd
       |> ITSet.of_list
@@ -110,8 +111,8 @@ module IndexTerms = struct
     let b_xs, b_r = dest_int_addition (false, repeated) b in
     let a_xs_neg = List.map (fun (it, i) -> (it, Z.sub Z.zero i)) a_xs in
     let xs =
-      List.sort (fun a b -> IT.compare (fst a) (fst b)) (a_xs_neg @ b_xs)
-      |> group (fun a b -> IT.equal (fst a) (fst b))
+      List.sort (fun a b -> T.compare (fst a) (fst b)) (a_xs_neg @ b_xs)
+      |> group (fun a b -> T.equal (fst a) (fst b))
       |> List.map (fun xs ->
         (fst (List.hd xs), List.fold_left Z.add Z.zero (List.map snd xs)))
       |> List.filter (fun t -> not (Z.equal (snd t) Z.zero))
@@ -119,7 +120,7 @@ module IndexTerms = struct
     let mul_z t i =
       if Z.equal i Z.one then
         t
-      else if IT.equal z1 t then
+      else if T.equal z1 t then
         z_ i loc
       else
         mul_ (t, z_ i loc) loc
@@ -128,7 +129,7 @@ module IndexTerms = struct
       if Z.equal i Z.zero then
         t
       else if Z.gt i (Z.of_int 0) then
-        if IT.equal t z0 then mul_z x i else add_ (t, mul_z x i) loc
+        if T.equal t z0 then mul_z x i else add_ (t, mul_z x i) loc
       else
         sub_ (t, mul_z x (Z.sub Z.zero i)) loc
     in
@@ -136,15 +137,15 @@ module IndexTerms = struct
 
 
   let simp_comp_if_int a b loc =
-    if BaseTypes.equal (IT.get_bt a) BaseTypes.Integer then
+    if BaseTypes.equal (T.get_bt a) BaseTypes.Integer then
       simp_int_comp a b loc
     else
       (a, b)
 
 
   let rec record_member_reduce it member =
-    let loc = IT.get_loc it in
-    match IT.get_term it with
+    let loc = T.get_loc it in
+    match T.get_term it with
     | Record members -> List.assoc Id.equal member members
     | RecordUpdate ((t, m), v) ->
       if Id.equal m member then
@@ -154,52 +155,52 @@ module IndexTerms = struct
     | ITE (cond, it1, it2) ->
       ite_ (cond, record_member_reduce it1 member, record_member_reduce it2 member) loc
     | _ ->
-      let member_tys = BT.record_bt (IT.get_bt it) in
+      let member_tys = BT.record_bt (T.get_bt it) in
       let member_bt = List.assoc Id.equal member member_tys in
       IT.recordMember_ ~member_bt (it, member) loc
 
 
   (* let rec datatype_member_reduce it member member_bt = *)
-  (*   match IT.get_term it with *)
+  (*   match T.get_term it with *)
   (*     | DatatypeCons (nm, members_rec) -> *)
-  (*       let members = BT.record_bt (IT.get_bt members_rec) in *)
+  (*       let members = BT.record_bt (T.get_bt members_rec) in *)
   (*       if List.exists (Id.equal member) (List.map fst members) *)
   (*       then record_member_reduce members_rec member *)
-  (*       else IT.IT (DatatypeMember (it, member), member_bt) *)
+  (*       else T.IT (DatatypeMember (it, member), member_bt) *)
   (*     | ITE (cond, it1, it2) -> *)
   (*       ite_ (cond, datatype_member_reduce it1 member member_bt, *)
   (*           datatype_member_reduce it2 member member_bt) *)
-  (*     | _ -> IT.IT (DatatypeMember (it, member), member_bt) *)
+  (*     | _ -> T.IT (DatatypeMember (it, member), member_bt) *)
 
   let rec tuple_nth_reduce it n item_bt =
-    let loc = IT.get_loc it in
-    match IT.get_term it with
+    let loc = T.get_loc it in
+    match T.get_term it with
     | Tuple items -> List.nth items n
     | ITE (cond, it1, it2) ->
       ite_ (cond, tuple_nth_reduce it1 n item_bt, tuple_nth_reduce it2 n item_bt) loc
     | _ -> IT.nthTuple_ ~item_bt (n, it) loc
 
 
-  let rec accessor_reduce (f : IT.t -> IT.t option) it =
-    let bt = IT.get_bt it in
+  let rec accessor_reduce (f : T.t -> T.t option) it =
+    let bt = T.get_bt it in
     let step, it2 =
-      match IT.get_term it with
+      match T.get_term it with
       | RecordMember (t, m) -> (true, record_member_reduce (accessor_reduce f t) m)
       (* | DatatypeMember (t, m) -> *)
       (*     (true, datatype_member_reduce (accessor_reduce f t) m bt) *)
       | NthTuple (n, t) -> (true, tuple_nth_reduce (accessor_reduce f t) n bt)
       | _ -> (false, it)
     in
-    if step && not (IT.equal it it2) then
+    if step && not (T.equal it it2) then
       accessor_reduce f it2
     else (
       match f it with None -> it | Some it3 -> accessor_reduce f it3)
 
 
   let cast_reduce bt it =
-    let loc = IT.get_loc it in
-    match (bt, IT.is_const it) with
-    | _, _ when BT.equal (IT.get_bt it) bt -> it
+    let loc = T.get_loc it in
+    match (bt, Terms.is_const it) with
+    | _, _ when BT.equal (T.get_bt it) bt -> it
     | BT.Bits (sign, sz), Some (Terms.Bits ((sign2, sz2), z), _) ->
       let z = BT.normalise_to_range (sign, sz) (BT.normalise_to_range (sign2, sz2) z) in
       num_lit_ z bt loc
@@ -227,7 +228,7 @@ module IndexTerms = struct
       | Binop (Add, a, b) ->
         let a = aux a in
         let b = aux b in
-        (match (a, b, IT.get_num_z a, IT.get_num_z b) with
+        (match (a, b, Terms.get_num_z a, Terms.get_num_z b) with
          | _, _, Some i1, Some i2 -> num_lit_norm the_bt (Z.add i1 i2) the_loc
          | IT (Const (Q q1), _, _), IT (Const (Q q2), _, _), _, _ ->
            IT (Const (Q (Q.add q1 q2)), the_bt, the_loc)
@@ -242,14 +243,14 @@ module IndexTerms = struct
       | Binop (Sub, a, b) ->
         let a = aux a in
         let b = aux b in
-        (match (a, b, the_bt, IT.get_num_z a, IT.get_num_z b) with
-         | _, _, BT.Integer, _, _ when IT.equal a b -> int_ 0 the_loc
-         | _, _, BT.Real, _, _ when IT.equal a b -> q_ (0, 1) the_loc
+        (match (a, b, the_bt, Terms.get_num_z a, Terms.get_num_z b) with
+         | _, _, BT.Integer, _, _ when T.equal a b -> int_ 0 the_loc
+         | _, _, BT.Real, _, _ when T.equal a b -> q_ (0, 1) the_loc
          | _, _, _, Some i1, Some i2 -> num_lit_norm the_bt (Z.sub i1 i2) the_loc
          | IT (Const (Q q1), _, _), IT (Const (Q q2), _, _), _, _, _ ->
            IT (Const (Q (Q.sub q1 q2)), the_bt, the_loc)
          | a, _, _, _, Some z when Z.equal z Z.zero -> a
-         | IT (Binop (Add, c, d), _, _), _, _, _, _ when IT.equal c b ->
+         | IT (Binop (Add, c, d), _, _), _, _, _, _ when T.equal c b ->
            (* (c + d) - b when c = b *)
            d
          | _, _, _, _, _ -> IT (Binop (Sub, a, b), the_bt, the_loc))
@@ -273,7 +274,7 @@ module IndexTerms = struct
            z_ (Z.div a b) the_loc
          | IT (Const (Z a), _, _), _ when Z.equal a Z.zero -> int_ 0 the_loc
          | _, IT (Const (Z b), _, _) when Z.equal b Z.one -> a
-         | IT (Binop (Mul, b', c), _, _), _ when IT.equal b' b -> c
+         | IT (Binop (Mul, b', c), _, _), _ when T.equal b' b -> c
          | _ -> IT (Binop (Div, a, b), the_bt, the_loc))
       | Binop (Exp, a, b) ->
         let a = aux a in
@@ -326,11 +327,11 @@ module IndexTerms = struct
         let a = aux a in
         let b = aux b in
         let a, b = simp_comp_if_int a b the_loc in
-        (match (a, b, IT.get_num_z a, IT.get_num_z b) with
+        (match (a, b, Terms.get_num_z a, Terms.get_num_z b) with
          | _, _, Some z1, Some z2 -> IT (Const (Bool (Z.leq z1 z2)), the_bt, the_loc)
          | IT (Const (Q q1), _, _), IT (Const (Q q2), _, _), _, _ ->
            IT (Const (Bool (Q.leq q1 q2)), the_bt, the_loc)
-         | _, _, _, _ when IT.equal a b -> bool_ true the_loc
+         | _, _, _, _ when T.equal a b -> bool_ true the_loc
          | ( IT (Binop (Rem, _, IT (Const (Z z1), _, _)), _, _),
              IT (Const (Z z2), _, _),
              _,
@@ -345,10 +346,10 @@ module IndexTerms = struct
       | Binop (Min, a, b) ->
         let a = aux a in
         let b = aux b in
-        if IT.equal a b then
+        if T.equal a b then
           a
         else (
-          match (a, b, IT.get_num_z a, IT.get_num_z b) with
+          match (a, b, Terms.get_num_z a, Terms.get_num_z b) with
           | _, _, Some i1, Some i2 -> IT.num_lit_ (Z.min i1 i2) the_bt the_loc
           | IT (Const (Q q1), _, _), IT (Const (Q q2), _, _), _, _ ->
             IT (Const (Q (Q.min q1 q2)), the_bt, the_loc)
@@ -361,10 +362,10 @@ module IndexTerms = struct
       | Binop (Max, a, b) ->
         let a = aux a in
         let b = aux b in
-        if IT.equal a b then
+        if T.equal a b then
           a
         else (
-          match (a, b, IT.get_num_z a, IT.get_num_z b) with
+          match (a, b, Terms.get_num_z a, Terms.get_num_z b) with
           | _, _, Some i1, Some i2 -> IT.num_lit_ (Z.max i1 i2) the_bt the_loc
           | IT (Const (Q q1), _, _), IT (Const (Q q2), _, _), _, _ ->
             IT (Const (Q (Q.max q1 q2)), the_bt, the_loc)
@@ -382,7 +383,7 @@ module IndexTerms = struct
          | _, IT (Const (Bool true), _, _) -> it1
          | IT (Const (Bool false), _, _), _ -> bool_ false the_loc
          | _, IT (Const (Bool false), _, _) -> bool_ false the_loc
-         | _ when IT.equal it1 it2 -> it1
+         | _ when T.equal it1 it2 -> it1
          | _ -> IT (Binop (And, it1, it2), the_bt, the_loc))
       | Binop (Or, it1, it2) ->
         let it1 = aux it1 in
@@ -392,12 +393,12 @@ module IndexTerms = struct
          | _, IT (Const (Bool true), _, _) -> bool_ true the_loc
          | IT (Const (Bool false), _, _), _ -> it2
          | _, IT (Const (Bool false), _, _) -> it1
-         | _ when IT.equal it1 it2 -> it1
+         | _ when T.equal it1 it2 -> it1
          | _ -> IT (Binop (Or, it1, it2), the_bt, the_loc))
       | Binop (Implies, a, b) ->
         let a = aux a in
         let b = aux b in
-        if IT.equal a b then
+        if T.equal a b then
           IT (Const (Bool true), the_bt, the_loc)
         else (
           match (a, b) with
@@ -408,7 +409,7 @@ module IndexTerms = struct
           | _ -> IT (Binop (Implies, a, b), the_bt, the_loc))
       | Unop (op, a) ->
         let a = aux a in
-        (match (op, IT.get_term a) with
+        (match (op, T.get_term a) with
          | Not, Const (Bool b) -> bool_ (not b) the_loc
          | Not, Unop (Not, x) -> x
          | Negate, Unop (Negate, x) -> x
@@ -443,14 +444,14 @@ module IndexTerms = struct
         (match a with
          | IT (Const (Bool true), _, _) -> b
          | IT (Const (Bool false), _, _) -> c
-         | _ when IT.equal b c -> b
+         | _ when T.equal b c -> b
          | _ -> IT (ITE (a, b, c), the_bt, the_loc))
       | Binop (EQ, a, b) ->
         let a = aux a in
         let b = aux b in
-        let is_c t = Option.is_some (IT.is_const t) in
+        let is_c t = Option.is_some (Terms.is_const t) in
         (match (a, b) with
-         | _ when IT.equal a b -> IT (Const (Bool true), the_bt, the_loc)
+         | _ when T.equal a b -> IT (Const (Bool true), the_bt, the_loc)
          | IT (Const (Z z1), _, _), IT (Const (Z z2), _, _) ->
            bool_ (Z.equal z1 z2) the_loc
          | ( IT (Const (Bits (bits_info1, z1)), _, _),
@@ -461,7 +462,7 @@ module IndexTerms = struct
          (* Work-around for https://github.com/Z3Prover/z3/issues/7352 *)
          | ( IT (ArrayShift { base = base1; ct = ct1; index = index1 }, _, _),
              IT (ArrayShift { base = base2; ct = ct2; index = index2 }, _, _) )
-           when Sctypes.equal ct1 ct2 && IT.equal index1 index2 ->
+           when Sctypes.equal ct1 ct2 && T.equal index1 index2 ->
            eq_ (base1, base2) the_loc
          (* (cond ? const-1 : const-2) == const-3 *)
          | IT (ITE (cond, t1, t2), _, _), t3 when (is_c t1 || is_c t2) && is_c t3 ->
@@ -483,7 +484,7 @@ module IndexTerms = struct
          | _, _ -> eq_ (a, b) the_loc)
       | EachI ((i1, (s, s_bt), i2), t) ->
         let s' = Sym.fresh_same s in
-        let t = IndexTerms.(subst (make_rename ~from:s ~to_:s') t) in
+        let t = T.(subst (make_rename ~from:s ~to_:s') t) in
         let t = aux t in
         IT (EachI ((i1, (s', s_bt), i2), t), the_bt, the_loc)
       | Tuple its ->
@@ -495,11 +496,11 @@ module IndexTerms = struct
       | Struct (tag, members) ->
         (match members with
          | (_, IT (StructMember (str, _), _, _)) :: _
-           when BT.equal (Struct tag) (IT.get_bt str)
+           when BT.equal (Struct tag) (T.get_bt str)
                 && List.for_all
                      (function
                        | mem, IT (StructMember (str', mem'), _, _) ->
-                         Id.equal mem mem' && IT.equal str str'
+                         Id.equal mem mem' && T.equal str str'
                        | _ -> false)
                      members ->
            str
@@ -539,7 +540,7 @@ module IndexTerms = struct
         if isIntegerToPointerCast a || isIntegerToPointerCast b then (
           let loc = Cerb_location.other __LOC__ in
           aux (lt_ (addr_ a loc, addr_ b loc) the_loc))
-        else if IT.equal a b then
+        else if T.equal a b then
           bool_ false the_loc
         else
           IT (Binop (LTPointer, a, b), the_bt, the_loc)
@@ -549,7 +550,7 @@ module IndexTerms = struct
         if isIntegerToPointerCast a || isIntegerToPointerCast b then (
           let loc = Cerb_location.other __LOC__ in
           aux (le_ (addr_ a loc, addr_ b loc) the_loc))
-        else if IT.equal a b then
+        else if T.equal a b then
           bool_ true the_loc
         else
           IT (Binop (LEPointer, a, b), the_bt, the_loc)
@@ -600,11 +601,11 @@ module IndexTerms = struct
         let rec make map index =
           match map with
           | IT (MapDef ((s, abt), body), _, _) ->
-            assert (BT.equal abt (IT.get_bt index));
-            aux (IT.subst (IT.make_subst [ (s, index) ]) body)
+            assert (BT.equal abt (T.get_bt index));
+            aux (T.subst (T.make_subst [ (s, index) ]) body)
           | IT (MapSet (map', index', value'), _, _) ->
             (match (index, index') with
-             | _, _ when IT.equal index index' -> value'
+             | _, _ when T.equal index index' -> value'
              | IT (Const (Z z), _, _), IT (Const (Z z'), _, _) when not (Z.equal z z') ->
                make map' index
              | _ -> IT (MapGet (map, index), the_bt, the_loc))
@@ -619,7 +620,7 @@ module IndexTerms = struct
         make map index
       | MapDef ((s, abt), body) ->
         let s' = Sym.fresh_same s in
-        let body = IndexTerms.(subst (make_rename ~from:s ~to_:s') body) in
+        let body = T.(subst (make_rename ~from:s ~to_:s') body) in
         let body = aux body in
         IT (MapDef ((s', abt), body), the_bt, the_loc)
       | Apply (name, args) ->
@@ -654,10 +655,10 @@ module LogicalConstraints = struct
     match lc with
     | LC.T it -> LC.T (simp ~inline_functions simp_ctxt it)
     | LC.Forall ((q, qbt), body) ->
-      let q, body = IT.alpha_rename q body in
+      let q, body = T.alpha_rename q body in
       let body = simp ~inline_functions simp_ctxt body in
       (match body with
-       | IT (Const (Bool true), _, _) -> LC.T (bool_ true (IT.get_loc body))
+       | IT (Const (Bool true), _, _) -> LC.T (bool_ true (T.get_loc body))
        | _ -> LC.Forall ((q, qbt), body))
 end
 
@@ -684,7 +685,7 @@ module Request = struct
           q = qp.q;
           q_loc = qp.q_loc;
           step = qp.step;
-          permission = and_ permission (IT.get_loc qp.permission);
+          permission = and_ permission (T.get_loc qp.permission);
           iargs = List.map (IndexTerms.simp simp_ctxt) qp.iargs
         }
   end

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -763,13 +763,9 @@ let rec translate_term s iterm =
         | _ -> failwith "Mod")
      | ModNoSMT -> uninterp_same_type CN_Names.mod'
      | BW_Xor ->
-       (match get_bt iterm with
-        | BT.Bits _ -> SMT.bv_xor s1 s2
-        | _ -> failwith "BW_Xor")
+       (match get_bt iterm with BT.Bits _ -> SMT.bv_xor s1 s2 | _ -> failwith "BW_Xor")
      | BW_And ->
-       (match get_bt iterm with
-        | BT.Bits _ -> SMT.bv_and s1 s2
-        | _ -> failwith "BW_And")
+       (match get_bt iterm with BT.Bits _ -> SMT.bv_and s1 s2 | _ -> failwith "BW_And")
      | BW_Or ->
        (match get_bt iterm with BT.Bits _ -> SMT.bv_or s1 s2 | _ -> failwith "BW_Or")
      (* Shift amount should be positive? *)

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,5 +1,6 @@
 module SMT = Simple_smt
 module IT = IndexTerms
+open Terms
 open IT
 module LC = LogicalConstraints
 module CTypeMap = Map.Make (Sctypes)
@@ -648,7 +649,7 @@ let bv_ctz result_w =
 
 (** Translate a CN term to SMT *)
 let rec translate_term s iterm =
-  let loc = IT.get_loc iterm in
+  let loc = get_loc iterm in
   let struct_decls = s.globals.struct_decls in
   let maybe_name e k =
     if SMT.is_atom e then
@@ -661,14 +662,14 @@ let rec translate_term s iterm =
     let here = Locations.other __LOC__ in
     translate_term s (IT.default_ bt here)
   in
-  match IT.get_term iterm with
+  match get_term iterm with
   | Const c -> translate_const s c
   | Sym x -> SMT.atom (CN_Names.fn_name x)
   | Unop (op, e1) ->
     (match op with
      | BW_FFS_NoSMT ->
        (* NOTE: This desugaring duplicates e1 *)
-       let intl i = int_lit_ i (IT.get_bt e1) loc in
+       let intl i = IT.int_lit_ i (get_bt e1) loc in
        translate_term
          s
          (ite_
@@ -679,8 +680,8 @@ let rec translate_term s iterm =
      | BW_FLS_NoSMT ->
        (* copying and adjusting BW_FFS_NoSMT rule *)
        (* NOTE: This desugaring duplicates e1 *)
-       let sz = match IT.get_bt e1 with Bits (_sign, n) -> n | _ -> assert false in
-       let intl i = int_lit_ i (IT.get_bt e1) loc in
+       let sz = match get_bt e1 with Bits (_sign, n) -> n | _ -> assert false in
+       let intl i = int_lit_ i (get_bt e1) loc in
        translate_term
          s
          (ite_
@@ -690,20 +691,20 @@ let rec translate_term s iterm =
             loc)
      | Not -> SMT.bool_not (translate_term s e1)
      | Negate ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_neg (translate_term s e1)
         | BT.Integer | BT.Real -> SMT.num_neg (translate_term s e1)
         | _ -> failwith (__LOC__ ^ ":Unop (Negate, _)"))
      | BW_Compl ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_compl (translate_term s e1)
         | _ -> failwith (__LOC__ ^ ":Unop (BW_Compl, _)"))
      | BW_CLZ_NoSMT ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (_, w) -> maybe_name (translate_term s e1) (bv_clz w w)
         | _ -> failwith "solver: BW_CLZ_NoSMT: not a bitwise type")
      | BW_CTZ_NoSMT ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (_, w) -> maybe_name (translate_term s e1) (bv_ctz w w)
         | _ -> failwith "solver: BW_CTZ_NoSMT: not a bitwise type"))
   | Binop (op, e1, e2) ->
@@ -711,7 +712,7 @@ let rec translate_term s iterm =
     let s2 = translate_term s e2 in
     (* binary uninterpreted function, same type for arguments and result. *)
     let uninterp_same_type k =
-      let bt = IT.get_bt iterm in
+      let bt = get_bt iterm in
       SMT.app (Atom (k bt)) [ s1; s2 ]
     in
     (match op with
@@ -719,23 +720,23 @@ let rec translate_term s iterm =
      | Or -> SMT.bool_or s1 s2
      | Implies -> SMT.bool_implies s1 s2
      | Add ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_add s1 s2
         | BT.Integer | BT.Real -> SMT.num_add s1 s2
         | _ -> failwith "Add")
      | Sub ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_sub s1 s2
         | BT.Integer | BT.Real -> SMT.num_sub s1 s2
         | _ -> failwith "Sub")
      | Mul ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_mul s1 s2
         | BT.Integer | BT.Real -> SMT.num_mul s1 s2
         | _ -> failwith "Mul")
      | MulNoSMT -> uninterp_same_type CN_Names.mul
      | Div ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (BT.Signed, _) -> SMT.bv_sdiv s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_udiv s1 s2
         | BT.Integer | BT.Real -> SMT.num_div s1 s2
@@ -744,52 +745,52 @@ let rec translate_term s iterm =
      | Exp ->
        (match (get_num_z e1, get_num_z e2) with
         | Some z1, Some z2 when Z.fits_int z2 ->
-          translate_term s (num_lit_ (Z.pow z1 (Z.to_int z2)) (IT.get_bt e1) loc)
+          translate_term s (num_lit_ (Z.pow z1 (Z.to_int z2)) (get_bt e1) loc)
         | _, _ -> failwith "Exp")
      | ExpNoSMT -> uninterp_same_type CN_Names.exp
      | Rem ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (BT.Signed, _) -> SMT.bv_srem s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_urem s1 s2
         | BT.Integer -> SMT.num_rem s1 s2 (* CVC5 ?? *)
         | _ -> failwith "Rem")
      | RemNoSMT -> uninterp_same_type CN_Names.rem
      | Mod ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (BT.Signed, _) -> SMT.bv_smod s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_urem s1 s2
         | BT.Integer -> SMT.num_mod s1 s2
         | _ -> failwith "Mod")
      | ModNoSMT -> uninterp_same_type CN_Names.mod'
      | BW_Xor ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_xor s1 s2
         | _ -> failwith "BW_Xor")
      | BW_And ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_and s1 s2
         | _ -> failwith "BW_And")
      | BW_Or ->
-       (match IT.get_bt iterm with BT.Bits _ -> SMT.bv_or s1 s2 | _ -> failwith "BW_Or")
+       (match get_bt iterm with BT.Bits _ -> SMT.bv_or s1 s2 | _ -> failwith "BW_Or")
      (* Shift amount should be positive? *)
      | ShiftLeft ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits _ -> SMT.bv_shl s1 s2
         | _ -> failwith "ShiftLeft")
      (* Amount should be positive? *)
      | ShiftRight ->
-       (match IT.get_bt iterm with
+       (match get_bt iterm with
         | BT.Bits (BT.Signed, _) -> SMT.bv_ashr s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_lshr s1 s2
         | _ -> failwith "ShiftRight")
      | LT ->
-       (match IT.get_bt e1 with
+       (match get_bt e1 with
         | BT.Bits (BT.Signed, _) -> SMT.bv_slt s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_ult s1 s2
         | BT.Integer | BT.Real -> SMT.num_lt s1 s2
         | _ -> failwith "LT")
      | LE ->
-       (match IT.get_bt e1 with
+       (match get_bt e1 with
         | BT.Bits (BT.Signed, _) -> SMT.bv_sleq s1 s2
         | BT.Bits (BT.Unsigned, _) -> SMT.bv_uleq s1 s2
         | BT.Integer | BT.Real -> SMT.num_leq s1 s2
@@ -817,8 +818,8 @@ let rec translate_term s iterm =
   | EachI ((i1, (x, bt), i2), t) ->
     let rec aux i =
       if i <= i2 then (
-        let su = make_subst [ (x, num_lit_ (Z.of_int i) bt loc) ] in
-        let t1 = IT.subst su t in
+        let su = Terms.Normal.make_subst [ (x, num_lit_ (Z.of_int i) bt loc) ] in
+        let t1 = Terms.Normal.subst su t in
         if i = i2 then t1 else IT.and2_ (t1, aux (i + 1)) loc)
       else
         failwith "EachI"
@@ -830,7 +831,7 @@ let rec translate_term s iterm =
   (* Tuples *)
   | Tuple es -> CN_Tuple.con (List.map (translate_term s) es)
   | NthTuple (n, e1) ->
-    (match IT.get_bt e1 with
+    (match get_bt e1 with
      | Tuple ts -> CN_Tuple.get (List.length ts) n (translate_term s e1)
      | _ -> failwith "NthTuple: not a tuple")
   (* Structs *)
@@ -842,8 +843,8 @@ let rec translate_term s iterm =
   | StructMember (e1, f) ->
     SMT.app_ (CN_Names.struct_field_name f) [ translate_term s e1 ]
   | StructUpdate ((t, member), v) ->
-    let tag = BT.struct_bt (IT.get_bt t) in
-    let layout = Sym.Map.find (BT.struct_bt (IT.get_bt t)) struct_decls in
+    let tag = BT.struct_bt (get_bt t) in
+    let layout = Sym.Map.find (BT.struct_bt (get_bt t)) struct_decls in
     let members = Memory.member_types layout in
     let str =
       List.map
@@ -861,13 +862,13 @@ let rec translate_term s iterm =
   | OffsetOf (tag, member) ->
     let decl = Sym.Map.find tag struct_decls in
     let v = Option.get (Memory.member_offset decl member) in
-    translate_term s (int_lit_ v (IT.get_bt iterm) loc)
+    translate_term s (int_lit_ v (get_bt iterm) loc)
   (* Records *)
   | Record members ->
     let field (_, e) = translate_term s e in
     CN_Tuple.con (List.map field members)
   | RecordMember (e1, f) ->
-    (match IT.get_bt e1 with
+    (match get_bt e1 with
      | Record members ->
        let check (x, _) = Id.equal f x in
        let arity = List.length members in
@@ -876,7 +877,7 @@ let rec translate_term s iterm =
         | None -> failwith "Missing record field.")
      | _ -> failwith "RecordMemmber")
   | RecordUpdate ((t, member), v) ->
-    let members = BT.record_bt (IT.get_bt t) in
+    let members = BT.record_bt (get_bt t) in
     let str =
       List.map
         (fun (member', bt) ->
@@ -889,7 +890,7 @@ let rec translate_term s iterm =
            (member', value))
         members
     in
-    translate_term s (IT (Record str, IT.get_bt t, loc))
+    translate_term s (IT (Record str, get_bt t, loc))
   | MemberShift (t, tag, member) ->
     CN_Pointer.ptr_shift
       ~ptr:(translate_term s t)
@@ -914,17 +915,17 @@ let rec translate_term s iterm =
   | Head e1 -> CN_List.head (translate_term s e1)
   | Tail e1 -> CN_List.tail (translate_term s e1)
   | SizeOf ct ->
-    translate_term s (IT.int_lit_ (Memory.size_of_ctype ct) (IT.get_bt iterm) loc)
+    translate_term s (IT.int_lit_ (Memory.size_of_ctype ct) (get_bt iterm) loc)
   | Representable (ct, t) -> translate_term s (representable struct_decls ct t loc)
   | Good (ct, t) -> translate_term s (good_value struct_decls ct t loc)
   | Aligned t ->
     let addr = addr_ t.t loc in
-    assert (BT.equal (IT.get_bt addr) (IT.get_bt t.align));
+    assert (BT.equal (get_bt addr) (get_bt t.align));
     translate_term s (divisible_ (addr, t.align) loc)
   (* Maps *)
   | MapConst (bt, e1) ->
     let kt = translate_base_type bt in
-    let vt = translate_base_type (IT.get_bt e1) in
+    let vt = translate_base_type (get_bt e1) in
     SMT.arr_const kt vt (translate_term s e1)
   | MapSet (mp, k, v) ->
     SMT.arr_store (translate_term s mp) (translate_term s k) (translate_term s v)
@@ -962,7 +963,7 @@ let rec translate_term s iterm =
     in
     let rec do_alts v alts =
       match alts with
-      | [] -> translate_term s (default_ (IT.get_bt iterm) loc)
+      | [] -> translate_term s (default_ (get_bt iterm) loc)
       | (pat, rhs) :: more ->
         let mb_cond, binds = match_pat v pat in
         let k = SMT.let_ binds (translate_term s rhs) in
@@ -975,18 +976,18 @@ let rec translate_term s iterm =
     failwith "todo: remove WrapI"
     (* bv_cast *)
     (*   ~to_:(Memory.bt_of_sct (Sctypes.Integer ity)) *)
-    (*   ~from:(IT.get_bt arg) *)
+    (*   ~from:(get_bt arg) *)
     (*   (translate_term s arg) *)
   | Cast (cbt, t) ->
     let smt_term = translate_term s t in
-    (match (IT.get_bt t, cbt) with
+    (match (get_bt t, cbt) with
      | Bits _, Loc () ->
        assert !cnBV;
        let addr =
-         if BT.equal (IT.get_bt t) Memory.uintptr_bt then
+         if BT.equal (get_bt t) Memory.uintptr_bt then
            smt_term
          else
-           bv_cast ~to_:Memory.uintptr_bt ~from:(IT.get_bt t) smt_term
+           bv_cast ~to_:Memory.uintptr_bt ~from:(get_bt t) smt_term
        in
        CN_Pointer.bits_to_ptr ~bits:addr ~alloc_id:(default Alloc_id)
      | Integer, Loc () ->
@@ -1025,7 +1026,7 @@ let rec translate_term s iterm =
      | MemByte, Option Alloc_id -> SMT.app_ CN_MemByte.alloc_id_name [ smt_term ]
      | Real, Integer -> SMT.real_to_int smt_term
      | Integer, Real -> SMT.int_to_real smt_term
-     | Bits _, Bits _ -> bv_cast ~to_:cbt ~from:(IT.get_bt t) smt_term
+     | Bits _, Bits _ -> bv_cast ~to_:cbt ~from:(get_bt t) smt_term
      (* TODO: may have to eventually add bv/integer casts *)
      | _ -> assert false)
   | CN_None t -> CN_Option.none (translate_base_type t)
@@ -1264,7 +1265,7 @@ let make globals variable_bindings =
 (* Models *)
 (* ---------------------------------------------------------------------------*)
 
-type model = IT.t -> IT.t option
+type model = Terms.Normal.t -> Terms.Normal.t option
 
 type model_with_q = model * (Sym.t * BaseTypes.t) list
 
@@ -1314,7 +1315,7 @@ module TryHard = struct
   let translate_forall solver qs body =
     let alpha_rename qs body =
       let comb (s1, bt) (qs1, body1) =
-        let s2, body2 = IT.alpha_rename s1 body1 in
+        let s2, body2 = Terms.Normal.alpha_rename s1 body1 in
         ((s2, bt) :: qs1, body2)
       in
       List.fold_right comb qs ([], body)
@@ -1373,18 +1374,18 @@ let _unused_try_hard = (TryHard.translate_functions, TryHard.translate_foralls)
 (** Goals are translated to this type *)
 type reduction =
   { qs : (Sym.t * BT.t) list; (* quantifier instantiation *)
-    expr : IT.t; (* translation of goal *)
-    extra : IT.t list (* additional assumptions *)
+    expr : Terms.Normal.t; (* translation of goal *)
+    extra : Terms.Normal.t list (* additional assumptions *)
   }
 
 (** TODO: maybe we should not have `extra` any more. *)
 let reduce_goal assumptions = function
   | LC.T expr -> { expr; qs = []; extra = [] }
   | Forall ((s, bt), expr) ->
-    let s, expr = IT.alpha_rename s expr in
+    let s, expr = Terms.Normal.alpha_rename s expr in
     let mk_extra = function
       | LC.Forall ((s', bt'), expr') when BT.equal bt bt' ->
-        Some (IT.subst (make_rename ~from:s' ~to_:s) expr')
+        Some Terms.Normal.(subst (make_rename ~from:s' ~to_:s) expr')
       | _ -> None
     in
     let extra = List.filter_map mk_extra (LC.Set.elements assumptions) in

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -69,7 +69,7 @@ val model : unit -> model_with_q
 (** Ask the solver to evaluate a CN term in the context of an already obtained
     counter-example model (e.g. for evaluating sub-terms). Might return None in
     case we ask for the value of a "don't care" value in the (minimal) model. *)
-val eval : model -> IndexTerms.t -> IndexTerms.t option
+val eval : model -> Terms.Normal.t -> Terms.Normal.t option
 
 (** Try undecidable SMT solving using full set of assumptions. *)
 val try_hard : bool ref

--- a/lib/terms.ml
+++ b/lib/terms.ml
@@ -1002,7 +1002,6 @@ module Surface = struct
 end
 
 module Normal = struct
-
   module BT = BaseTypes
   module CF = Cerb_frontend
 
@@ -1051,5 +1050,4 @@ module Normal = struct
   let get_loc = get_loc
 
   let fold_subterms = fold_subterms
-
 end

--- a/lib/terms.ml
+++ b/lib/terms.ml
@@ -921,3 +921,135 @@ let rec map_term_post (f : 'bt annot -> 'bt annot) (it : 'bt annot) : 'bt annot 
     | GetOpt it' -> GetOpt (loop it')
   in
   f (IT (it_, bt, here))
+
+
+let is_call (f : Sym.t) (IT (it_, _bt, _loc)) =
+  match it_ with Apply (f', _) when Sym.equal f f' -> true | _ -> false
+
+
+let is_good (ct : Sctypes.t) (IT (it_, _bt, _loc)) =
+  match it_ with Good (ct', _) when Sctypes.equal ct ct' -> true | _ -> false
+
+
+let mentions_call f = fold_subterms (fun _binders acc it -> acc || is_call f it) false
+
+let mentions_good ct = fold_subterms (fun _binders acc it -> acc || is_good ct it) false
+
+let preds_of t =
+  let add_p s = function IT (Apply (id, _), _, _) -> Sym.Set.add id s | _ -> s in
+  fold_subterms (fun _ -> add_p) Sym.Set.empty t
+
+
+let json it : Yojson.Safe.t = `String (Pp.plain (pp it))
+
+let is_const = function
+  | IT (Const const, bt, _loc) -> Option.Some (const, bt)
+  | _ -> None
+
+
+let is_z = function IT (Const (Z z), _bt, _loc) -> Option.Some z | _ -> None
+
+let is_z_ it = Option.is_some (is_z it)
+
+let get_num_z it =
+  match get_term it with
+  | Const (Z _) -> is_z it
+  | Const (Bits (info, z)) -> Some (BaseTypes.normalise_to_range info z)
+  | _ -> None
+
+
+let is_bits_const = function
+  | IT (Const (Bits (info, n)), _, _) -> Some (info, n)
+  | _ -> None
+
+
+let is_pointer = function
+  | IT (Const (Pointer { alloc_id; addr }), _bt, _) -> Some (alloc_id, addr)
+  | _ -> None
+
+
+let is_alloc_id = function
+  | IT (Const (Alloc_id alloc_id), _bt, _) -> Some alloc_id
+  | _ -> None
+
+
+let is_sym = function IT (Sym sym, bt, _) -> Some (sym, bt) | _ -> None
+
+let is_bool = function IT (Const (Bool b), _, _) -> Some b | _ -> None
+
+let is_true = function IT (Const (Bool true), _, _) -> true | _ -> false
+
+let is_false = function IT (Const (Bool false), _, _) -> true | _ -> false
+
+let is_eq = function IT (Binop (EQ, lhs, rhs), _, _) -> Some (lhs, rhs) | _ -> None
+
+let is_and = function IT (Binop (And, it, it'), _, _) -> Some (it, it') | _ -> None
+
+let is_pred_ = function IT (Apply (name, args), _, _) -> Some (name, args) | _ -> None
+
+let is_ctype_const = function IT (Const (CType_const ct), _, _) -> Some ct | _ -> None
+
+module Surface = struct
+  type t' = BaseTypes.Surface.t term
+
+  type t = BaseTypes.Surface.t annot
+
+  let compare = compare_annot BaseTypes.Surface.compare
+
+  let proj = map_annot BaseTypes.Surface.proj
+
+  let inj x = map_annot BaseTypes.Surface.inj x
+end
+
+module Normal = struct
+
+  module BT = BaseTypes
+  module CF = Cerb_frontend
+
+  let pp ?(prec = 0) = pp ~prec
+
+  let pp_with_typf f it = Pp.typ (pp it) (f (get_bt it))
+
+  let pp_with_typ = pp_with_typf BT.pp
+
+  type t = BT.t annot
+
+  type t' = BT.t term
+
+  let equal = equal_annot BT.equal
+
+  let compare = compare_annot BT.compare
+
+  let subst = subst BT.equal
+
+  let alpha_rename = alpha_rename BT.equal
+
+  let suitably_alpha_rename = suitably_alpha_rename BT.equal
+
+  let make_subst = make_subst BT.equal
+
+  let make_rename = make_rename BT.equal
+
+  let free_vars_bts = free_vars_bts BT.equal
+
+  let free_vars_bts_list = free_vars_bts_list BT.equal
+
+  let free_vars = free_vars BT.equal
+
+  let free_vars_list = free_vars_list BT.equal
+
+  let free_vars_with_rename = free_vars_with_rename BT.equal
+
+  let bound_by_pattern = bound_by_pattern
+
+  let dtree = dtree
+
+  let get_bt = get_bt
+
+  let get_term = get_term
+
+  let get_loc = get_loc
+
+  let fold_subterms = fold_subterms
+
+end

--- a/lib/testGeneration/bennet/abstractDomains/interpreter.ml
+++ b/lib/testGeneration/bennet/abstractDomains/interpreter.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -72,7 +73,7 @@ module Make (GT : GenTerms.T) (I : Domain.T with type t = GT.AD.t) = struct
                let callee_constraint = AD.to_lc callee_d in
                (* Create substitution: formal_param -> actual_arg *)
                let subst =
-                 IT.make_subst
+                 T.make_subst
                    (List.map2
                       (fun (formal_sym, _) actual_arg -> (formal_sym, actual_arg))
                       callee_gd.iargs
@@ -134,7 +135,7 @@ module Make (GT : GenTerms.T) (I : Domain.T with type t = GT.AD.t) = struct
           let d' = I.abs_assert (LC.T it_if) d in
           aux abs_ctx defs_ctx gt_then d' should_assert
         in
-        let not_it_if = IT.not_ it_if (IT.get_loc it_if) in
+        let not_it_if = IT.not_ it_if (T.get_loc it_if) in
         let gt_else, d_else_list =
           let d' = I.abs_assert (LC.T not_it_if) d in
           aux abs_ctx defs_ctx gt_else d' should_assert

--- a/lib/testGeneration/bennet/abstractDomains/interval_.ml
+++ b/lib/testGeneration/bennet/abstractDomains/interval_.ml
@@ -305,11 +305,7 @@ module IntervalBasis = struct
         print_endline
           Pp.(
             plain
-              (T.pp it
-               ^^^ pp b1
-               ^^ parens (BT.pp b1.bt)
-               ^^^ pp b2
-               ^^ parens (BT.pp b2.bt)));
+              (T.pp it ^^^ pp b1 ^^ parens (BT.pp b1.bt) ^^^ pp b2 ^^ parens (BT.pp b2.bt)));
         failwith __LOC__);
       forward_abs_binop op b1 b2
     | Cast (_, _) ->

--- a/lib/testGeneration/bennet/abstractDomains/interval_.ml
+++ b/lib/testGeneration/bennet/abstractDomains/interval_.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 
 module IntervalBasis = struct
@@ -123,7 +124,7 @@ module IntervalBasis = struct
       brackets (z start ^^ !^".." ^^ z stop)
 
 
-  let forward_abs_binop (op : IT.binop) (b1 : t) (b2 : t) : t option =
+  let forward_abs_binop (op : Terms.binop) (b1 : t) (b2 : t) : t option =
     assert (BT.equal b1.bt b2.bt);
     if b1.is_bottom || b2.is_bottom then
       Some (bottom b1.bt)
@@ -290,7 +291,7 @@ module IntervalBasis = struct
         { bt = target_bt; is_bottom = false; start = clamped_start; stop = clamped_stop })
 
 
-  let forward_abs_it (it : IT.t) (b_args : t list) : t option =
+  let forward_abs_it (it : T.t) (b_args : t list) : t option =
     let (IT (it_, bt, _loc)) = it in
     match it_ with
     | Const (Bits (_, n)) -> Some (of_interval bt n n)
@@ -304,7 +305,7 @@ module IntervalBasis = struct
         print_endline
           Pp.(
             plain
-              (IT.pp it
+              (T.pp it
                ^^^ pp b1
                ^^ parens (BT.pp b1.bt)
                ^^^ pp b2
@@ -321,11 +322,11 @@ module IntervalBasis = struct
     | _ -> None
 
 
-  let rec backward_abs_it (it : IT.t) (bs : t list) =
+  let rec backward_abs_it (it : T.t) (bs : t list) =
     let (IT (it_, _, loc)) = it in
     match it_ with
     | Binop (EQ, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       if Option.is_none (BT.is_bits_bt bt) && not (BT.equal bt (BT.Loc ())) then
         bs
       else (
@@ -333,14 +334,14 @@ module IntervalBasis = struct
         let b = meet b1 b2 in
         [ b; b ])
     | Binop (LE, it', _) | Binop (LEPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       let min, max = get_extrema bt in
       let b1, b2 = match bs with [ b1; b2 ] -> (b1, b2) | _ -> failwith __LOC__ in
       let b1' = of_interval bt min b2.stop in
       let b2' = of_interval bt b1.start max in
       [ meet b1 b1'; meet b2 b2' ]
     | Binop (LT, it', _) | Binop (LTPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       let min, max = get_extrema bt in
       let b1, b2 = match bs with [ b1; b2 ] -> (b1, b2) | _ -> failwith __LOC__ in
       let b1' = of_interval bt min (Z.sub b2.stop Z.one) in
@@ -354,7 +355,7 @@ module IntervalBasis = struct
       backward_abs_it (IT.lt_ (it2, it1) loc) bs
     (* TODO: NE *)
     | _ ->
-      if BT.equal BT.Bool (IT.get_bt it) then
+      if BT.equal BT.Bool (T.get_bt it) then
         bs
       else
         List.tl bs
@@ -417,7 +418,7 @@ module IntervalBasis = struct
 
   let definitions () = Pp.empty
 
-  let to_it (sym : Sym.t) (t : t) : IT.t =
+  let to_it (sym : Sym.t) (t : t) : T.t =
     let loc = Locations.other __LOC__ in
     if is_bottom t then
       IT.bool_ false loc

--- a/lib/testGeneration/bennet/abstractDomains/nonRelational.ml
+++ b/lib/testGeneration/bennet/abstractDomains/nonRelational.ml
@@ -224,9 +224,7 @@ module Make (B : BASIS) = struct
        (* De Morgan's Law *)
        | IT (Binop (And, e1, e2), info, loc) ->
          Binop
-           ( Or,
-             cnf (IT (Unop (Not, e1), info, loc)),
-             cnf (IT (Unop (Not, e2), info, loc)) )
+           (Or, cnf (IT (Unop (Not, e1), info, loc)), cnf (IT (Unop (Not, e2), info, loc)))
        | IT (Binop (Or, e1, e2), info, loc) ->
          Binop
            ( And,
@@ -485,9 +483,7 @@ module Make (B : BASIS) = struct
                 (b_res
                  :: List.map
                       (fun (it, t) ->
-                         Option.value
-                           ~default:(B.top (T.get_bt it))
-                           (Option.map tree_b t))
+                         Option.value ~default:(B.top (T.get_bt it)) (Option.map tree_b t))
                       (List.combine its ts))
             in
             assert (List.length bs = List.length ts);

--- a/lib/testGeneration/bennet/abstractDomains/nonRelational.ml
+++ b/lib/testGeneration/bennet/abstractDomains/nonRelational.ml
@@ -1,6 +1,7 @@
 (** Non-relational numeric domain *)
 
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -35,9 +36,9 @@ module type BASIS = sig
 
   val of_interval : BT.t -> Z.t -> Z.t -> t
 
-  val forward_abs_it : IT.t -> t list -> t option
+  val forward_abs_it : T.t -> t list -> t option
 
-  val backward_abs_it : IT.t -> t list -> t list
+  val backward_abs_it : T.t -> t list -> t list
 
   val widen : t -> t -> t
 
@@ -53,7 +54,7 @@ module type BASIS = sig
 
   val definitions : unit -> Pp.document
 
-  val to_it : Sym.t -> t -> IT.t
+  val to_it : Sym.t -> t -> T.t
 end
 
 module Make (B : BASIS) = struct
@@ -211,7 +212,7 @@ module Make (B : BASIS) = struct
 
   let tree_test t = match t with Test (t1, t2) -> (t1, t2) | _ -> failwith __LOC__
 
-  let rec cnf_ (e : BT.t IT.term) : BT.t IT.term =
+  let rec cnf_ (e : BT.t Terms.term) : BT.t Terms.term =
     match e with
     | Unop (Not, e') ->
       (match cnf e' with
@@ -224,7 +225,7 @@ module Make (B : BASIS) = struct
        | IT (Binop (And, e1, e2), info, loc) ->
          Binop
            ( Or,
-             cnf (IT.IT (Unop (Not, e1), info, loc)),
+             cnf (IT (Unop (Not, e1), info, loc)),
              cnf (IT (Unop (Not, e2), info, loc)) )
        | IT (Binop (Or, e1, e2), info, loc) ->
          Binop
@@ -246,12 +247,12 @@ module Make (B : BASIS) = struct
     | _ -> e
 
 
-  and cnf (e : IT.t) : IT.t =
+  and cnf (e : T.t) : T.t =
     let (IT (e, info, loc)) = e in
     IT (cnf_ e, info, loc)
 
 
-  let rec forward_abs_it (it : IT.t) (od : t) : forward_tree option =
+  let rec forward_abs_it (it : T.t) (od : t) : forward_tree option =
     let open Option in
     let (IT (it_, bt, _loc)) = it in
     let single_arg it1 =
@@ -354,7 +355,7 @@ module Make (B : BASIS) = struct
     | CopyAllocId { addr = it1; loc = it2 }
     | Aligned { t = it1; align = it2 } ->
       dual_arg it1 it2
-    | Let ((x, it1), it2) -> single_arg (IT.subst (IT.make_subst [ (x, it1) ]) it2)
+    | Let ((x, it1), it2) -> single_arg (T.subst (T.make_subst [ (x, it1) ]) it2)
     (* Triple argument cases *)
     | ITE (it1, it2, it3) | MapSet (it1, it2, it3) -> triple_arg it1 it2 it3
     (* List argument cases *)
@@ -372,20 +373,20 @@ module Make (B : BASIS) = struct
       return (Op (all_bs, b))
 
 
-  let rec backward_abs_it (it : IT.t) (t : forward_tree option) : t =
+  let rec backward_abs_it (it : T.t) (t : forward_tree option) : t =
     match t with
     | None -> top
     | Some t ->
       let (IT (it_, bt, _loc)) = it in
       let propagate_single it1 =
-        if B.supported (IT.get_bt it1) then (
+        if B.supported (T.get_bt it1) then (
           match t with
           | Op ([ t1 ], b_res) ->
             (match
                B.backward_abs_it
                  it
                  [ b_res;
-                   Option.value ~default:(B.top (IT.get_bt it1)) (Option.map tree_b t1)
+                   Option.value ~default:(B.top (T.get_bt it1)) (Option.map tree_b t1)
                  ]
              with
              | [ b1 ] ->
@@ -393,26 +394,26 @@ module Make (B : BASIS) = struct
                backward_abs_it it1 (Some t1')
              | _ -> failwith __LOC__)
           | Leaf b ->
-            (match B.backward_abs_it it [ b; B.top (IT.get_bt it1) ] with
+            (match B.backward_abs_it it [ b; B.top (T.get_bt it1) ] with
              | [ b' ] -> backward_abs_it it1 (Some (Leaf b'))
              | _ -> failwith __LOC__)
           | _ ->
             print_endline (Pp.plain (pp_tree t));
-            print_endline (Pp.plain (IT.pp it));
+            print_endline (Pp.plain (T.pp it));
             failwith __LOC__)
         else
           top
       in
       let propagate_dual it1 it2 =
-        if B.supported (IT.get_bt it1) && B.supported (IT.get_bt it2) then (
+        if B.supported (T.get_bt it1) && B.supported (T.get_bt it2) then (
           match t with
           | Op ([ t1; t2 ], b_res) ->
             (match
                B.backward_abs_it
                  it
                  [ b_res;
-                   Option.value ~default:(B.top (IT.get_bt it1)) (Option.map tree_b t1);
-                   Option.value ~default:(B.top (IT.get_bt it2)) (Option.map tree_b t2)
+                   Option.value ~default:(B.top (T.get_bt it1)) (Option.map tree_b t1);
+                   Option.value ~default:(B.top (T.get_bt it2)) (Option.map tree_b t2)
                  ]
              with
              | [ b1; b2 ] ->
@@ -422,7 +423,7 @@ module Make (B : BASIS) = struct
              | _ -> failwith __LOC__)
           | Leaf b ->
             (match
-               B.backward_abs_it it [ b; B.top (IT.get_bt it1); B.top (IT.get_bt it2) ]
+               B.backward_abs_it it [ b; B.top (T.get_bt it1); B.top (T.get_bt it2) ]
              with
              | [ b1; b2 ] ->
                meet
@@ -435,9 +436,9 @@ module Make (B : BASIS) = struct
       in
       let propagate_triple it1 it2 it3 =
         if
-          B.supported (IT.get_bt it1)
-          && B.supported (IT.get_bt it2)
-          && B.supported (IT.get_bt it3)
+          B.supported (T.get_bt it1)
+          && B.supported (T.get_bt it2)
+          && B.supported (T.get_bt it3)
         then (
           match t with
           | Op ([ t1; t2; t3 ], b_res) ->
@@ -445,9 +446,9 @@ module Make (B : BASIS) = struct
                B.backward_abs_it
                  it
                  [ b_res;
-                   Option.value ~default:(B.top (IT.get_bt it1)) (Option.map tree_b t1);
-                   Option.value ~default:(B.top (IT.get_bt it2)) (Option.map tree_b t2);
-                   Option.value ~default:(B.top (IT.get_bt it3)) (Option.map tree_b t3)
+                   Option.value ~default:(B.top (T.get_bt it1)) (Option.map tree_b t1);
+                   Option.value ~default:(B.top (T.get_bt it2)) (Option.map tree_b t2);
+                   Option.value ~default:(B.top (T.get_bt it3)) (Option.map tree_b t3)
                  ]
              with
              | [ b1; b2; b3 ] ->
@@ -460,7 +461,7 @@ module Make (B : BASIS) = struct
              | _ -> failwith __LOC__)
           | Leaf b ->
             (match
-               B.backward_abs_it it [ b; B.top (IT.get_bt it1); B.top (IT.get_bt it1) ]
+               B.backward_abs_it it [ b; B.top (T.get_bt it1); B.top (T.get_bt it1) ]
              with
              | [ b1; b2 ] ->
                meet
@@ -474,7 +475,7 @@ module Make (B : BASIS) = struct
           top
       in
       let propagate_list its =
-        if its |> List.map IT.get_bt |> List.for_all B.supported then (
+        if its |> List.map T.get_bt |> List.for_all B.supported then (
           match t with
           | Op (ts, b_res) ->
             assert (List.length ts = List.length its);
@@ -485,7 +486,7 @@ module Make (B : BASIS) = struct
                  :: List.map
                       (fun (it, t) ->
                          Option.value
-                           ~default:(B.top (IT.get_bt it))
+                           ~default:(B.top (T.get_bt it))
                            (Option.map tree_b t))
                       (List.combine its ts))
             in
@@ -497,7 +498,7 @@ module Make (B : BASIS) = struct
             List.fold_left meet top results
           | Leaf b ->
             let bs =
-              B.backward_abs_it it ([ b ] @ List.map (fun it -> B.top (IT.get_bt it)) its)
+              B.backward_abs_it it ([ b ] @ List.map (fun it -> B.top (T.get_bt it)) its)
             in
             assert (List.length bs = List.length its);
             let ts' = List.map (fun b -> Some (Leaf b)) bs in
@@ -521,14 +522,14 @@ module Make (B : BASIS) = struct
        | Unop (Not, IT (Binop (LEPointer, it1, it2), _, _))
        | Unop (Not, IT (Binop (LT, it1, it2), _, _))
        | Unop (Not, IT (Binop (LTPointer, it1, it2), _, _)) ->
-         if B.supported (IT.get_bt it1) then (
+         if B.supported (T.get_bt it1) then (
            let t1, t2 = tree_test t in
            let b1, b2 =
              match
                B.backward_abs_it
                  it
-                 [ Option.value ~default:(B.top (IT.get_bt it1)) (Option.map tree_b t1);
-                   Option.value ~default:(B.top (IT.get_bt it2)) (Option.map tree_b t2)
+                 [ Option.value ~default:(B.top (T.get_bt it1)) (Option.map tree_b t1);
+                   Option.value ~default:(B.top (T.get_bt it2)) (Option.map tree_b t2)
                  ]
              with
              | [ b1; b2 ] -> (b1, b2)
@@ -597,7 +598,7 @@ module Make (B : BASIS) = struct
            top
        | Let ((x, it1), it2) ->
          if B.supported bt then
-           propagate_single (IT.subst (IT.make_subst [ (x, it1) ]) it2)
+           propagate_single (T.subst (T.make_subst [ (x, it1) ]) it2)
          else
            top
        (* Complex cases *)
@@ -618,7 +619,7 @@ module Make (B : BASIS) = struct
            top)
 
 
-  let local_iteration (it : IT.t) (d : t) : t =
+  let local_iteration (it : T.t) (d : t) : t =
     let rec aux (d : t) (fuel : int) : t =
       if fuel <= 0 then
         d
@@ -652,7 +653,7 @@ module Make (B : BASIS) = struct
 
   let pp_args = B.pp_sym_args
 
-  let to_it (od : t) : IT.t =
+  let to_it (od : t) : T.t =
     let loc = Locations.other __LOC__ in
     match od with
     | None -> IT.bool_ false loc (* bottom = unsatisfiable *)

--- a/lib/testGeneration/bennet/abstractDomains/ownership.ml
+++ b/lib/testGeneration/bennet/abstractDomains/ownership.ml
@@ -10,6 +10,7 @@
 *)
 
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -52,7 +53,7 @@ module Inner = struct
       string_of_int before ^ ", " ^ string_of_int after
 
 
-    let to_it (oo : t) (sym : Sym.t) : IT.t =
+    let to_it (oo : t) (sym : Sym.t) : T.t =
       let loc = Locations.other __LOC__ in
       match oo with
       | Some (_, (0, 0)) | None -> IT.bool_ true loc
@@ -189,8 +190,8 @@ module Inner = struct
 
   let abs_assert _ d : t = d
 
-  let abs_assign (((it_addr, sct), _) : (IT.t * Sctypes.t) * IT.t) (d : t) : t =
-    let rec pointer_and_offset (it : IT.t) : ((Sym.t * BaseTypes.t) * int) option =
+  let abs_assign (((it_addr, sct), _) : (T.t * Sctypes.t) * T.t) (d : t) : t =
+    let rec pointer_and_offset (it : T.t) : ((Sym.t * BaseTypes.t) * int) option =
       let open Option in
       match it with
       | IT (CopyAllocId { loc = ptr; _ }, _, _) ->
@@ -230,7 +231,7 @@ module Inner = struct
 
   let pp_args () = "before, after"
 
-  let to_it (d : t) : IT.t =
+  let to_it (d : t) : T.t =
     let loc = Locations.other __LOC__ in
     match d with
     | None -> IT.bool_ false loc (* bottom = unsatisfiable *)

--- a/lib/testGeneration/bennet/abstractDomains/product.ml
+++ b/lib/testGeneration/bennet/abstractDomains/product.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module Sym = Sym
@@ -780,7 +781,7 @@ let product_domains (domains : (module Domain.T) list) =
           product
 
 
-      let abs_assign (assign_info : (IT.t * Sctypes.t) * IT.t) (product : t) : t =
+      let abs_assign (assign_info : (T.t * Sctypes.t) * T.t) (product : t) : t =
         Array.map
           (fun comp ->
              match comp with

--- a/lib/testGeneration/bennet/abstractDomains/tNum.ml
+++ b/lib/testGeneration/bennet/abstractDomains/tNum.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 
 (** Tristate number (tnum) abstract domain.
@@ -464,7 +465,7 @@ module TristateBasis = struct
       top t1.bt
 
 
-  let forward_abs_binop (op : IT.binop) (t1 : t) (t2 : t) : t option =
+  let forward_abs_binop (op : Terms.binop) (t1 : t) (t2 : t) : t option =
     assert (BT.equal t1.bt t2.bt);
     if is_bottom t1 || is_bottom t2 then
       Some (bottom t1.bt)
@@ -483,7 +484,7 @@ module TristateBasis = struct
       | _ -> None)
 
 
-  let forward_abs_unop (op : IT.unop) (t : t) : t option =
+  let forward_abs_unop (op : Terms.unop) (t : t) : t option =
     match op with
     | BW_Compl -> Some (tnum_not t)
     | Negate ->
@@ -553,7 +554,7 @@ module TristateBasis = struct
           of_tnum target_bt t.value t.mask))
 
 
-  let forward_abs_it (it : IT.t) (t_args : t list) : t option =
+  let forward_abs_it (it : T.t) (t_args : t list) : t option =
     let (IT (it_, bt, _loc)) = it in
     match it_ with
     | Const (Bits (_, n)) -> Some (of_const bt n)
@@ -567,7 +568,7 @@ module TristateBasis = struct
         print_endline
           Pp.(
             plain
-              (IT.pp it
+              (T.pp it
                ^^^ pp t1
                ^^ parens (BT.pp t1.bt)
                ^^^ pp t2
@@ -591,11 +592,11 @@ module TristateBasis = struct
     | _ -> None
 
 
-  let rec backward_abs_it (it : IT.t) (ts : t list) =
+  let rec backward_abs_it (it : T.t) (ts : t list) =
     let (IT (it_, _, loc)) = it in
     match it_ with
     | Binop (EQ, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       if Option.is_none (BT.is_bits_bt bt) && not (BT.equal bt (BT.Loc ())) then
         ts
       else (
@@ -604,7 +605,7 @@ module TristateBasis = struct
         [ t; t ])
     (* Handle inequality via negation of equality *)
     | Unop (Not, IT (Binop (EQ, it', _), _, _)) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       if Option.is_none (BT.is_bits_bt bt) && not (BT.equal bt (BT.Loc ())) then
         ts
       else (
@@ -657,7 +658,7 @@ module TristateBasis = struct
         else (* Both are non-constant - conservative: no refinement *)
           ts)
     | Binop (LE, it', _) | Binop (LEPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       let min, max = get_extrema bt in
       let t1, t2 = match ts with [ t1; t2 ] -> (t1, t2) | _ -> failwith __LOC__ in
       (* Convert stored unsigned values to signed for interval computation *)
@@ -669,7 +670,7 @@ module TristateBasis = struct
       let t2'' = if Z.equal t1.mask Z.zero then meet t2 t2' else t2 in
       [ t1''; t2'' ]
     | Binop (LT, it', _) | Binop (LTPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = T.get_bt it' in
       let min, max = get_extrema bt in
       let t1, t2 = match ts with [ t1; t2 ] -> (t1, t2) | _ -> failwith __LOC__ in
       (* Convert stored unsigned values to signed for interval computation *)
@@ -855,7 +856,7 @@ module TristateBasis = struct
           let refined_t1 = of_tnum t1.bt derived_value derived_mask in
           [ meet t1 refined_t1; t2 ]))
     | _ ->
-      if BT.equal BT.Bool (IT.get_bt it) then
+      if BT.equal BT.Bool (T.get_bt it) then
         ts
       else
         List.tl ts
@@ -918,7 +919,7 @@ module TristateBasis = struct
 
   let definitions () = Pp.empty
 
-  let to_it (sym : Sym.t) (t : t) : IT.t =
+  let to_it (sym : Sym.t) (t : t) : T.t =
     let loc = Locations.other __LOC__ in
     if is_bottom t then
       IT.bool_ false loc

--- a/lib/testGeneration/bennet/abstractDomains/tNum.ml
+++ b/lib/testGeneration/bennet/abstractDomains/tNum.ml
@@ -568,11 +568,7 @@ module TristateBasis = struct
         print_endline
           Pp.(
             plain
-              (T.pp it
-               ^^^ pp t1
-               ^^ parens (BT.pp t1.bt)
-               ^^^ pp t2
-               ^^ parens (BT.pp t2.bt)));
+              (T.pp it ^^^ pp t1 ^^ parens (BT.pp t1.bt) ^^^ pp t2 ^^ parens (BT.pp t2.bt)));
         failwith __LOC__);
       forward_abs_binop op t1 t2
     | Unop (op, _) ->

--- a/lib/testGeneration/bennet/abstractDomains/wrappedInterval.ml
+++ b/lib/testGeneration/bennet/abstractDomains/wrappedInterval.ml
@@ -866,13 +866,13 @@ module WrappedIntervalBasis = struct
                 (* Compute bitwise operation bounds for this pair *)
                 let lb, ub =
                   match op with
-                  | IT.BW_Or ->
+                  | Terms.BW_Or ->
                     ( min_or bt s1'.start s1'.stop s2'.start s2'.stop,
                       max_or bt s1'.start s1'.stop s2'.start s2'.stop )
-                  | IT.BW_And ->
+                  | BW_And ->
                     ( min_and bt s1'.start s1'.stop s2'.start s2'.stop,
                       max_and bt s1'.start s1'.stop s2'.start s2'.stop )
-                  | IT.BW_Xor ->
+                  | BW_Xor ->
                     ( min_xor bt s1'.start s1'.stop s2'.start s2'.stop,
                       max_xor bt s1'.start s1'.stop s2'.start s2'.stop )
                   | _ -> failwith "unsupported bitwise operation"
@@ -902,7 +902,7 @@ module WrappedIntervalBasis = struct
       else (
         let k_int = Z.to_int k in
         match op with
-        | IT.ShiftLeft ->
+        | Terms.ShiftLeft ->
           (* Left shift: check if lower (width-k) bits fit in interval *)
           let num_bits_survive_shift = width - k_int in
           if num_bits_survive_shift <= 0 then
@@ -921,7 +921,7 @@ module WrappedIntervalBasis = struct
               let max_val = Z.sub (Z.shift_left Z.one num_bits_survive_shift) Z.one in
               let upper_bound = normalize bt (Z.shift_left max_val k_int) in
               { bt; is_bottom = false; start = Z.zero; stop = upper_bound }))
-        | IT.ShiftRight ->
+        | ShiftRight ->
           (* Right shift algorithm - determine if logical or arithmetic based on type *)
           let is_signed =
             match BT.is_bits_bt bt with Some (Signed, _) -> true | _ -> false
@@ -980,7 +980,7 @@ module WrappedIntervalBasis = struct
         | _ -> failwith "unsupported shift operation"))
 
 
-  let forward_abs_binop (op : IT.binop) (b1 : t) (b2 : t) : t option =
+  let forward_abs_binop (op : Terms.binop) (b1 : t) (b2 : t) : t option =
     assert (BT.equal b1.bt b2.bt);
     if b1.is_bottom || b2.is_bottom then
       Some (bottom b1.bt)
@@ -1028,7 +1028,7 @@ module WrappedIntervalBasis = struct
 
 
   (* Handle unary operations *)
-  let forward_abs_unop (op : IT.unop) (b : t) : t option =
+  let forward_abs_unop (op : Terms.unop) (b : t) : t option =
     match op with
     | BW_Compl ->
       if b.is_bottom then
@@ -1055,7 +1055,7 @@ module WrappedIntervalBasis = struct
     | _ -> None
 
 
-  let forward_abs_it (it : IT.t) (b_args : t list) : t option =
+  let forward_abs_it (it : Terms.Normal.t) (b_args : t list) : t option =
     let (IT (it_, bt, _loc)) = it in
     match it_ with
     | Const (Bits (_, n)) -> Some (of_interval bt n n)
@@ -1069,7 +1069,7 @@ module WrappedIntervalBasis = struct
         print_endline
           Pp.(
             plain
-              (IT.pp it
+              (Terms.pp it
                ^^^ pp b1
                ^^ parens (BT.pp b1.bt)
                ^^^ pp b2
@@ -1139,12 +1139,12 @@ module WrappedIntervalBasis = struct
   (* Helper: check if an interval is a constant (singleton) *)
   let is_constant_range s = Z.equal s.start s.stop
 
-  let rec backward_abs_it (it : IT.t) (bs : t list) =
+  let rec backward_abs_it (it : Terms.Normal.t) (bs : t list) =
     let (IT (it_, _, loc)) = it in
     match it_ with
     (* Handle inequality via negation of equality *)
     | Unop (Not, IT (Binop (EQ, it', _), _, _)) ->
-      let bt = IT.get_bt it' in
+      let bt = Terms.get_bt it' in
       if Option.is_none (BT.is_bits_bt bt) && not (BT.equal bt (BT.Loc ())) then
         bs
       else (
@@ -1179,7 +1179,7 @@ module WrappedIntervalBasis = struct
         else (* Both are intervals - conservative: no refinement *)
           bs)
     | Binop (EQ, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = Terms.get_bt it' in
       if Option.is_none (BT.is_bits_bt bt) && not (BT.equal bt (BT.Loc ())) then
         bs
       else (
@@ -1187,14 +1187,14 @@ module WrappedIntervalBasis = struct
         let b = meet b1 b2 in
         [ b; b ])
     | Binop (LE, it', _) | Binop (LEPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = Terms.get_bt it' in
       let min, max = get_extrema bt in
       let b1, b2 = match bs with [ b1; b2 ] -> (b1, b2) | _ -> failwith __LOC__ in
       let b1' = of_interval bt min b2.stop in
       let b2' = of_interval bt b1.start max in
       [ meet b1 b1'; meet b2 b2' ]
     | Binop (LT, it', _) | Binop (LTPointer, it', _) ->
-      let bt = IT.get_bt it' in
+      let bt = Terms.get_bt it' in
       let min, max = get_extrema bt in
       let b1, b2 = match bs with [ b1; b2 ] -> (b1, b2) | _ -> failwith __LOC__ in
       let b1' = of_interval bt min (Z.sub b2.stop Z.one) in
@@ -1207,7 +1207,7 @@ module WrappedIntervalBasis = struct
     | Unop (Not, IT (Binop (LTPointer, it1, it2), _, _)) ->
       backward_abs_it (IT.lt_ (it2, it1) loc) bs
     | _ ->
-      if BT.equal BT.Bool (IT.get_bt it) then
+      if BT.equal BT.Bool (Terms.get_bt it) then
         bs
       else
         List.tl bs
@@ -1270,7 +1270,7 @@ module WrappedIntervalBasis = struct
 
   let definitions () = Pp.empty
 
-  let to_it (sym : Sym.t) (t : t) : IT.t =
+  let to_it (sym : Sym.t) (t : t) : Terms.Normal.t =
     let loc = Locations.other __LOC__ in
     if is_bottom t then
       IT.bool_ false loc

--- a/lib/testGeneration/bennet/domain.ml
+++ b/lib/testGeneration/bennet/domain.ml
@@ -1,4 +1,4 @@
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 
 let ret_sym = Sym.fresh "return"
@@ -88,7 +88,7 @@ module type T = sig
   (** Abstract interpretation operations *)
   val abs_assert : LC.t -> t -> t
 
-  val abs_assign : (IT.t * Sctypes.t) * IT.t -> t -> t
+  val abs_assign : (T.t * Sctypes.t) * T.t -> t -> t
 
   (** Check truthiness *)
   val to_lc : t -> LC.t

--- a/lib/testGeneration/bennet/genTerms.ml
+++ b/lib/testGeneration/bennet/genTerms.ml
@@ -1,5 +1,5 @@
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 
 type ('tag, 'ast) annot =
@@ -11,30 +11,30 @@ module Base (AD : Domain.T) = struct
   type ('tag, 'recur) ast =
     [ `Arbitrary (** Generate arbitrary values *)
     | `Symbolic (** Generate symbolic values *)
-    | `ArbitrarySpecialized of (IT.t option * IT.t option) * (IT.t option * IT.t option)
+    | `ArbitrarySpecialized of (T.t option * T.t option) * (T.t option * T.t option)
       (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
     | `ArbitraryDomain of AD.Relative.t
-    | `Call of Sym.t * IT.t list
-      (** Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-    | `Asgn of (IT.t * Sctypes.t) * IT.t * ('tag, 'recur) annot
+    | `Call of Sym.t * T.t list
+      (** Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+    | `Asgn of (T.t * Sctypes.t) * T.t * ('tag, 'recur) annot
       (** Claim ownership and assign a value to a memory location *)
     | `LetStar of (Sym.t * ('tag, 'recur) annot) * ('tag, 'recur) annot
       (** Backtrack point *)
-    | `Return of IT.t (** Monadic return *)
+    | `Return of T.t (** Monadic return *)
     | `Assert of LC.t * ('tag, 'recur) annot
       (** Assert some [LC.t] are true, backtracking otherwise *)
     | `AssertDomain of AD.t * ('tag, 'recur) annot
       (** Assert domain constraints are satisfied, backtracking otherwise *)
-    | `ITE of IT.t * ('tag, 'recur) annot * ('tag, 'recur) annot (** If-then-else *)
-    | `Map of (Sym.t * BT.t * IT.t) * ('tag, 'recur) annot
+    | `ITE of T.t * ('tag, 'recur) annot * ('tag, 'recur) annot (** If-then-else *)
+    | `Map of (Sym.t * BT.t * T.t) * ('tag, 'recur) annot
     | `Pick of ('tag, 'recur) annot list (** Pick among a list of options *)
-    | `CallSized of Sym.t * IT.t list * (int * Sym.t)
+    | `CallSized of Sym.t * T.t list * (int * Sym.t)
     | `PickSized of (Z.t * ('tag, 'recur) annot) list
       (** Pick among a list of options, weighted by the provided [Z.t]s *)
     | `SplitSize of Sym.Set.t * ('tag, 'recur) annot
     | `AsgnElab of
-        Sym.t * (((Sym.t * BT.t) * IT.t) * Sctypes.t) * IT.t * ('tag, 'recur) annot
-    | `MapElab of (Sym.t * BT.t * (IT.t * IT.t) * IT.t) * ('tag, 'recur) annot
+        Sym.t * (((Sym.t * BT.t) * T.t) * Sctypes.t) * T.t * ('tag, 'recur) annot
+    | `MapElab of (Sym.t * BT.t * (T.t * T.t) * T.t) * ('tag, 'recur) annot
     | `PickSizedElab of Sym.t * (Z.t * ('tag, 'recur) annot) list
     | `SplitSizeElab of Sym.t * Sym.Set.t * ('tag, 'recur) annot
     ]
@@ -59,7 +59,7 @@ module type T = sig
   val symbolic_ : tag_t -> BT.t -> Locations.t -> t
 
   val arbitrary_specialized_
-    :  (IT.t option * IT.t option) * (IT.t option * IT.t option) ->
+    :  (T.t option * T.t option) * (T.t option * T.t option) ->
     tag_t ->
     BT.t ->
     Locations.t ->
@@ -67,23 +67,23 @@ module type T = sig
 
   val arbitrary_domain_ : AD.Relative.t -> tag_t -> BT.t -> Locations.t -> t
 
-  val call_ : Sym.t * IT.t list -> tag_t -> BT.t -> Locations.t -> t
+  val call_ : Sym.t * T.t list -> tag_t -> BT.t -> Locations.t -> t
 
-  val asgn_ : (IT.t * Sctypes.t) * IT.t * t -> tag_t -> Locations.t -> t
+  val asgn_ : (T.t * Sctypes.t) * T.t * t -> tag_t -> Locations.t -> t
 
   val let_star_ : (Sym.t * t) * t -> tag_t -> Locations.t -> t
 
-  val return_ : IT.t -> tag_t -> Locations.t -> t
+  val return_ : T.t -> tag_t -> Locations.t -> t
 
   val assert_ : LC.t * t -> tag_t -> Locations.t -> t
 
   val assert_domain_ : AD.t * t -> tag_t -> Locations.t -> t
 
-  val ite_ : IT.t * t * t -> tag_t -> Locations.t -> t
+  val ite_ : T.t * t * t -> tag_t -> Locations.t -> t
 
-  val map_ : (Sym.t * BT.t * IT.t) * t -> tag_t -> Locations.t -> t
+  val map_ : (Sym.t * BT.t * T.t) * t -> tag_t -> Locations.t -> t
 
-  val map_elab_ : (Sym.t * BT.t * (IT.t * IT.t) * IT.t) * t -> tag_t -> Locations.t -> t
+  val map_elab_ : (Sym.t * BT.t * (T.t * T.t) * T.t) * t -> tag_t -> Locations.t -> t
 
   val pick_ : t list -> tag_t -> BT.t -> Locations.t -> t
 
@@ -91,10 +91,10 @@ module type T = sig
 
   val pick_sized_elab_ : Sym.t -> (Z.t * t) list -> tag_t -> BT.t -> Locations.t -> t
 
-  val call_sized_ : Sym.t * IT.t list * (int * Sym.t) -> tag_t -> BT.t -> Locations.t -> t
+  val call_sized_ : Sym.t * T.t list * (int * Sym.t) -> tag_t -> BT.t -> Locations.t -> t
 
   val asgn_elab_
-    :  Sym.t * (((Sym.t * BT.t) * IT.t) * Sctypes.t) * IT.t * t ->
+    :  Sym.t * (((Sym.t * BT.t) * T.t) * Sctypes.t) * T.t * t ->
     tag_t ->
     Locations.t ->
     t
@@ -127,7 +127,7 @@ module Make (GT : T) = struct
     is_arbitrary_ gt_
 
 
-  let is_call_ (gt_ : GT.t_) : (Sym.t * IT.t list) option =
+  let is_call_ (gt_ : GT.t_) : (Sym.t * T.t list) option =
     match gt_ with `Call x -> Some x | _ -> None
 
 
@@ -136,7 +136,7 @@ module Make (GT : T) = struct
     is_call_ gt_
 
 
-  let is_asgn_ (gt_ : GT.t_) : ((IT.t * Sctypes.ctype) * IT.t * GT.t) option =
+  let is_asgn_ (gt_ : GT.t_) : ((T.t * Sctypes.ctype) * T.t * GT.t) option =
     match gt_ with `Asgn x -> Some x | _ -> None
 
 
@@ -165,7 +165,7 @@ module Make (GT : T) = struct
     | `ArbitrarySpecialized ((min_inc, min_ex), (max_inc, max_ex)) ->
       let pp_opt = function
         | None -> !^"None"
-        | Some it -> !^"Some" ^^^ parens (IT.pp it)
+        | Some it -> !^"Some" ^^^ parens (T.pp it)
       in
       !^"arbitrary_specialized"
       ^^ angles (BT.pp bt)
@@ -176,9 +176,9 @@ module Make (GT : T) = struct
     | `ArbitraryDomain d ->
       !^"arbitrary_domain" ^^ angles (BT.pp bt) ^^ parens (AD.Relative.pp d)
     | `Call (fsym, iargs) ->
-      Sym.pp fsym ^^ parens (nest 2 (separate_map (comma ^^ break 1) IT.pp iargs))
+      Sym.pp fsym ^^ parens (nest 2 (separate_map (comma ^^ break 1) T.pp iargs))
     | `Asgn ((it_addr, ty), it_val, gt') ->
-      Sctypes.pp ty ^^^ IT.pp it_addr ^^^ !^":=" ^^^ IT.pp it_val ^^ semi ^/^ pp gt'
+      Sctypes.pp ty ^^^ T.pp it_addr ^^^ !^":=" ^^^ T.pp it_val ^^ semi ^/^ pp gt'
     | `LetStar ((x, gt1), gt2) ->
       !^"let*"
       ^^^ Sym.pp x
@@ -188,7 +188,7 @@ module Make (GT : T) = struct
       ^^ nest 2 (break 1 ^^ pp gt1)
       ^^ semi
       ^/^ pp gt2
-    | `Return it -> !^"return" ^^^ IT.pp it
+    | `Return it -> !^"return" ^^^ T.pp it
     | `Assert (lc, gt') ->
       !^"assert" ^^ parens (nest 2 (break 1 ^^ LC.pp lc) ^^ break 1) ^^ semi ^/^ pp gt'
     | `AssertDomain (d, gt') ->
@@ -198,13 +198,13 @@ module Make (GT : T) = struct
       ^/^ pp gt'
     | `ITE (it_if, gt_then, gt_else) ->
       !^"if"
-      ^^^ parens (IT.pp it_if)
+      ^^^ parens (T.pp it_if)
       ^^^ braces (nest 2 (break 1 ^^ pp gt_then) ^^ break 1)
       ^^^ !^"else"
       ^^^ braces (nest 2 (break 1 ^^ pp gt_else) ^^ break 1)
     | `Map ((i, i_bt, it_perm), gt') ->
       !^"map"
-      ^^^ parens (BT.pp i_bt ^^^ Sym.pp i ^^ semi ^^^ IT.pp it_perm)
+      ^^^ parens (BT.pp i_bt ^^^ Sym.pp i ^^ semi ^^^ T.pp it_perm)
       ^^ braces (nest 2 (break 1 ^^ pp gt') ^^ break 1)
     | `Pick gts ->
       !^"pick"
@@ -217,7 +217,7 @@ module Make (GT : T) = struct
     | `CallSized (fsym, iargs, (n, size_sym)) ->
       Sym.pp fsym
       ^^ brackets (int n ^^ comma ^^^ Sym.pp size_sym)
-      ^^ parens (nest 2 (separate_map (comma ^^ break 1) IT.pp iargs))
+      ^^ parens (nest 2 (separate_map (comma ^^ break 1) T.pp iargs))
     | `PickSized wgts ->
       !^"pick"
       ^^ parens
@@ -239,9 +239,9 @@ module Make (GT : T) = struct
             (BT.pp i_bt
              ^^^ Sym.pp i
              ^^ semi
-             ^^^ IT.pp it_perm
+             ^^^ T.pp it_perm
              ^^ c_comment
-                  (IT.pp it_min ^^ !^" <= " ^^ Sym.pp i ^^ !^" <= " ^^ IT.pp it_max))
+                  (T.pp it_min ^^ !^" <= " ^^ Sym.pp i ^^ !^" <= " ^^ T.pp it_max))
       ^^ braces (c_comment (BT.pp bt) ^^ nest 2 (break 1 ^^ pp gt_inner) ^^ break 1)
     | `PickSizedElab (choice_var, wgts) ->
       !^"pick"
@@ -262,9 +262,9 @@ module Make (GT : T) = struct
       ^/^ pp gt_rest
     | `AsgnElab (backtrack_var, (((p_sym, p_bt), it_addr), sct), it_val, gt_rest) ->
       Sctypes.pp sct
-      ^^^ IT.pp it_addr
+      ^^^ T.pp it_addr
       ^^^ !^":="
-      ^^^ IT.pp it_val
+      ^^^ T.pp it_val
       ^^ semi
       ^^^ c_comment
             (!^"can be backtracked to as"
@@ -280,14 +280,14 @@ module Make (GT : T) = struct
     match gt_ with
     | `Arbitrary | `ArbitraryDomain _ | `Symbolic -> Sym.Map.empty
     | `ArbitrarySpecialized ((min_inc, min_ex), (max_inc, max_ex)) ->
-      IT.free_vars_bts_list (List.filter_map Fun.id [ min_inc; min_ex; max_inc; max_ex ])
-    | `Call (_, iargs) | `CallSized (_, iargs, _) -> IT.free_vars_bts_list iargs
+      T.free_vars_bts_list (List.filter_map Fun.id [ min_inc; min_ex; max_inc; max_ex ])
+    | `Call (_, iargs) | `CallSized (_, iargs, _) -> T.free_vars_bts_list iargs
     | `Asgn ((it_addr, _), it_val, gt') | `AsgnElab (_, ((_, it_addr), _), it_val, gt') ->
       Sym.Map.union
         (fun _ bt1 bt2 ->
            assert (BT.equal bt1 bt2);
            Some bt1)
-        (IT.free_vars_bts_list [ it_addr; it_val ])
+        (T.free_vars_bts_list [ it_addr; it_val ])
         (free_vars_bts gt')
     | `LetStar ((x, gt_inner), gt_rest) ->
       Sym.Map.union
@@ -296,7 +296,7 @@ module Make (GT : T) = struct
            Some bt1)
         (free_vars_bts gt_inner)
         (Sym.Map.remove x (free_vars_bts gt_rest))
-    | `Return it -> IT.free_vars_bts it
+    | `Return it -> T.free_vars_bts it
     | `Assert (lc, gt') ->
       (Sym.Map.union (fun _ bt1 bt2 ->
          assert (BT.equal bt1 bt2);
@@ -309,7 +309,7 @@ module Make (GT : T) = struct
         (fun _ bt1 bt2 ->
            assert (BT.equal bt1 bt2);
            Some bt1)
-        (IT.free_vars_bts it_if)
+        (T.free_vars_bts it_if)
         (free_vars_bts_list [ gt_then; gt_else ])
     | `Map ((i, _, it_perm), gt') | `MapElab ((i, _, _, it_perm), gt') ->
       Sym.Map.remove
@@ -318,7 +318,7 @@ module Make (GT : T) = struct
            (fun _ bt1 bt2 ->
               assert (BT.equal bt1 bt2);
               Some bt1)
-           (IT.free_vars_bts it_perm)
+           (T.free_vars_bts it_perm)
            (free_vars_bts gt'))
     | `Pick gts -> free_vars_bts_list gts
     | `PickSized wgts | `PickSizedElab (_, wgts) ->
@@ -394,15 +394,15 @@ module Make (GT : T) = struct
       | `ArbitrarySpecialized ((min_inc, min_ex), (max_inc, max_ex)) ->
         [ min_inc; min_ex; max_inc; max_ex ]
         |> List.filter_map Fun.id
-        |> List.map IT.preds_of
+        |> List.map Terms.preds_of
         |> List.fold_left Sym.Set.union Sym.Set.empty
-      | `Return it -> IT.preds_of it
+      | `Return it -> Terms.preds_of it
       | `Call (_, its) | `CallSized (_, its, _) ->
-        its |> List.map IT.preds_of |> List.fold_left Sym.Set.union Sym.Set.empty
+        its |> List.map Terms.preds_of |> List.fold_left Sym.Set.union Sym.Set.empty
       | `Asgn ((it_addr, _), it_val, gt_rest)
       | `AsgnElab (_, ((_, it_addr), _), it_val, gt_rest) ->
         [ it_addr; it_val ]
-        |> List.map IT.preds_of
+        |> List.map Terms.preds_of
         |> List.fold_left Sym.Set.union (aux gt_rest)
       | `LetStar ((_, gt_inner), gt_rest) -> Sym.Set.union (aux gt_inner) (aux gt_rest)
       | `Assert (lc, gt_rest) -> Sym.Set.union (LC.preds_of lc) (aux gt_rest)
@@ -411,9 +411,9 @@ module Make (GT : T) = struct
       | `SplitSizeElab (_, _, gt_rest) ->
         aux gt_rest
       | `ITE (it_if, gt_then, gt_else) ->
-        List.fold_left Sym.Set.union (IT.preds_of it_if) [ aux gt_then; aux gt_else ]
+        List.fold_left Sym.Set.union (Terms.preds_of it_if) [ aux gt_then; aux gt_else ]
       | `Map ((_, _, it_perm), gt_inner) | `MapElab ((_, _, _, it_perm), gt_inner) ->
-        Sym.Set.union (IT.preds_of it_perm) (aux gt_inner)
+        Sym.Set.union (Terms.preds_of it_perm) (aux gt_inner)
       | `Pick gts -> gts |> List.map aux |> List.fold_left Sym.Set.union Sym.Set.empty
       | `PickSized wgts | `PickSizedElab (_, wgts) ->
         wgts |> List.map snd |> List.map aux |> List.fold_left Sym.Set.union Sym.Set.empty
@@ -421,51 +421,51 @@ module Make (GT : T) = struct
     aux gt
 
 
-  let rec subst (su : [ `Term of IT.t | `Rename of Sym.t ] Subst.t) (gt : t) : t =
+  let rec subst (su : [ `Term of T.t | `Rename of Sym.t ] Subst.t) (gt : t) : t =
     let (Annot (gt_, tag, bt, loc)) = gt in
     match gt_ with
     | `Arbitrary -> arbitrary_ tag bt loc
     | `Symbolic -> symbolic_ tag bt loc
     | `ArbitrarySpecialized ((min_inc, min_ex), (max_inc, max_ex)) ->
       arbitrary_specialized_
-        ( (Option.map (IT.subst su) min_inc, Option.map (IT.subst su) min_ex),
-          (Option.map (IT.subst su) max_inc, Option.map (IT.subst su) max_ex) )
+        ( (Option.map (T.subst su) min_inc, Option.map (T.subst su) min_ex),
+          (Option.map (T.subst su) max_inc, Option.map (T.subst su) max_ex) )
         tag
         bt
         loc
     | `ArbitraryDomain ad -> arbitrary_domain_ ad tag bt loc
-    | `Call (fsym, iargs) -> call_ (fsym, List.map (IT.subst su) iargs) tag bt loc
+    | `Call (fsym, iargs) -> call_ (fsym, List.map (T.subst su) iargs) tag bt loc
     | `CallSized (fsym, iargs, sz) ->
-      call_sized_ (fsym, List.map (IT.subst su) iargs, sz) tag bt loc
+      call_sized_ (fsym, List.map (T.subst su) iargs, sz) tag bt loc
     | `Asgn ((it_addr, sct), it_val, g') ->
-      asgn_ ((IT.subst su it_addr, sct), IT.subst su it_val, subst su g') tag loc
+      asgn_ ((T.subst su it_addr, sct), T.subst su it_val, subst su g') tag loc
     | `AsgnElab (backtrack_var, ((pointer, it_addr), sct), it_val, g') ->
       asgn_elab_
         ( backtrack_var,
-          ((pointer, IT.subst su it_addr), sct),
-          IT.subst su it_val,
+          ((pointer, T.subst su it_addr), sct),
+          T.subst su it_val,
           subst su g' )
         tag
         loc
     | `LetStar ((x, gt1), gt2) ->
       let x, gt2 = suitably_alpha_rename_gen su.relevant x gt2 in
       let_star_ ((x, subst su gt1), subst su gt2) tag loc
-    | `Return it -> return_ (IT.subst su it) tag loc
+    | `Return it -> return_ (T.subst su it) tag loc
     | `Assert (lc, gt') -> assert_ (LC.subst su lc, subst su gt') tag loc
     | `AssertDomain (ad, gt') -> assert_domain_ (ad, subst su gt') tag loc
     | `ITE (it, gt_then, gt_else) ->
-      ite_ (IT.subst su it, subst su gt_then, subst su gt_else) tag loc
+      ite_ (T.subst su it, subst su gt_then, subst su gt_else) tag loc
     | `Map ((i, i_bt, it_perm), gt') ->
-      let i', it_perm = IT.suitably_alpha_rename su.relevant i it_perm in
-      let gt' = subst (IT.make_rename ~from:i ~to_:i') gt' in
-      map_ ((i', i_bt, IT.subst su it_perm), subst su gt') tag loc
+      let i', it_perm = T.suitably_alpha_rename su.relevant i it_perm in
+      let gt' = subst (T.make_rename ~from:i ~to_:i') gt' in
+      map_ ((i', i_bt, T.subst su it_perm), subst su gt') tag loc
     | `MapElab ((i, i_bt, (it_min, it_max), it_perm), gt') ->
-      let i', it_min = IT.suitably_alpha_rename su.relevant i it_min in
-      let it_max = IT.subst (IT.make_rename ~from:i ~to_:i') it_max in
-      let it_perm = IT.subst (IT.make_rename ~from:i ~to_:i') it_perm in
-      let gt' = subst (IT.make_rename ~from:i ~to_:i') gt' in
+      let i', it_min = T.suitably_alpha_rename su.relevant i it_min in
+      let it_max = T.subst (T.make_rename ~from:i ~to_:i') it_max in
+      let it_perm = T.subst (T.make_rename ~from:i ~to_:i') it_perm in
+      let gt' = subst (T.make_rename ~from:i ~to_:i') gt' in
       map_elab_
-        ( (i', i_bt, (IT.subst su it_min, IT.subst su it_max), IT.subst su it_perm),
+        ( (i', i_bt, (T.subst su it_min, T.subst su it_max), T.subst su it_perm),
           subst su gt' )
         tag
         loc
@@ -486,7 +486,7 @@ module Make (GT : T) = struct
 
   and alpha_rename_gen x gt =
     let x' = Sym.fresh_same x in
-    (x', subst (IT.make_rename ~from:x ~to_:x') gt)
+    (x', subst (T.make_rename ~from:x ~to_:x') gt)
 
 
   and suitably_alpha_rename_gen syms x gt =
@@ -655,9 +655,9 @@ module Make (GT : T) = struct
   (***************)
 
   let elaborate_asgn_ (`Asgn ((it_addr, sct), it_value, gt_rest))
-    : [> `AsgnElab of Sym.t * (((Sym.t * BT.t) * IT.t) * Sctypes.t) * IT.t * GT.t ]
+    : [> `AsgnElab of Sym.t * (((Sym.t * BT.t) * T.t) * Sctypes.t) * T.t * GT.t ]
     =
-    let rec pointer_of (it : IT.t) : Sym.t * BT.t =
+    let rec pointer_of (it : T.t) : Sym.t * BT.t =
       match it with
       | IT (CopyAllocId { loc = ptr; _ }, _, _)
       | IT (ArrayShift { base = ptr; _ }, _, _)
@@ -667,7 +667,7 @@ module Make (GT : T) = struct
       | _ ->
         let pointers =
           it_addr
-          |> IT.free_vars_bts
+          |> T.free_vars_bts
           |> Sym.Map.filter (fun _ bt -> BT.equal bt (BT.Loc ()))
         in
         if not (Sym.Map.cardinal pointers == 1) then
@@ -680,9 +680,9 @@ module Make (GT : T) = struct
                       (fun (x, bt) -> Sym.pp x ^^ colon ^^^ BT.pp bt)
                       (List.of_seq (Sym.Map.to_seq pointers)))
                  ^^^ !^" in "
-                 ^^ IT.pp it_addr)));
+                 ^^ T.pp it_addr)));
         if Sym.Map.is_empty pointers then (
-          print_endline (Pp.plain (IT.pp it));
+          print_endline (Pp.plain (T.pp it));
           failwith __LOC__);
         Sym.Map.choose pointers
     in
@@ -696,7 +696,7 @@ module Make (GT : T) = struct
 
 
   let elaborate_map_ (`Map ((i, i_bt, it_perm), gt_inner)) =
-    let it_min, it_max = IT.Bounds.get_bounds (i, i_bt) it_perm in
+    let it_min, it_max = IndexTerms.Bounds.get_bounds (i, i_bt) it_perm in
     `MapElab ((i, i_bt, (it_min, it_max), it_perm), gt_inner)
 
 

--- a/lib/testGeneration/bennet/genTerms.ml
+++ b/lib/testGeneration/bennet/genTerms.ml
@@ -240,8 +240,8 @@ module Make (GT : T) = struct
              ^^^ Sym.pp i
              ^^ semi
              ^^^ T.pp it_perm
-             ^^ c_comment
-                  (T.pp it_min ^^ !^" <= " ^^ Sym.pp i ^^ !^" <= " ^^ T.pp it_max))
+             ^^ c_comment (T.pp it_min ^^ !^" <= " ^^ Sym.pp i ^^ !^" <= " ^^ T.pp it_max)
+            )
       ^^ braces (c_comment (BT.pp bt) ^^ nest 2 (break 1 ^^ pp gt_inner) ^^ break 1)
     | `PickSizedElab (choice_var, wgts) ->
       !^"pick"

--- a/lib/testGeneration/bennet/memberIndirection.ml
+++ b/lib/testGeneration/bennet/memberIndirection.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -11,63 +12,63 @@ module Make (GT : GenTerms.T) = struct
     | Record of (Id.t * Sym.t) list
     | Tuple of Sym.t list
 
-  let rec replace_memberof_it (k : kind) (sym : Sym.t) (it : IT.t) : IT.t =
+  let rec replace_memberof_it (k : kind) (sym : Sym.t) (it : T.t) : T.t =
     let repl = replace_memberof_it k sym in
     let (IT (it_, bt, loc)) = it in
     let it_ =
       match it_ with
       | Const _ | Sym _ | SizeOf _ | OffsetOf _ | Nil _ -> it_
-      | Unop (op, it') -> IT.Unop (op, repl it')
-      | Binop (op, it1, it2) -> IT.Binop (op, repl it1, repl it2)
-      | ITE (it1, it2, it3) -> IT.ITE (repl it1, repl it2, repl it3)
+      | Unop (op, it') -> Unop (op, repl it')
+      | Binop (op, it1, it2) -> Binop (op, repl it1, repl it2)
+      | ITE (it1, it2, it3) -> ITE (repl it1, repl it2, repl it3)
       | EachI ((min, (i_sym, i_bt), max), it') ->
-        IT.EachI ((min, (i_sym, i_bt), max), repl it')
-      | Tuple its -> IT.Tuple (List.map repl its)
+        EachI ((min, (i_sym, i_bt), max), repl it')
+      | Tuple its -> Tuple (List.map repl its)
       | NthTuple (n, it') ->
-        (match (k, IT.is_sym it') with
-         | Tuple syms, Some (y, _y_bt) when Sym.equal y sym -> IT.Sym (List.nth syms n)
-         | _ -> IT.NthTuple (n, repl it'))
-      | Struct (tag, xits) -> IT.Struct (tag, List.map_snd repl xits)
+        (match (k, Terms.is_sym it') with
+         | Tuple syms, Some (y, _y_bt) when Sym.equal y sym -> Sym (List.nth syms n)
+         | _ -> NthTuple (n, repl it'))
+      | Struct (tag, xits) -> Struct (tag, List.map_snd repl xits)
       | StructMember (it', x) ->
-        (match (k, IT.is_sym it') with
+        (match (k, Terms.is_sym it') with
          | Struct dict, Some (y, _y_bt) when Sym.equal y sym ->
-           IT.Sym (List.assoc Id.equal x dict)
-         | _ -> IT.StructMember (repl it', x))
+           Sym (List.assoc Id.equal x dict)
+         | _ -> StructMember (repl it', x))
       | StructUpdate ((it_struct, x), it_val) ->
-        IT.StructUpdate ((repl it_struct, x), repl it_val)
-      | Record xits -> IT.Record (List.map_snd repl xits)
+        StructUpdate ((repl it_struct, x), repl it_val)
+      | Record xits -> Record (List.map_snd repl xits)
       | RecordMember (it', x) ->
-        (match (k, IT.is_sym it') with
+        (match (k, Terms.is_sym it') with
          | Record dict, Some (y, _y_bt) when Sym.equal y sym ->
-           IT.Sym (List.assoc Id.equal x dict)
-         | _ -> IT.RecordMember (repl it', x))
+           Sym (List.assoc Id.equal x dict)
+         | _ -> RecordMember (repl it', x))
       | RecordUpdate ((it_record, x), it_val) ->
-        IT.RecordUpdate ((repl it_record, x), repl it_val)
-      | Constructor (tag, xits) -> IT.Constructor (tag, List.map_snd repl xits)
-      | MemberShift (it', tag, member) -> IT.MemberShift (it', tag, member)
+        RecordUpdate ((repl it_record, x), repl it_val)
+      | Constructor (tag, xits) -> Constructor (tag, List.map_snd repl xits)
+      | MemberShift (it', tag, member) -> MemberShift (it', tag, member)
       | ArrayShift { base; ct; index } ->
-        IT.ArrayShift { base = repl base; ct; index = repl index }
-      | CopyAllocId { addr; loc } -> IT.CopyAllocId { addr = repl addr; loc = repl loc }
-      | HasAllocId it' -> IT.HasAllocId (repl it')
-      | Cons (it1, it2) -> IT.Cons (repl it1, repl it2)
-      | Head it' -> IT.Head (repl it')
-      | Tail it' -> IT.Tail (repl it')
-      | Representable (sct, it') -> IT.Representable (sct, repl it')
-      | Good (sct, it') -> IT.Good (sct, repl it')
-      | Aligned { t; align } -> IT.Aligned { t = repl t; align = repl align }
-      | WrapI (sct, it') -> IT.WrapI (sct, repl it')
-      | MapConst (bt, it') -> IT.MapConst (bt, repl it')
-      | MapSet (it1, it2, it3) -> IT.MapSet (repl it1, repl it2, repl it3)
-      | MapGet (it1, it2) -> IT.MapGet (repl it1, repl it2)
-      | MapDef ((x, bt), it') -> IT.MapDef ((x, bt), repl it')
-      | Apply (fsym, its) -> IT.Apply (fsym, List.map repl its)
-      | Let ((x, it1), it2) -> IT.Let ((x, repl it1), it2)
-      | Match (it', pits) -> IT.Match (repl it', List.map_snd repl pits)
-      | Cast (bt, it') -> IT.Cast (bt, repl it')
-      | CN_None bt -> IT.CN_None bt
-      | CN_Some it' -> IT.CN_Some (repl it')
-      | IsSome it' -> IT.IsSome (repl it')
-      | GetOpt it' -> IT.GetOpt (repl it')
+        ArrayShift { base = repl base; ct; index = repl index }
+      | CopyAllocId { addr; loc } -> CopyAllocId { addr = repl addr; loc = repl loc }
+      | HasAllocId it' -> HasAllocId (repl it')
+      | Cons (it1, it2) -> Cons (repl it1, repl it2)
+      | Head it' -> Head (repl it')
+      | Tail it' -> Tail (repl it')
+      | Representable (sct, it') -> Representable (sct, repl it')
+      | Good (sct, it') -> Good (sct, repl it')
+      | Aligned { t; align } -> Aligned { t = repl t; align = repl align }
+      | WrapI (sct, it') -> WrapI (sct, repl it')
+      | MapConst (bt, it') -> MapConst (bt, repl it')
+      | MapSet (it1, it2, it3) -> MapSet (repl it1, repl it2, repl it3)
+      | MapGet (it1, it2) -> MapGet (repl it1, repl it2)
+      | MapDef ((x, bt), it') -> MapDef ((x, bt), repl it')
+      | Apply (fsym, its) -> Apply (fsym, List.map repl its)
+      | Let ((x, it1), it2) -> Let ((x, repl it1), it2)
+      | Match (it', pits) -> Match (repl it', List.map_snd repl pits)
+      | Cast (bt, it') -> Cast (bt, repl it')
+      | CN_None bt -> CN_None bt
+      | CN_Some it' -> CN_Some (repl it')
+      | IsSome it' -> IsSome (repl it')
+      | GetOpt it' -> GetOpt (repl it')
     in
     IT (it_, bt, loc)
 
@@ -102,12 +103,12 @@ module Make (GT : GenTerms.T) = struct
       | `LetStar ((x, Annot (`Return (IT (Record xits, bt, loc_it)), _, _, loc_ret)), gt')
         ->
         let members_to_indirect, members_to_leave =
-          xits |> List.partition (fun (_, it) -> Option.is_none (IT.is_sym it))
+          xits |> List.partition (fun (_, it) -> Option.is_none (Terms.is_sym it))
         in
         let indirect_map =
           List.map_snd (fun _ -> Sym.fresh_anon ()) members_to_indirect
           @ List.map
-              (fun (y, it) -> (y, fst (Option.get (IT.is_sym it))))
+              (fun (y, it) -> (y, fst (Option.get (Terms.is_sym it))))
               members_to_leave
         in
         let k =
@@ -124,7 +125,7 @@ module Make (GT : GenTerms.T) = struct
                      indirect_map
                      |> List.map (fun (y, z) ->
                        let it = List.assoc Id.equal y xits in
-                       (y, IT.sym_ (z, IT.get_bt it, IT.get_loc it)))
+                       (y, IT.sym_ (z, T.get_bt it, T.get_loc it)))
                    in
                    match bt with
                    | Struct tag -> IT.struct_ (tag, members) loc_it
@@ -150,11 +151,11 @@ module Make (GT : GenTerms.T) = struct
         let items_to_indirect, items_to_leave =
           items
           |> List.mapi (fun i it -> (i, it))
-          |> List.partition (fun (_, it) -> Option.is_none (IT.is_sym it))
+          |> List.partition (fun (_, it) -> Option.is_none (Terms.is_sym it))
         in
         let indirect_map =
           List.map_snd (fun _ -> Sym.fresh_anon ()) items_to_indirect
-          @ List.map (fun (i, it) -> (i, fst (Option.get (IT.is_sym it)))) items_to_leave
+          @ List.map (fun (i, it) -> (i, fst (Option.get (Terms.is_sym it)))) items_to_leave
         in
         let k = Tuple (List.map snd indirect_map) in
         let gt_main =
@@ -165,7 +166,7 @@ module Make (GT : GenTerms.T) = struct
                      indirect_map
                      |> List.map (fun (i, sym) ->
                        let it = List.nth items i in
-                       IT.sym_ (sym, IT.get_bt it, IT.get_loc it))
+                       IT.sym_ (sym, T.get_bt it, T.get_loc it))
                    in
                    IT.tuple_ tuple_items loc_it)
                   tag

--- a/lib/testGeneration/bennet/memberIndirection.ml
+++ b/lib/testGeneration/bennet/memberIndirection.ml
@@ -155,7 +155,9 @@ module Make (GT : GenTerms.T) = struct
         in
         let indirect_map =
           List.map_snd (fun _ -> Sym.fresh_anon ()) items_to_indirect
-          @ List.map (fun (i, it) -> (i, fst (Option.get (Terms.is_sym it)))) items_to_leave
+          @ List.map
+              (fun (i, it) -> (i, fst (Option.get (Terms.is_sym it))))
+              items_to_leave
         in
         let k = Tuple (List.map snd indirect_map) in
         let gt_main =

--- a/lib/testGeneration/bennet/stage1/convert.ml
+++ b/lib/testGeneration/bennet/stage1/convert.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 module AT = ArgumentTypes
@@ -67,7 +68,7 @@ module Make (AD : Domain.T) = struct
     modify (OptCtx.add gd)
 
 
-  let transform_vars (generated : Sym.Set.t) (_oarg : BT.t) (lat : IT.t LAT.t)
+  let transform_vars (generated : Sym.Set.t) (_oarg : BT.t) (lat : T.t LAT.t)
     : Sym.Set.t * (Tm.t -> Tm.t)
     =
     let rec aux (xbts : (Sym.t * BT.t) list) : Tm.t -> Tm.t =
@@ -82,12 +83,12 @@ module Make (AD : Domain.T) = struct
     in
     let xs, xbts =
       match lat with
-      | Define ((x, it), _info, _) -> (Sym.Set.singleton x, IT.free_vars_bts it)
+      | Define ((x, it), _info, _) -> (Sym.Set.singleton x, T.free_vars_bts it)
       | Resource ((x, ((P { name = Owned _; _ } as ret), bt)), _, _) ->
         (Sym.Set.singleton x, Sym.Map.add x bt (Request.free_vars_bts ret))
       | Resource ((x, (ret, _)), _, _) -> (Sym.Set.singleton x, Request.free_vars_bts ret)
       | Constraint (lc, _, _) -> (Sym.Set.empty, LC.free_vars_bts lc)
-      | I it -> (Sym.Set.empty, IT.free_vars_bts it)
+      | I it -> (Sym.Set.empty, T.free_vars_bts it)
     in
     let xbts =
       xbts
@@ -111,7 +112,7 @@ module Make (AD : Domain.T) = struct
             (name : Sym.t)
             (generated : Sym.Set.t)
             (oarg : BT.t)
-            (lat : IT.t LAT.t)
+            (lat : T.t LAT.t)
     : Tm.t m
     =
     (* Generate any free variables needed *)
@@ -121,7 +122,7 @@ module Make (AD : Domain.T) = struct
       match lat with
       | Define ((x, it), (loc, _), lat') ->
         let@ gt' = transform_it_lat filename recursive preds name generated oarg lat' in
-        return (Tm.let_star_ ((x, Tm.return_ it () (IT.get_loc it)), gt') () loc)
+        return (Tm.let_star_ ((x, Tm.return_ it () (T.get_loc it)), gt') () loc)
       | Resource
           ((x, (P { name = Owned (ct, _); pointer; iargs = _ }, bt)), (loc, _), lat') ->
         let@ gt' = transform_it_lat filename recursive preds name generated oarg lat' in
@@ -217,7 +218,7 @@ module Make (AD : Domain.T) = struct
       | Constraint (lc, (loc, _), lat') ->
         let@ gt' = transform_it_lat filename recursive preds name generated oarg lat' in
         return (Tm.assert_ (lc, gt') () loc)
-      | I it -> return (Tm.return_ it () (IT.get_loc it))
+      | I it -> return (Tm.return_ it () (T.get_loc it))
     in
     return (f_gt_init gt)
 
@@ -234,7 +235,7 @@ module Make (AD : Domain.T) = struct
     =
     match cls with
     | [ cl ] ->
-      assert (IT.is_true cl.guard);
+      assert (Terms.is_true cl.guard);
       transform_it_lat filename recursive preds name iargs oarg cl.packing_ft
     | cl :: cls' ->
       let it_if = cl.guard in
@@ -400,7 +401,7 @@ module Make (AD : Domain.T) = struct
               | SD_ObjectAddress x' -> (x, `Rename (Sym.fresh x')) :: acc
               | _ -> acc)
            []
-      |> Subst.make IT.free_vars_with_rename
+      |> Subst.make T.free_vars_with_rename
     in
     let preds =
       List.map_snd

--- a/lib/testGeneration/bennet/stage1/destructArbitrary.ml
+++ b/lib/testGeneration/bennet/stage1/destructArbitrary.ml
@@ -109,7 +109,7 @@ module Make (AD : Domain.T) = struct
              Term.let_star_
                ( (y, arbitrary_of_sctype sct loc_arb),
                  Term.asgn_
-                   ( (IT.memberShift_ (it_addr, tag, member) (IT.get_loc it_addr), sct),
+                   ( (IT.memberShift_ (it_addr, tag, member) (Terms.get_loc it_addr), sct),
                      IT.sym_ (y, Memory.bt_of_sct sct, loc),
                      gt_rest' )
                    ()

--- a/lib/testGeneration/bennet/stage1/destructProducts.ml
+++ b/lib/testGeneration/bennet/stage1/destructProducts.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -73,7 +74,7 @@ module Make (AD : Domain.T) = struct
   (* Rebuild the original (whole-struct/record/tuple) argument value from the
      destructured leaf symbols, so any reference to the parent symbol that is not
      a member access (e.g. [valid_state(s)], [Good(struct T, s)]) stays in scope. *)
-  let rec it_of_new_args (na : new_args) (loc : Locations.t) : IT.t =
+  let rec it_of_new_args (na : new_args) (loc : Locations.t) : T.t =
     match na with
     | Struct (tag, members) ->
       IT.struct_
@@ -174,8 +175,8 @@ module Make (AD : Domain.T) = struct
       failwith "destructProducts: unexpected record/tuple C-typed parameter"
 
 
-  let transform_it (prog5 : unit Mucore.file) ((it, bt) : IT.t * BT.t) : IT.t list =
-    let rec aux ((it, bt) : IT.t * BT.t) : IT.t list =
+  let transform_it (prog5 : unit Mucore.file) ((it, bt) : T.t * BT.t) : T.t list =
+    let rec aux ((it, bt) : T.t * BT.t) : T.t list =
       match bt with
       | BT.Struct tag ->
         (match Pmap.find tag prog5.tagDefs with
@@ -209,7 +210,7 @@ module Make (AD : Domain.T) = struct
     aux (it, bt)
 
 
-  let transform_its (prog5 : unit Mucore.file) (its : (IT.t * BT.t) list) : IT.t list =
+  let transform_its (prog5 : unit Mucore.file) (its : (T.t * BT.t) list) : T.t list =
     its |> List.map (transform_it prog5) |> List.flatten
 
 

--- a/lib/testGeneration/bennet/stage1/pruneReturns.ml
+++ b/lib/testGeneration/bennet/stage1/pruneReturns.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -32,28 +33,28 @@ module Make (AD : Domain.T) = struct
 
 
   (* Analyze how a symbol is used within an IT expression *)
-  let rec analyze_it_usage (sym : Sym.t) (it : IT.t) : usage_analysis =
-    match IT.get_term it with
+  let rec analyze_it_usage (sym : Sym.t) (it : T.t) : usage_analysis =
+    match T.get_term it with
     | Sym s when Sym.equal s sym ->
       (* Direct use of the symbol itself *)
       { empty_analysis with used_directly = true }
     | StructMember (t, member) ->
       (* Check if the base is our symbol *)
-      (match IT.get_term t with
+      (match T.get_term t with
        | Sym s when Sym.equal s sym ->
          { empty_analysis with struct_members = IdSet.singleton member }
        | _ ->
          (* The base is not our symbol, recurse normally *)
          analyze_it_usage sym t)
     | RecordMember (t, member) ->
-      (match IT.get_term t with
+      (match T.get_term t with
        | Sym s when Sym.equal s sym ->
          { empty_analysis with record_members = IdSet.singleton member }
        | _ ->
          (* The base is not our symbol, recurse normally *)
          analyze_it_usage sym t)
     | NthTuple (n, t) ->
-      (match IT.get_term t with
+      (match T.get_term t with
        | Sym s when Sym.equal s sym -> { empty_analysis with tuple_indices = [ n ] }
        | _ ->
          (* The base is not our symbol, recurse normally *)
@@ -113,7 +114,7 @@ module Make (AD : Domain.T) = struct
     | EachI (_, t) -> analyze_it_usage sym t
 
 
-  and analyze_it_usage_list (sym : Sym.t) (its : IT.t list) : usage_analysis =
+  and analyze_it_usage_list (sym : Sym.t) (its : T.t list) : usage_analysis =
     merge_analysis_list (List.map (analyze_it_usage sym) its)
 
 
@@ -351,7 +352,7 @@ module Make (AD : Domain.T) = struct
                | StructDef layout ->
                  let member_types_list = Memory.member_types layout in
                  (* Build struct with defaults for pruned members *)
-                 (match IT.get_term it with
+                 (match T.get_term it with
                   | Struct (tag, members) ->
                     let new_members =
                       List.map
@@ -370,7 +371,7 @@ module Make (AD : Domain.T) = struct
                | _ -> gt)
             | _ -> gt)
          | Record ids_to_remove ->
-           (match IT.get_term it with
+           (match T.get_term it with
             | Record members ->
               let kept_members =
                 List.filter
@@ -380,7 +381,7 @@ module Make (AD : Domain.T) = struct
               Term.return_ (IT.record_ kept_members loc) () loc
             | _ -> gt)
          | Tuple indices_to_remove ->
-           (match IT.get_term it with
+           (match T.get_term it with
             | Tuple items ->
               let kept_items =
                 List.filteri
@@ -429,28 +430,28 @@ module Make (AD : Domain.T) = struct
     match request with
     | Struct _ | Nothing -> term
     | Entire | Record _ | Tuple _ ->
-      let adapt_it (it : IT.t) : IT.t =
+      let adapt_it (it : T.t) : T.t =
         let (IT (it_, bt, loc)) = it in
         match it_ with
         (* Direct symbol reference - update its type *)
         | Sym s when Sym.equal s sym -> IT.sym_ (s, new_bt, loc)
         (* Struct member access *)
         | StructMember (base_it, member) ->
-          (match IT.get_term base_it with
+          (match T.get_term base_it with
            | Sym s when Sym.equal s sym ->
              let new_base = IT.sym_ (s, new_bt, loc) in
              IT (StructMember (new_base, member), bt, loc)
            | _ -> it)
         (* Record member access *)
         | RecordMember (base_it, member) ->
-          (match IT.get_term base_it with
+          (match T.get_term base_it with
            | Sym s when Sym.equal s sym ->
              let new_base = IT.sym_ (s, new_bt, loc) in
              IT (RecordMember (new_base, member), bt, loc)
            | _ -> it)
         (* Tuple index access - remap indices for Tuple pruning *)
         | NthTuple (n, base_it) ->
-          (match IT.get_term base_it with
+          (match T.get_term base_it with
            | Sym s when Sym.equal s sym ->
              (match request with
               | Tuple indices_to_remove ->
@@ -470,33 +471,33 @@ module Make (AD : Domain.T) = struct
       in
       let adapt_lc (lc : LC.t) : LC.t =
         match lc with
-        | LC.T it -> LC.T (IT.map_term_pre adapt_it it)
+        | LC.T it -> LC.T (Terms.map_term_pre adapt_it it)
         | LC.Forall ((s, forall_bt), body) ->
-          LC.Forall ((s, forall_bt), IT.map_term_pre adapt_it body)
+          LC.Forall ((s, forall_bt), Terms.map_term_pre adapt_it body)
       in
       let rec adapt_term (gt : Term.t) : Term.t =
         let (GenTerms.Annot (gt_, tag, term_bt, loc)) = gt in
         match gt_ with
         | `Arbitrary | `Symbolic -> gt
         | `Call (fsym, iargs) ->
-          Term.call_ (fsym, List.map (IT.map_term_pre adapt_it) iargs) tag term_bt loc
+          Term.call_ (fsym, List.map (Terms.map_term_pre adapt_it) iargs) tag term_bt loc
         | `Asgn ((it_addr, sct), it_val, gt') ->
           Term.asgn_
-            ( (IT.map_term_pre adapt_it it_addr, sct),
-              IT.map_term_pre adapt_it it_val,
+            ( (Terms.map_term_pre adapt_it it_addr, sct),
+              Terms.map_term_pre adapt_it it_val,
               adapt_term gt' )
             tag
             loc
-        | `Return it -> Term.return_ (IT.map_term_pre adapt_it it) tag loc
+        | `Return it -> Term.return_ (Terms.map_term_pre adapt_it it) tag loc
         | `Assert (lc, gt') -> Term.assert_ (adapt_lc lc, adapt_term gt') tag loc
         | `ITE (it_if, gt_then, gt_else) ->
           Term.ite_
-            (IT.map_term_pre adapt_it it_if, adapt_term gt_then, adapt_term gt_else)
+            (Terms.map_term_pre adapt_it it_if, adapt_term gt_then, adapt_term gt_else)
             tag
             loc
         | `Map ((i, i_bt, it_perm), gt_inner) ->
           Term.map_
-            ((i, i_bt, IT.map_term_pre adapt_it it_perm), adapt_term gt_inner)
+            ((i, i_bt, Terms.map_term_pre adapt_it it_perm), adapt_term gt_inner)
             tag
             loc
         | `LetStar ((x, gt_inner), gt_rest) ->

--- a/lib/testGeneration/bennet/stage1/term.ml
+++ b/lib/testGeneration/bennet/stage1/term.ml
@@ -1,5 +1,5 @@
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 module CF = Cerb_frontend
 
@@ -15,16 +15,16 @@ module Make (AD : Domain.T) = struct
       type 'recur ast =
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
-        | `Call of Sym.t * IT.t list
-          (** `Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `Asgn of (IT.t * Sctypes.t) * IT.t * 'recur annot
+        | `Call of Sym.t * T.t list
+          (** `Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `Asgn of (T.t * Sctypes.t) * T.t * 'recur annot
           (** Claim ownership and assign a value to a memory location *)
         | `LetStar of (Sym.t * 'recur annot) * 'recur annot (** Backtrack point *)
-        | `Return of IT.t (** Monadic return *)
+        | `Return of T.t (** Monadic return *)
         | `Assert of LC.t * 'recur annot
           (** `Assert some [LC.t] are true, backtracking otherwise *)
-        | `ITE of IT.t * 'recur annot * 'recur annot (** If-then-else *)
-        | `Map of (Sym.t * BT.t * IT.t) * 'recur annot
+        | `ITE of T.t * 'recur annot * 'recur annot (** If-then-else *)
+        | `Map of (Sym.t * BT.t * T.t) * 'recur annot
         ]
       [@@deriving eq, ord]
 
@@ -47,12 +47,12 @@ module Make (AD : Domain.T) = struct
         Annot (`Symbolic, tag, bt, loc)
 
 
-      let call_ ((fsym, its) : Sym.t * IT.t list) (tag : tag_t) (bt : BT.t) loc : t =
+      let call_ ((fsym, its) : Sym.t * T.t list) (tag : tag_t) (bt : BT.t) loc : t =
         Annot (`Call (fsym, its), tag, bt, loc)
 
 
       let asgn_
-            (((it_addr, ct), it_val, gt') : (IT.t * Sctypes.t) * IT.t * t)
+            (((it_addr, ct), it_val, gt') : (T.t * Sctypes.t) * T.t * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -66,22 +66,22 @@ module Make (AD : Domain.T) = struct
         Annot (`LetStar ((x, gt1), gt2), tag, basetype gt2, loc)
 
 
-      let return_ (it : IT.t) (tag : tag_t) (loc : Locations.t) : t =
-        Annot (`Return it, tag, IT.get_bt it, loc)
+      let return_ (it : T.t) (tag : tag_t) (loc : Locations.t) : t =
+        Annot (`Return it, tag, T.get_bt it, loc)
 
 
       let assert_ ((lc, gt') : LC.t * t) (tag : tag_t) (loc : Locations.t) : t =
         Annot (`Assert (lc, gt'), tag, basetype gt', loc)
 
 
-      let ite_ ((it_if, gt_then, gt_else) : IT.t * t * t) (tag : tag_t) loc : t =
+      let ite_ ((it_if, gt_then, gt_else) : T.t * t * t) (tag : tag_t) loc : t =
         let bt = basetype gt_then in
         assert (BT.equal bt (basetype gt_else));
         Annot (`ITE (it_if, gt_then, gt_else), tag, bt, loc)
 
 
       let map_
-            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * IT.t) * t)
+            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * T.t) * t)
             (tag : tag_t)
             loc
         : t

--- a/lib/testGeneration/bennet/stage1/unfold.ml
+++ b/lib/testGeneration/bennet/stage1/unfold.ml
@@ -1,5 +1,3 @@
-module IT = IndexTerms
-
 module Make (AD : Domain.T) = struct
   module Ctx = Ctx.Make (AD)
   module Def = Def.Make (AD)
@@ -20,7 +18,7 @@ module Make (AD : Domain.T) = struct
                aux
                  (depth + 1)
                  (Term.subst
-                    (IT.make_subst (List.combine (List.map fst gd.iargs) iargs))
+                    (Terms.Normal.make_subst (List.combine (List.map fst gd.iargs) iargs))
                     gd.body)
              with
              | Not_found -> gt (* Keep call if definition not found *))

--- a/lib/testGeneration/bennet/stage2/eachFusion.ml
+++ b/lib/testGeneration/bennet/stage2/eachFusion.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -7,14 +8,14 @@ module Make (AD : Domain.T) = struct
 
   let simp = Simplify.IndexTerms.simp (Simplify.default Global.empty)
 
-  let is_simp_true it = IT.is_true (simp it)
+  let is_simp_true it = Terms.is_true (simp it)
 
-  let check_index_ok (m : Sym.t) (i : Sym.t) (it : IT.t) : bool =
-    let rec aux (it : IT.t) : bool =
+  let check_index_ok (m : Sym.t) (i : Sym.t) (it : T.t) : bool =
+    let rec aux (it : T.t) : bool =
       let (IT (it_, _bt, _loc)) = it in
       match it_ with
       | MapGet (IT (Sym x, _, _), it_key) when Sym.equal m x ->
-        (match IT.is_sym it_key with Some (j, _) -> Sym.equal i j | _ -> false)
+        (match Terms.is_sym it_key with Some (j, _) -> Sym.equal i j | _ -> false)
       | Const _ | SizeOf _ | OffsetOf _ | Nil _ | CN_None _ -> true
       | Sym x -> not (Sym.equal x m)
       | Unop (_, it')
@@ -59,13 +60,13 @@ module Make (AD : Domain.T) = struct
         (vars : Sym.Set.t)
         (x : Sym.t)
         (new_i : Sym.t)
-        ((it_min, it_max) : IT.t * IT.t)
+        ((it_min, it_max) : T.t * T.t)
         (gt : Term.t)
-    : Term.t * IT.t
+    : Term.t * T.t
     =
     let it_true = IT.bool_ true (Locations.other __LOC__) in
     let it_and a b = IT.and2_ (a, b) (Locations.other __LOC__) in
-    let rec aux (delete : bool) (gt : Term.t) : Term.t * IT.t =
+    let rec aux (delete : bool) (gt : Term.t) : Term.t * T.t =
       let (Annot (gt_, (), _, loc)) = gt in
       match gt_ with
       | `Arbitrary | `Symbolic | `Call _ | `Return _ | `Map _ -> (gt, it_true)
@@ -73,7 +74,7 @@ module Make (AD : Domain.T) = struct
         let _, constraints =
           gts |> List.map (aux false) |> List.map_snd simp |> List.split
         in
-        if List.exists IT.is_true constraints then
+        if List.exists Terms.is_true constraints then
           (gt, it_true)
         else
           ( gt,
@@ -93,20 +94,20 @@ module Make (AD : Domain.T) = struct
           ( Forall
               ((i, i_bt), (IT (Binop (Implies, it_perm, it_body), _, loc_implies) as it)),
             gt' )
-        when Sym.Set.mem x (IT.free_vars it) && check_index_ok x i it ->
+        when Sym.Set.mem x (T.free_vars it) && check_index_ok x i it ->
         let it_min', it_max' = IndexTerms.Bounds.get_bounds (i, i_bt) it_perm in
         let gt', res = aux delete gt' in
         if
-          IT.equal it_min it_min'
-          && IT.equal it_max it_max'
+          T.equal it_min it_min'
+          && T.equal it_max it_max'
           && Sym.Set.subset
-               (Sym.Set.remove i (IT.free_vars_list [ it_perm; it_body ]))
+               (Sym.Set.remove i (T.free_vars_list [ it_perm; it_body ]))
                vars
         then (
           let res' =
             (it_and
-               (IT.subst
-                  (IT.make_rename ~from:i ~to_:new_i)
+               (T.subst
+                  (T.make_rename ~from:i ~to_:new_i)
                   (IT.impl_ (it_perm, it_body) loc_implies)))
               res
           in
@@ -120,7 +121,7 @@ module Make (AD : Domain.T) = struct
         let gt', res = aux delete gt' in
         (Term.assert_ (lc, gt') () loc, res)
       | `ITE (it_if, gt_then, gt_else) ->
-        let delete' = Sym.Set.subset (IT.free_vars it_if) vars in
+        let delete' = Sym.Set.subset (T.free_vars it_if) vars in
         let gt_then', then_constraints = aux delete' gt_then in
         let gt_else', else_constraints = aux delete' gt_else in
         let gt' = Term.ite_ (it_if, gt_then', gt_else') () loc in
@@ -135,17 +136,17 @@ module Make (AD : Domain.T) = struct
     aux true gt
 
 
-  let replace_index (m : Sym.t) (i : Sym.t) (result : Sym.t) (it : IT.t) : IT.t =
-    let aux (it : IT.t) : IT.t =
+  let replace_index (m : Sym.t) (i : Sym.t) (result : Sym.t) (it : T.t) : T.t =
+    let aux (it : T.t) : T.t =
       let (IT (it_, bt, loc)) = it in
       match it_ with
       | MapGet (IT (Sym y, _, _), IT (Sym j, _, _)) when Sym.equal m y ->
         if not (Sym.equal i j) then
-          failwith (Pp.plain (IT.pp it) ^ " @ " ^ __LOC__);
+          failwith (Pp.plain (T.pp it) ^ " @ " ^ __LOC__);
         IT.sym_ (result, bt, loc)
       | _ -> it
     in
-    IT.map_term_pre aux it
+    Terms.map_term_pre aux it
 
 
   let transform_gt (vars : Sym.Set.t) (gt : Term.t) : Term.t =

--- a/lib/testGeneration/bennet/stage2/flipIfs.ml
+++ b/lib/testGeneration/bennet/stage2/flipIfs.ml
@@ -14,7 +14,7 @@ module Make (AD : Domain.T) = struct
       | `Pick wgts -> Term.pick_ (List.map aux wgts) () bt loc
       | `ITE (it_if, gt_then, gt_else) ->
         let gt_then, gt_else = (aux gt_then, aux gt_else) in
-        if not (Sym.Set.subset (IT.free_vars it_if) iargs) then (
+        if not (Sym.Set.subset (Terms.Normal.free_vars it_if) iargs) then (
           let wgts1 =
             match gt_then with
             | Annot (`Pick gts, (), _, _) ->

--- a/lib/testGeneration/bennet/stage2/inlineGen.ml
+++ b/lib/testGeneration/bennet/stage2/inlineGen.ml
@@ -1,4 +1,4 @@
-module IT = IndexTerms
+module T = Terms.Normal
 
 module Make (AD : Domain.T) = struct
   module PruneCallGraph = PruneCallGraph.Make (Term.Make (AD))
@@ -18,7 +18,7 @@ module Make (AD : Domain.T) = struct
           let gd = Ctx.find fsym ctx in
           aux
             (Term.subst
-               (IT.make_subst (List.combine (List.map fst gd.iargs) iargs))
+               (T.make_subst (List.combine (List.map fst gd.iargs) iargs))
                gd.body)
         | `Asgn ((it_addr, sct), it_val, gt_rest) ->
           let gt_rest = aux gt_rest in
@@ -90,7 +90,7 @@ module Make (AD : Domain.T) = struct
           let gd = Ctx.find fsym ctx in
           aux
             (Term.subst
-               (IT.make_subst (List.combine (List.map fst gd.iargs) iargs))
+               (T.make_subst (List.combine (List.map fst gd.iargs) iargs))
                gd.body)
         | `Call _ -> gt
         | `Asgn ((it_addr, sct), it_val, gt_rest) ->
@@ -137,7 +137,7 @@ module Make (AD : Domain.T) = struct
           let gd = Ctx.find fsym ctx in
           aux
             (Term.subst
-               (IT.make_subst (List.combine (List.map fst gd.iargs) iargs))
+               (T.make_subst (List.combine (List.map fst gd.iargs) iargs))
                gd.body)
         | `Asgn ((it_addr, sct), it_val, gt_rest) ->
           let gt_rest = aux gt_rest in

--- a/lib/testGeneration/bennet/stage2/reorder/reorder.ml
+++ b/lib/testGeneration/bennet/stage2/reorder/reorder.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -50,7 +51,7 @@ module Make (AD : Domain.T) = struct
           ( Assert (T (IT (Binop (EQ, IT (Cast (_, IT (Sym x, _, _)), _, _), it), _, _))),
             _ )
         :: stmts'
-        when not (Sym.Set.mem x (IT.free_vars it)) ->
+        when not (Sym.Set.mem x (T.free_vars it)) ->
         let g' =
           List.fold_left
             (fun g' y ->
@@ -59,7 +60,7 @@ module Make (AD : Domain.T) = struct
                else
                  add_edge_no_cycle g' (y, x))
             g
-            (it |> IT.free_vars |> Sym.Set.to_seq |> List.of_seq)
+            (it |> T.free_vars |> Sym.Set.to_seq |> List.of_seq)
         in
         consider_equalities stmts' g'
       | Stmt (Assert (T (IT (Binop (EQ, it, IT (Sym x, _, _)), _, _))), _) :: stmts'
@@ -67,7 +68,7 @@ module Make (AD : Domain.T) = struct
           ( Assert (T (IT (Binop (EQ, it, IT (Cast (_, IT (Sym x, _, _)), _, _)), _, _))),
             _ )
         :: stmts'
-        when not (Sym.Set.mem x (IT.free_vars it)) ->
+        when not (Sym.Set.mem x (T.free_vars it)) ->
         let g' =
           Seq.fold_left
             (fun g' y ->
@@ -76,7 +77,7 @@ module Make (AD : Domain.T) = struct
                else
                  add_edge_no_cycle g' (y, x))
             g
-            (it |> IT.free_vars |> Sym.Set.to_seq)
+            (it |> T.free_vars |> Sym.Set.to_seq)
         in
         consider_equalities stmts' g'
       | _ :: stmts' -> consider_equalities stmts' g
@@ -148,7 +149,7 @@ module Make (AD : Domain.T) = struct
           (fun (stmt : Stmt.t) ->
              match stmt with
              | Stmt (Asgn ((it_addr, _sct), it_val), _) ->
-               Sym.Set.subset (IT.free_vars_list [ it_addr; it_val ]) vars
+               Sym.Set.subset (T.free_vars_list [ it_addr; it_val ]) vars
              | Stmt (Assert lc, _) -> Sym.Set.subset (LC.free_vars lc) vars
              | _ -> false)
           stmts

--- a/lib/testGeneration/bennet/stage2/reorder/stmt.ml
+++ b/lib/testGeneration/bennet/stage2/reorder/stmt.ml
@@ -1,5 +1,5 @@
 module BT = BaseTypes
-module IT = IndexTerms
+module IT = Terms.Normal
 module LC = LogicalConstraints
 
 module Make (AD : Domain.T) = struct

--- a/lib/testGeneration/bennet/stage2/simplifyGen/branchPruning.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/branchPruning.ml
@@ -9,9 +9,9 @@ module Make (AD : Domain.T) = struct
         match gt with
         | Annot (`Pick [ gt' ], (), _, _) -> gt'
         | Annot (`ITE (it_cond, gt_then, gt_else), (), _, _) ->
-          if IT.is_true it_cond then
+          if Terms.is_true it_cond then
             gt_then
-          else if IT.is_false it_cond then
+          else if Terms.is_false it_cond then
             gt_else
           else
             gt
@@ -35,9 +35,9 @@ module Make (AD : Domain.T) = struct
         contains_false_assertion gt_inner || contains_false_assertion gt'
       | `Assert (lc, gt') ->
         (match lc with
-         | (T it | Forall (_, it)) when IT.is_false it -> true
+         | (T it | Forall (_, it)) when Terms.is_false it -> true
          | Forall (_, IT (Binop (Implies, it_perm, it_body), _, _))
-           when IT.is_true it_perm && IT.is_false it_body ->
+           when Terms.is_true it_perm && Terms.is_false it_body ->
            true
          | _ -> contains_false_assertion gt')
       | `ITE (_, gt_then, gt_else) ->
@@ -58,7 +58,7 @@ module Make (AD : Domain.T) = struct
           if contains_false_assertion gt_else then
             Term.assert_ (T it_if, gt_then) () loc_ite
           else if contains_false_assertion gt_then then
-            Term.assert_ (T (IT.not_ it_if (IT.get_loc it_if)), gt_else) () loc_ite
+            Term.assert_ (T (IT.not_ it_if (Terms.get_loc it_if)), gt_else) () loc_ite
           else
             gt
         | _ -> gt

--- a/lib/testGeneration/bennet/stage2/simplifyGen/inlineTerm.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/inlineTerm.ml
@@ -1,4 +1,4 @@
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 
 module Make (AD : Domain.T) = struct
@@ -11,7 +11,7 @@ module Make (AD : Domain.T) = struct
         let (Annot (gt_, (), _, _loc)) = gt in
         match gt_ with
         | `LetStar ((x, Annot (`Return it, (), _, _)), gt') ->
-          Term.subst (IT.make_subst [ (x, it) ]) gt'
+          Term.subst (T.make_subst [ (x, it) ]) gt'
         | _ -> gt
       in
       Term.map_gen_pre aux gt
@@ -45,13 +45,13 @@ module Make (AD : Domain.T) = struct
       | `Call (_fsym, iargs) ->
         ( gt,
           iargs
-          |> List.map IT.free_vars
+          |> List.map T.free_vars
           |> List.map of_symset
           |> List.fold_left union Sym.Map.empty )
       | `Asgn ((it_addr, sct), it_val, gt') ->
         let only_ret =
           [ it_addr; it_val ]
-          |> List.map IT.free_vars
+          |> List.map T.free_vars
           |> List.map of_symset
           |> List.fold_left union Sym.Map.empty
         in
@@ -67,21 +67,21 @@ module Make (AD : Domain.T) = struct
           (Term.let_star_ ((x, gt_inner), gt') () loc, union only_ret only_ret'))
       | `Return it ->
         ( gt,
-          (match IT.is_sym it with
+          (match Terms.is_sym it with
            | Some (x, _bt) -> Sym.Map.singleton x true
-           | None -> it |> IT.free_vars |> of_symset) )
+           | None -> it |> T.free_vars |> of_symset) )
       | `Assert (lc, gt') ->
         let only_ret = lc |> LC.free_vars |> of_symset in
         let gt', only_ret' = transform_aux gt' in
         (Term.assert_ (lc, gt') () loc, union only_ret only_ret')
       | `ITE (it_if, gt_then, gt_else) ->
-        let only_ret = it_if |> IT.free_vars |> of_symset in
+        let only_ret = it_if |> T.free_vars |> of_symset in
         let gt_then, only_ret' = transform_aux gt_then in
         let gt_else, only_ret'' = transform_aux gt_else in
         ( Term.ite_ (it_if, gt_then, gt_else) () loc,
           [ only_ret; only_ret'; only_ret'' ] |> List.fold_left union Sym.Map.empty )
       | `Map ((i, i_bt, it_perm), gt_inner) ->
-        let only_ret = it_perm |> IT.free_vars |> Sym.Set.remove i |> of_symset in
+        let only_ret = it_perm |> T.free_vars |> Sym.Set.remove i |> of_symset in
         let gt_inner, only_ret' = transform_aux gt_inner in
         let only_ret' = only_ret' |> Sym.Map.remove i |> Sym.Map.map (fun _ -> false) in
         (Term.map_ ((i, i_bt, it_perm), gt_inner) () loc, union only_ret only_ret')

--- a/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/conjunction.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/conjunction.ml
@@ -1,11 +1,12 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
 module Make (AD : Domain.T) = struct
   module Term = Term.Make (AD)
 
-  let rec cnf_ (e : BT.t IT.term) : BT.t IT.term =
+  let rec cnf_ (e : BT.t Terms.term) : BT.t Terms.term =
     match e with
     | Unop (Not, e') ->
       (match cnf e' with
@@ -38,13 +39,13 @@ module Make (AD : Domain.T) = struct
     | _ -> e
 
 
-  and cnf (e : IT.t) : IT.t =
+  and cnf (e : T.t) : T.t =
     let (IT (e, info, loc)) = e in
     IT (cnf_ e, info, loc)
 
 
-  let listify_constraints (it : IT.t) : IT.t list =
-    let rec loop (c : IT.t) : IT.t list =
+  let listify_constraints (it : T.t) : T.t list =
+    let rec loop (c : T.t) : T.t list =
       match c with IT (Binop (And, e1, e2), _, _) -> loop e1 @ loop e2 | _ -> [ c ]
     in
     loop it
@@ -64,7 +65,7 @@ module Make (AD : Domain.T) = struct
           it
           |> cnf
           |> listify_constraints
-          |> List.partition (fun it' -> Sym.Set.mem i_sym (IT.free_vars it'))
+          |> List.partition (fun it' -> Sym.Set.mem i_sym (T.free_vars it'))
         in
         let gt_forall =
           Term.assert_ (LC.Forall ((i_sym, i_bt), IT.and_ its_in loc), gt') () loc

--- a/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/disjunction.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/disjunction.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -8,7 +9,7 @@ module Make (AD : Domain.T) = struct
     let (Annot (gt_, (), _, _)) = gt in
     match gt_ with
     | `Arbitrary | `Symbolic -> false
-    | `Return it -> not (Sym.Set.disjoint ext (IT.free_vars it))
+    | `Return it -> not (Sym.Set.disjoint ext (T.free_vars it))
     | `Call _ -> true
     | `Pick gts -> gts |> List.exists (is_external ext)
     | `Asgn (_, _, gt_rest) -> is_external ext gt_rest
@@ -19,7 +20,7 @@ module Make (AD : Domain.T) = struct
     | `Map (_, gt_inner) -> is_external ext gt_inner
 
 
-  let rec dnf_ (e : BT.t IT.term) : BT.t IT.term =
+  let rec dnf_ (e : BT.t Terms.term) : BT.t Terms.term =
     match e with
     | Unop (Not, e') ->
       (match dnf e' with
@@ -52,13 +53,13 @@ module Make (AD : Domain.T) = struct
     | _ -> e
 
 
-  and dnf (e : IT.t) : IT.t =
+  and dnf (e : T.t) : T.t =
     let (IT (e, info, loc)) = e in
     IT (dnf_ e, info, loc)
 
 
-  let listify_constraints (it : IT.t) : IT.t list =
-    let rec loop (c : IT.t) : IT.t list =
+  let listify_constraints (it : T.t) : T.t list =
+    let rec loop (c : T.t) : T.t list =
       match c with IT (Binop (Or, e1, e2), _, _) -> loop e1 @ loop e2 | _ -> [ c ]
     in
     loop it
@@ -84,7 +85,7 @@ module Make (AD : Domain.T) = struct
            let its_split, its_left =
              it
              |> listify_constraints
-             |> List.partition (fun (it' : IT.t) ->
+             |> List.partition (fun (it' : T.t) ->
                match it' with
                | IT (Binop (EQ, IT (Sym x, _, _), _), _, _) when not (Sym.Set.mem x ext)
                  ->
@@ -92,7 +93,7 @@ module Make (AD : Domain.T) = struct
                | IT (Binop (EQ, _, IT (Sym x, _, _)), _, _) when not (Sym.Set.mem x ext)
                  ->
                  true
-               | _ -> Sym.Set.disjoint ext (IT.free_vars it'))
+               | _ -> Sym.Set.disjoint ext (T.free_vars it'))
            in
            if List.is_empty its_split then
              gt

--- a/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/ite.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/ite.ml
@@ -1,33 +1,34 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
 module Make (AD : Domain.T) = struct
   module Term = Term.Make (AD)
 
-  let transform_it (it : IT.t) : IT.t =
-    let aux (it : IT.t) : IT.t =
+  let transform_it (it : T.t) : T.t =
+    let aux (it : T.t) : T.t =
       match it with
       | IT (Unop (op, IT (ITE (it_if, it_then, it_else), _, loc_ite)), bt_unop, loc_unop)
         ->
-        let f it' = IT.IT (Unop (op, it'), bt_unop, loc_unop) in
+        let f it' = Terms.IT (Unop (op, it'), bt_unop, loc_unop) in
         IT.ite_ (it_if, f it_then, f it_else) loc_ite
       | IT
           ( Binop (op, IT (ITE (it_if, it_then, it_else), _, loc_ite), it2),
             bt_binop,
             loc_binop ) ->
-        let f it' = IT.IT (Binop (op, it', it2), bt_binop, loc_binop) in
+        let f it' = Terms.IT (Binop (op, it', it2), bt_binop, loc_binop) in
         IT.ite_ (it_if, f it_then, f it_else) loc_ite
       | IT
           ( Binop (op, it1, IT (ITE (it_if, it_then, it_else), _, loc_ite)),
             bt_binop,
             loc_binop ) ->
-        let f it' = IT.IT (Binop (op, it1, it'), bt_binop, loc_binop) in
+        let f it' = Terms.IT (Binop (op, it1, it'), bt_binop, loc_binop) in
         IT.ite_ (it_if, f it_then, f it_else) loc_ite
       | IT
           ( EachI ((min, (i, i_bt), max), IT (ITE (it_if, it_then, it_else), _, loc_ite)),
             _,
             loc_each )
-        when not (Sym.Set.mem i (IT.free_vars it_if)) ->
+        when not (Sym.Set.mem i (T.free_vars it_if)) ->
         let f it' = IT.eachI_ (min, (i, i_bt), max) it' loc_each in
         IT.ite_ (it_if, f it_then, f it_else) loc_ite
       | IT (Cast (cast_bt, IT (ITE (it_if, it_then, it_else), _, loc_ite)), _, loc_cast)
@@ -37,7 +38,7 @@ module Make (AD : Domain.T) = struct
       (* TODO: Complete cases *)
       | _ -> it
     in
-    IT.map_term_post aux it
+    Terms.map_term_post aux it
 
 
   let transform_lc (lc : LC.t) : LC.t =
@@ -54,7 +55,7 @@ module Make (AD : Domain.T) = struct
     let (Annot (gt_, (), _, _)) = gt in
     match gt_ with
     | `Arbitrary | `Symbolic -> false
-    | `Return it -> not (Sym.Set.disjoint ext (IT.free_vars it))
+    | `Return it -> not (Sym.Set.disjoint ext (T.free_vars it))
     | `Call _ -> true
     | `Pick gts -> gts |> List.exists (is_external ext)
     | `Asgn (_, _, gt_rest) -> is_external ext gt_rest
@@ -81,7 +82,7 @@ module Make (AD : Domain.T) = struct
         let gt' = aux ext gt' in
         (match transform_lc lc with
          | T (IT (ITE (it_if, it_then, it_else), _, loc_ite))
-           when Sym.Set.disjoint ext (IT.free_vars it_if) ->
+           when Sym.Set.disjoint ext (T.free_vars it_if) ->
            Term.ite_
              ( it_if,
                Term.assert_ (T it_then, gt') () loc,

--- a/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/let.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/let.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -10,7 +11,7 @@ module Make (AD : Domain.T) = struct
       match gt_ with
       | `Assert (T (IT (Let ((x, it_inner), it_rest), _, loc_let)), gt') ->
         Term.let_star_
-          ( (x, Term.return_ it_inner () (IT.get_loc it_inner)),
+          ( (x, Term.return_ it_inner () (T.get_loc it_inner)),
             Term.assert_ (LC.T it_rest, gt') () loc )
           ()
           loc_let

--- a/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/let.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/liftConstraints/let.ml
@@ -1,5 +1,4 @@
 module T = Terms.Normal
-module IT = IndexTerms
 module LC = LogicalConstraints
 
 module Make (AD : Domain.T) = struct

--- a/lib/testGeneration/bennet/stage2/simplifyGen/partialEvaluation.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/partialEvaluation.ml
@@ -1,6 +1,9 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
+
+open Terms
 
 module Make (AD : Domain.T) = struct
   module Term = Term.Make (AD)
@@ -20,14 +23,14 @@ module Make (AD : Domain.T) = struct
 
 
     let eval_num_binop
-          (eval : IT.t -> (IT.t, string) result)
+          (eval : T.t -> (T.t, string) result)
           (bt : BT.t)
           (here : Locations.t)
           (f : Z.t -> Z.t -> Z.t)
-          (it1 : IT.t)
-          (it2 : IT.t)
+          (it1 : T.t)
+          (it2 : T.t)
           (loc : string)
-      : (IT.t, string) result
+      : (T.t, string) result
       =
       let ( let@ ) = Result.bind in
       let return = Result.ok in
@@ -41,29 +44,29 @@ module Make (AD : Domain.T) = struct
         let@ () = check_bits_bt (sgn1, sz1) (sgn2, sz2) here in
         return @@ IT.num_lit_ (BT.normalise_to_range_bt bt (f n1 n2)) bt here
       | _, IT (Const (Z _), _, _) ->
-        Error ("Not constant integer `" ^ Pp.plain (IT.pp it1) ^ "` (" ^ loc ^ ")")
+        Error ("Not constant integer `" ^ Pp.plain (T.pp it1) ^ "` (" ^ loc ^ ")")
       | _, IT (Const (Bits _), _, _) ->
-        Error ("Not constant bitvector `" ^ Pp.plain (IT.pp it1) ^ "` (" ^ loc ^ ")")
+        Error ("Not constant bitvector `" ^ Pp.plain (T.pp it1) ^ "` (" ^ loc ^ ")")
       | IT (Const (Z _), _, _), _ ->
-        Error ("Not constant integer `" ^ Pp.plain (IT.pp it2) ^ "` (" ^ loc ^ ")")
+        Error ("Not constant integer `" ^ Pp.plain (T.pp it2) ^ "` (" ^ loc ^ ")")
       | IT (Const (Bits _), _, _), _ ->
-        Error ("Not constant bitvector `" ^ Pp.plain (IT.pp it2) ^ "` (" ^ loc ^ ")")
+        Error ("Not constant bitvector `" ^ Pp.plain (T.pp it2) ^ "` (" ^ loc ^ ")")
       | _, _ ->
         Error
           ("Not constant integer or bitvector `"
-           ^ Pp.plain (IT.pp it1)
+           ^ Pp.plain (T.pp it1)
            ^ "` and `"
-           ^ Pp.plain (IT.pp it2)
+           ^ Pp.plain (T.pp it2)
            ^ "` ("
            ^ loc
            ^ ")")
 
 
     let eval_term_generic
-          (eval_aux : IT.t -> (IT.t, string) result)
+          (eval_aux : T.t -> (T.t, string) result)
           (prog5 : unit Mucore.file)
-          (it : IT.t)
-      : (IT.t, string) result
+          (it : T.t)
+      : (T.t, string) result
       =
       let ( let@ ) = Result.bind in
       let return = Result.ok in
@@ -213,7 +216,7 @@ module Make (AD : Domain.T) = struct
         let@ it2 = eval_aux it2 in
         (match (it1, it2) with
          | IT (Const c1, _, _), IT (Const c2, _, _) ->
-           return @@ bool_ (equal_const c1 c2) here
+           return @@ bool_ (Terms.equal_const c1 c2) here
          | IT (Tuple its1, _, _), IT (Tuple its2, _, _) ->
            eval_aux
              (and_ (List.map (fun its -> eq_ its here) (List.combine its1 its2)) here)
@@ -269,8 +272,8 @@ module Make (AD : Domain.T) = struct
       | EachI ((i_start, (i_sym, bt'), i_end), it') ->
         let rec loop i =
           if i <= i_end then (
-            let su = make_subst [ (i_sym, num_lit_ (Z.of_int i) bt' here) ] in
-            let t1 = IT.subst su it' in
+            let su = T.make_subst [ (i_sym, num_lit_ (Z.of_int i) bt' here) ] in
+            let t1 = T.subst su it' in
             if i = i_end then
               t1
             else
@@ -286,7 +289,7 @@ module Make (AD : Domain.T) = struct
          | _ -> Error ("Not tuple (" ^ __LOC__ ^ ")"))
       | SizeOf ty ->
         return
-        @@ IT
+        @@ Terms.IT
              ( Const
                  (Bits
                     ( (Unsigned, Memory.size_of_ctype Sctypes.(Integer Size_t)),
@@ -340,7 +343,7 @@ module Make (AD : Domain.T) = struct
         eval_aux (good_value struct_decls ty it' here)
       | Aligned { t; align } ->
         let addr = addr_ t here in
-        if not (BT.equal (IT.get_bt addr) (IT.get_bt align)) then
+        if not (BT.equal (T.get_bt addr) (T.get_bt align)) then
           Error "Mismatched types"
         else
           eval_aux (divisible_ (addr, align) here)
@@ -358,12 +361,12 @@ module Make (AD : Domain.T) = struct
          | Some { args; body = Def it_body; _ } | Some { args; body = Rec_Def it_body; _ }
            ->
            return
-           @@ IT.subst (IT.make_subst (List.combine (List.map fst args) its)) it_body
+           @@ T.subst (T.make_subst (List.combine (List.map fst args) its)) it_body
          | Some { body = Uninterp; _ } ->
            Error ("Function " ^ Sym.pp_string fsym ^ " is uninterpreted")
          | None -> Error ("Function " ^ Sym.pp_string fsym ^ " was not found"))
       | Let ((x, it_v), it_rest) ->
-        eval_aux (IT.subst (IT.make_subst [ (x, it_v) ]) it_rest)
+        eval_aux (T.subst (T.make_subst [ (x, it_v) ]) it_rest)
       | StructMember (it', member) ->
         let@ it' = eval_aux it' in
         (match it' with
@@ -402,10 +405,10 @@ module Make (AD : Domain.T) = struct
           match it' with IT (Constructor _, _, _) -> true | _ -> false
         in
         if not is_constructor then
-          return @@ IT (Match (it', pits), bt, here)
+          return @@ Terms.IT (Match (it', pits), bt, here)
         else (
-          let rec get_match (it_match : IT.t) (p : BT.t pattern)
-            : (Sym.t * IT.t) list option
+          let rec get_match (it_match : T.t) (p : BT.t pattern)
+            : (Sym.t * T.t) list option
             =
             let (Pat (p_, _, _)) = p in
             match p_ with
@@ -433,13 +436,13 @@ module Make (AD : Domain.T) = struct
                (fun (p, it_case) ->
                   let open Option in
                   let@ sub = get_match it' p in
-                  Some (IT.subst (IT.make_subst sub) it_case))
+                  Some (T.subst (T.make_subst sub) it_case))
                pits))
       | WrapI _ -> Error "todo: WrapI"
       | MapGet (it_m, it_k) ->
         let@ it_m = eval_aux it_m in
         let@ it_k = eval_aux it_k in
-        let aux (it_m : IT.t) (it_k : IT.t) : (IT.t, string) result =
+        let aux (it_m : T.t) (it_k : T.t) : (T.t, string) result =
           match it_m with
           | IT (MapConst (_, it_body), _, _) -> eval_aux it_body
           | IT (MapSet (it_m', it_k', it_v), _, _) ->
@@ -449,7 +452,7 @@ module Make (AD : Domain.T) = struct
              | Some _, Some _ -> eval_aux (map_get_ it_m' it_k here)
              | _, _ -> Error "not a valid key")
           | IT (MapDef ((k, _), it_body), _, _) ->
-            eval_aux (IT.subst (IT.make_subst [ (k, it_k) ]) it_body)
+            eval_aux (T.subst (T.make_subst [ (k, it_k) ]) it_body)
           | _ -> Error "Attempted MapGet on non-map"
         in
         aux it_m it_k
@@ -462,8 +465,8 @@ module Make (AD : Domain.T) = struct
       | GetOpt _ -> Error "todo: GetOpt"
 
 
-    let eval_term_strictly (prog5 : unit Mucore.file) (it : IT.t) : (IT.t, string) result =
-      let rec eval_aux (it : IT.t) : (IT.t, string) result =
+    let eval_term_strictly (prog5 : unit Mucore.file) (it : T.t) : (T.t, string) result =
+      let rec eval_aux (it : T.t) : (T.t, string) result =
         let ( let@ ) = Result.bind in
         let return = Result.ok in
         let open IT in
@@ -503,7 +506,7 @@ module Make (AD : Domain.T) = struct
           eval_term_generic
             eval_aux
             prog5
-            (IT.IT (StructUpdate ((it_struct, member), it_value), bt, here))
+            (IT (StructUpdate ((it_struct, member), it_value), bt, here))
         | Record xits ->
           let@ xits =
             List.fold_right
@@ -520,7 +523,7 @@ module Make (AD : Domain.T) = struct
           eval_term_generic
             eval_aux
             prog5
-            (IT.IT (RecordUpdate ((it_record, member), it_value), bt, here))
+            (IT (RecordUpdate ((it_record, member), it_value), bt, here))
         | Constructor (constr, xits) ->
           let@ xits =
             List.fold_right
@@ -557,9 +560,9 @@ module Make (AD : Domain.T) = struct
       eval_aux it
 
 
-    let eval_term_lazily (prog5 : unit Mucore.file) (it : IT.t) : (IT.t, string) result =
-      let rec eval_aux (it : IT.t) : (IT.t, string) result =
-        let open IT in
+    let eval_term_lazily (prog5 : unit Mucore.file) (it : T.t) : (T.t, string) result =
+      let rec eval_aux (it : T.t) : (T.t, string) result =
+        (* let open IT in *)
         let (IT (t_, _, _)) = it in
         match t_ with
         | Const _ | Sym _ | Unop _ | Binop _ | ITE _ | EachI _ | NthTuple _
@@ -582,8 +585,8 @@ module Make (AD : Domain.T) = struct
       eval_aux it
 
 
-    let eval ?(mode = Strict) ?(prog5 : unit Mucore.file = Mucore.empty_file) (it : IT.t)
-      : (IT.t, string) result
+    let eval ?(mode = Strict) ?(prog5 : unit Mucore.file = Mucore.empty_file) (it : T.t)
+      : (T.t, string) result
       =
       match mode with
       | Strict -> eval_term_strictly prog5 it
@@ -593,13 +596,13 @@ module Make (AD : Domain.T) = struct
     let partial_eval
           ?(mode = Strict)
           ?(prog5 : unit Mucore.file = Mucore.empty_file)
-          (it : IT.t)
-      : IT.t
+          (it : T.t)
+      : T.t
       =
-      let f ?(mode = mode) (it : IT.t) : IT.t =
+      let f ?(mode = mode) (it : T.t) : T.t =
         match eval ~mode ~prog5 it with Ok it' -> it' | Error _ -> it
       in
-      let aux (it : IT.t) : IT.t =
+      let aux (it : T.t) : T.t =
         match it with
         | IT (Apply (fsym, _), _, _) ->
           (* If we lazily evaluate every sub-term, all applications will result in a
@@ -611,7 +614,7 @@ module Make (AD : Domain.T) = struct
            | Some { body = Uninterp; _ } | None -> it)
         | _ -> f it
       in
-      IT.map_term_post aux it
+      map_term_post aux it
   end
 
   module LogicalConstraints = struct

--- a/lib/testGeneration/bennet/stage2/simplifyGen/partialEvaluation.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/partialEvaluation.ml
@@ -2,7 +2,6 @@ module BT = BaseTypes
 module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
-
 open Terms
 
 module Make (AD : Domain.T) = struct
@@ -360,8 +359,7 @@ module Make (AD : Domain.T) = struct
         (match List.assoc_opt Sym.equal fsym prog5.logical_predicates with
          | Some { args; body = Def it_body; _ } | Some { args; body = Rec_Def it_body; _ }
            ->
-           return
-           @@ T.subst (T.make_subst (List.combine (List.map fst args) its)) it_body
+           return @@ T.subst (T.make_subst (List.combine (List.map fst args) its)) it_body
          | Some { body = Uninterp; _ } ->
            Error ("Function " ^ Sym.pp_string fsym ^ " is uninterpreted")
          | None -> Error ("Function " ^ Sym.pp_string fsym ^ " was not found"))

--- a/lib/testGeneration/bennet/stage2/simplifyGen/pushPull.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/pushPull.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -17,7 +18,7 @@ module Make (AD : Domain.T) = struct
            let z = Sym.fresh_anon () in
            let gt4 =
              Term.subst
-               (IT.make_subst
+               (T.make_subst
                   [ (y, IT.sym_ (z, Term.basetype gt3, Locations.other __LOC__)) ])
                gt4
            in

--- a/lib/testGeneration/bennet/stage2/simplifyGen/removeUnused.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/removeUnused.ml
@@ -1,5 +1,3 @@
-module IT = IndexTerms
-
 module Make (AD : Domain.T) = struct
   module Term = Term.Make (AD)
 
@@ -12,7 +10,7 @@ module Make (AD : Domain.T) = struct
         when (not (Term.contains_constraint gt_inner))
              && not (Sym.Set.mem x (Term.free_vars gt_rest)) ->
         gt_rest
-      | `Assert (T it, gt_rest) when IT.is_true it -> gt_rest
+      | `Assert (T it, gt_rest) when Terms.is_true it -> gt_rest
       | _ -> gt
     in
     Term.map_gen_post aux gt

--- a/lib/testGeneration/bennet/stage2/simplifyGen/simplifyIndexTerm.ml
+++ b/lib/testGeneration/bennet/stage2/simplifyGen/simplifyIndexTerm.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -12,7 +13,7 @@ module Make (AD : Domain.T) = struct
           logical_functions = Sym.Map.of_seq (List.to_seq prog5.logical_predicates)
         }
       in
-      let simp_it (it : IT.t) : IT.t =
+      let simp_it (it : T.t) : T.t =
         Simplify.IndexTerms.simp ~inline_functions:true (Simplify.default globals) it
       in
       let simp_lc (lc : LC.t) : LC.t =
@@ -39,9 +40,9 @@ module Make (AD : Domain.T) = struct
   end
 
   module Fixes = struct
-    let simplify_it (it : IT.t) : IT.t =
-      let aux (it : IT.t) : IT.t =
-        let (IT.IT (it_, bt, loc)) = it in
+    let simplify_it (it : T.t) : T.t =
+      let aux (it : T.t) : T.t =
+        let (Terms.IT (it_, bt, loc)) = it in
         match it_ with
         (* Fulminate ignores `good` already, so we will too for benefits to laziness *)
         (* FIXME: Want a more formal guarantee from generators in future *)
@@ -86,14 +87,14 @@ module Make (AD : Domain.T) = struct
           IT.cast_ bt1 (IT.cast_ bt2 it' loc_cast2) loc_cast1
         | Cast
             ((Bits (sign1, bits1) as bt1), IT (Cast (Bits (sign2, bits2), it_inner), _, _))
-          when BT.equal bt1 (IT.get_bt it_inner)
+          when BT.equal bt1 (T.get_bt it_inner)
                &&
                let f = BT.fits_range (sign2, bits2) in
                let min, max = BT.bits_range (sign1, bits1) in
                f min && f max ->
           it_inner
         | Cast ((Loc () as bt1), IT (Cast (Bits (sign2, bits2), it_inner), _, _))
-          when BT.equal bt1 (IT.get_bt it_inner)
+          when BT.equal bt1 (T.get_bt it_inner)
                &&
                let sign1, bits1 = Option.get (BT.is_bits_bt Memory.uintptr_bt) in
                let f = BT.fits_range (sign2, bits2) in
@@ -101,7 +102,7 @@ module Make (AD : Domain.T) = struct
                f min && f max ->
           it_inner
         | Cast ((Bits (sign1, bits1) as bt1), IT (Cast (Loc (), it_inner), _, _))
-          when BT.equal bt1 (IT.get_bt it_inner)
+          when BT.equal bt1 (T.get_bt it_inner)
                &&
                let sign2, bits2 = Option.get (BT.is_bits_bt Memory.uintptr_bt) in
                let f = BT.fits_range (sign2, bits2) in
@@ -141,7 +142,7 @@ module Make (AD : Domain.T) = struct
                   _,
                   _ ),
               IT (Sym x', _, _) )
-          when Sym.equal x x' && IT.equal it1 it2 ->
+          when Sym.equal x x' && T.equal it1 it2 ->
           IT.eq_
             (IT.mod_ (IT.sym_ (x, x_bt, x_loc), it1) loc, IT.num_lit_ Z.zero x_bt loc)
             loc
@@ -172,13 +173,13 @@ module Make (AD : Domain.T) = struct
                     (MulNoSMT, IT (Binop (DivNoSMT, IT (Sym x', _, _), it1), _, _), it2),
                   _,
                   _ ) )
-          when Sym.equal x x' && IT.equal it1 it2 ->
+          when Sym.equal x x' && T.equal it1 it2 ->
           IT.eq_
             (IT.mod_ (IT.sym_ (x, x_bt, x_loc), it1) loc, IT.num_lit_ Z.zero x_bt loc)
             loc
-        | (Binop (Min, it1, it2) | Binop (Max, it1, it2)) when IT.equal it1 it2 -> it1
+        | (Binop (Min, it1, it2) | Binop (Max, it1, it2)) when T.equal it1 it2 -> it1
         | Binop (Min, it1, it2) ->
-          (match (IT.is_bits_const it1, IT.is_bits_const it2) with
+          (match (Terms.is_bits_const it1, Terms.is_bits_const it2) with
            | Some (_, n1), Some (_, n2) -> IT.num_lit_ (Z.min n1 n2) bt loc
            | Some ((sgn, sz), n), _ when Z.equal n (fst (BT.bits_range (sgn, sz))) -> it1
            | _, Some ((sgn, sz), n) when Z.equal n (fst (BT.bits_range (sgn, sz))) -> it2
@@ -186,7 +187,7 @@ module Make (AD : Domain.T) = struct
            | _, Some ((sgn, sz), n) when Z.equal n (snd (BT.bits_range (sgn, sz))) -> it1
            | _ -> it)
         | Binop (Max, it1, it2) ->
-          (match (IT.is_bits_const it1, IT.is_bits_const it2) with
+          (match (Terms.is_bits_const it1, Terms.is_bits_const it2) with
            | Some (_, n1), Some (_, n2) -> IT.num_lit_ (Z.max n1 n2) bt loc
            | Some ((sgn, sz), n), _ when Z.equal n (snd (BT.bits_range (sgn, sz))) -> it1
            | _, Some ((sgn, sz), n) when Z.equal n (snd (BT.bits_range (sgn, sz))) -> it2
@@ -195,7 +196,7 @@ module Make (AD : Domain.T) = struct
            | _ -> it)
         | _ -> it
       in
-      IT.map_term_post aux it
+      Terms.map_term_post aux it
 
 
     let simplify_lc (lc : LC.t) : LC.t =
@@ -204,7 +205,7 @@ module Make (AD : Domain.T) = struct
       | Forall ((i, i_bt), IT (Binop (Implies, it_perm, it_body), _, loc_implies)) ->
         let it_perm = simplify_it it_perm in
         let it_body = simplify_it it_body in
-        if IT.is_false it_perm || IT.is_true it_body then
+        if Terms.is_false it_perm || Terms.is_true it_body then
           LC.T (IT.bool_ true loc_implies)
         else
           LC.Forall ((i, i_bt), IT.impl_ (it_perm, it_body) loc_implies)

--- a/lib/testGeneration/bennet/stage2/specializeEquality.ml
+++ b/lib/testGeneration/bennet/stage2/specializeEquality.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -6,9 +7,9 @@ module Make (AD : Domain.T) = struct
   module Term = Term.Make (AD)
 
   let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t)
-    : (Term.t * IT.t) option
+    : (Term.t * T.t) option
     =
-    let rec aux (gt : Term.t) : (Term.t * IT.t) option =
+    let rec aux (gt : Term.t) : (Term.t * T.t) option =
       let open Option in
       let (Annot (gt_, (), _, loc)) = gt in
       match gt_ with
@@ -27,13 +28,13 @@ module Make (AD : Domain.T) = struct
       | `Assert (T (IT (Binop (EQ, IT (Sym x', bt, _), it), _, _)), gt_rest)
       | `Assert
           (T (IT (Binop (EQ, IT (Cast (_, IT (Sym x', bt, _)), _, _), it), _, _)), gt_rest)
-        when Sym.equal x x' && Sym.Set.subset (IT.free_vars it) vars ->
-        return (gt_rest, IT.cast_ bt it (IT.get_loc it))
+        when Sym.equal x x' && Sym.Set.subset (T.free_vars it) vars ->
+        return (gt_rest, IT.cast_ bt it (T.get_loc it))
       | `Assert (T (IT (Binop (EQ, it, IT (Sym x', bt, _)), _, _)), gt_rest)
       | `Assert
           (T (IT (Binop (EQ, it, IT (Cast (_, IT (Sym x', bt, _)), _, _)), _, _)), gt_rest)
-        when Sym.equal x x' && Sym.Set.subset (IT.free_vars it) vars ->
-        return (gt_rest, IT.cast_ bt it (IT.get_loc it))
+        when Sym.equal x x' && Sym.Set.subset (T.free_vars it) vars ->
+        return (gt_rest, IT.cast_ bt it (T.get_loc it))
       | `Assert (lc, gt_rest) ->
         let@ gt_rest, it = aux gt_rest in
         return (Term.assert_ (lc, gt_rest) () loc, it)

--- a/lib/testGeneration/bennet/stage2/specializeEquality.ml
+++ b/lib/testGeneration/bennet/stage2/specializeEquality.ml
@@ -6,8 +6,7 @@ module Make (AD : Domain.T) = struct
   module Def = Def.Make (AD)
   module Term = Term.Make (AD)
 
-  let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t)
-    : (Term.t * T.t) option
+  let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t) : (Term.t * T.t) option
     =
     let rec aux (gt : Term.t) : (Term.t * T.t) option =
       let open Option in

--- a/lib/testGeneration/bennet/stage2/term.ml
+++ b/lib/testGeneration/bennet/stage2/term.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module CF = Cerb_frontend
@@ -15,16 +16,16 @@ module Make (AD : Domain.T) = struct
       type 'recur ast =
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
-        | `Call of Sym.t * IT.t list
-          (** `Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `Asgn of (IT.t * Sctypes.t) * IT.t * 'recur annot
+        | `Call of Sym.t * T.t list
+          (** `Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `Asgn of (T.t * Sctypes.t) * T.t * 'recur annot
           (** Claim ownership and assign a value to a memory location *)
         | `LetStar of (Sym.t * 'recur annot) * 'recur annot (** Backtrack point *)
-        | `Return of IT.t (** Monadic return *)
+        | `Return of T.t (** Monadic return *)
         | `Assert of LC.t * 'recur annot
           (** `Assert some [LC.t] are true, backtracking otherwise *)
-        | `ITE of IT.t * 'recur annot * 'recur annot (** If-then-else *)
-        | `Map of (Sym.t * BT.t * IT.t) * 'recur annot
+        | `ITE of T.t * 'recur annot * 'recur annot (** If-then-else *)
+        | `Map of (Sym.t * BT.t * T.t) * 'recur annot
         | `Pick of 'recur annot list
         ]
       [@@deriving eq, ord]
@@ -48,12 +49,12 @@ module Make (AD : Domain.T) = struct
           let name = "Stage 2"
         end)
 
-      let call_ ((fsym, its) : Sym.t * IT.t list) (tag : tag_t) (bt : BT.t) loc : t =
+      let call_ ((fsym, its) : Sym.t * T.t list) (tag : tag_t) (bt : BT.t) loc : t =
         Annot (`Call (fsym, its), tag, bt, loc)
 
 
       let asgn_
-            (((it_addr, ct), it_val, gt') : (IT.t * Sctypes.t) * IT.t * t)
+            (((it_addr, ct), it_val, gt') : (T.t * Sctypes.t) * T.t * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -67,22 +68,22 @@ module Make (AD : Domain.T) = struct
         Annot (`LetStar ((x, gt1), gt2), tag, basetype gt2, loc)
 
 
-      let return_ (it : IT.t) (tag : tag_t) (loc : Locations.t) : t =
-        Annot (`Return it, tag, IT.get_bt it, loc)
+      let return_ (it : T.t) (tag : tag_t) (loc : Locations.t) : t =
+        Annot (`Return it, tag, T.get_bt it, loc)
 
 
       let assert_ ((lc, gt') : LC.t * t) (tag : tag_t) (loc : Locations.t) : t =
         Annot (`Assert (lc, gt'), tag, basetype gt', loc)
 
 
-      let ite_ ((it_if, gt_then, gt_else) : IT.t * t * t) (tag : tag_t) loc : t =
+      let ite_ ((it_if, gt_then, gt_else) : T.t * t * t) (tag : tag_t) loc : t =
         let bt = basetype gt_then in
         assert (BT.equal bt (basetype gt_else));
         Annot (`ITE (it_if, gt_then, gt_else), tag, bt, loc)
 
 
       let map_
-            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * IT.t) * t)
+            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * T.t) * t)
             (tag : tag_t)
             loc
         : t

--- a/lib/testGeneration/bennet/stage3/simplifyNames.ml
+++ b/lib/testGeneration/bennet/stage3/simplifyNames.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 module StringMap = Map.Make (String)
 
@@ -43,7 +44,7 @@ module Make (AD : Domain.T) = struct
             ( StringMap.add name (n + 1) vars,
               y,
               Term.subst
-                (IT.make_subst
+                (T.make_subst
                    [ (x, IT.sym_ (y, Term.basetype gt_inner, Term.loc gt_inner)) ])
                 gt' )
           | None -> (StringMap.add name 1 vars, x, gt')
@@ -65,10 +66,10 @@ module Make (AD : Domain.T) = struct
           | Some n ->
             let name' = name ^ "_" ^ string_of_int n in
             let j = Sym.fresh name' in
-            let su = IT.make_rename ~from:i_sym ~to_:j in
+            let su = T.make_rename ~from:i_sym ~to_:j in
             ( StringMap.add name (n + 1) vars,
               j,
-              IT.subst su it_perm,
+              T.subst su it_perm,
               Term.subst su gt_inner )
           | None -> (StringMap.add name 1 vars, i_sym, it_perm, gt_inner)
         in

--- a/lib/testGeneration/bennet/stage3/specializeEquality.ml
+++ b/lib/testGeneration/bennet/stage3/specializeEquality.ml
@@ -7,8 +7,7 @@ module Make (AD : Domain.T) = struct
   module Def = Stage2.Def
   module Term = Stage2.Term
 
-  let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t)
-    : (Term.t * T.t) option
+  let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t) : (Term.t * T.t) option
     =
     let rec aux (gt : Term.t) : (Term.t * T.t) option =
       let open Option in

--- a/lib/testGeneration/bennet/stage3/specializeEquality.ml
+++ b/lib/testGeneration/bennet/stage3/specializeEquality.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 
 module Make (AD : Domain.T) = struct
@@ -7,9 +8,9 @@ module Make (AD : Domain.T) = struct
   module Term = Stage2.Term
 
   let find_constraint (vars : Sym.Set.t) (x : Sym.t) (gt : Term.t)
-    : (Term.t * IT.t) option
+    : (Term.t * T.t) option
     =
-    let rec aux (gt : Term.t) : (Term.t * IT.t) option =
+    let rec aux (gt : Term.t) : (Term.t * T.t) option =
       let open Option in
       let (Annot (gt_, (), _, loc)) = gt in
       match gt_ with
@@ -28,13 +29,13 @@ module Make (AD : Domain.T) = struct
       | `Assert (T (IT (Binop (EQ, IT (Sym x', bt, _), it), _, _)), gt_rest)
       | `Assert
           (T (IT (Binop (EQ, IT (Cast (_, IT (Sym x', bt, _)), _, _), it), _, _)), gt_rest)
-        when Sym.equal x x' && Sym.Set.subset (IT.free_vars it) vars ->
-        return (gt_rest, IT.cast_ bt it (IT.get_loc it))
+        when Sym.equal x x' && Sym.Set.subset (T.free_vars it) vars ->
+        return (gt_rest, IT.cast_ bt it (T.get_loc it))
       | `Assert (T (IT (Binop (EQ, it, IT (Sym x', bt, _)), _, _)), gt_rest)
       | `Assert
           (T (IT (Binop (EQ, it, IT (Cast (_, IT (Sym x', bt, _)), _, _)), _, _)), gt_rest)
-        when Sym.equal x x' && Sym.Set.subset (IT.free_vars it) vars ->
-        return (gt_rest, IT.cast_ bt it (IT.get_loc it))
+        when Sym.equal x x' && Sym.Set.subset (T.free_vars it) vars ->
+        return (gt_rest, IT.cast_ bt it (T.get_loc it))
       | `Assert (lc, gt_rest) ->
         let@ gt_rest, it = aux gt_rest in
         return (Term.assert_ (lc, gt_rest) () loc, it)

--- a/lib/testGeneration/bennet/stage4/adPruning.ml
+++ b/lib/testGeneration/bennet/stage4/adPruning.ml
@@ -36,7 +36,7 @@ module Make (AD : Domain.T) = struct
         if contains_bottom_domain gt_else then
           Term.assert_ (T it_if, gt_then) () loc
         else if contains_bottom_domain gt_then then
-          Term.assert_ (T (IT.not_ it_if (IT.get_loc it_if)), gt_else) () loc
+          Term.assert_ (T (IT.not_ it_if (Terms.get_loc it_if)), gt_else) () loc
         else
           gt
       | _ -> gt

--- a/lib/testGeneration/bennet/stage4/smtPruning.ml
+++ b/lib/testGeneration/bennet/stage4/smtPruning.ml
@@ -57,7 +57,10 @@ module Make (AD : Domain.T) = struct
             let sym = Sym.fresh_anon () in
             let it_sym = IT.sym_ (sym, Terms.get_bt it_val, loc) in
             let@ () =
-              add_l_value sym it_val (loc, lazy Pp.(Sym.pp sym ^^^ !^"=" ^^^ Terms.pp it_val))
+              add_l_value
+                sym
+                it_val
+                (loc, lazy Pp.(Sym.pp sym ^^^ !^"=" ^^^ Terms.pp it_val))
             in
             add_r
               loc

--- a/lib/testGeneration/bennet/stage4/smtPruning.ml
+++ b/lib/testGeneration/bennet/stage4/smtPruning.ml
@@ -55,9 +55,9 @@ module Make (AD : Domain.T) = struct
             add_c loc (LC.T (IT.ne_ (it_addr, IT.null_ loc) loc))
           else (
             let sym = Sym.fresh_anon () in
-            let it_sym = IT.sym_ (sym, IT.get_bt it_val, loc) in
+            let it_sym = IT.sym_ (sym, Terms.get_bt it_val, loc) in
             let@ () =
-              add_l_value sym it_val (loc, lazy Pp.(Sym.pp sym ^^^ !^"=" ^^^ IT.pp it_val))
+              add_l_value sym it_val (loc, lazy Pp.(Sym.pp sym ^^^ !^"=" ^^^ Terms.pp it_val))
             in
             add_r
               loc

--- a/lib/testGeneration/bennet/stage4/specialize.ml
+++ b/lib/testGeneration/bennet/stage4/specialize.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -10,45 +11,45 @@ module Make (AD : Domain.T) = struct
   module Integer = struct
     module Rep = struct
       type t =
-        { min_inc : IT.t option; (* x >= n *)
-          min_ex : IT.t option; (* x > n, i.e., n < x *)
-          max_inc : IT.t option; (* x <= n *)
-          max_ex : IT.t option (* x < n *)
+        { min_inc : T.t option; (* x >= n *)
+          min_ex : T.t option; (* x > n, i.e., n < x *)
+          max_inc : T.t option; (* x <= n *)
+          max_ex : T.t option (* x < n *)
         }
 
-      let of_min_inc (it : IT.t) : t =
+      let of_min_inc (it : T.t) : t =
         { min_inc = Some it; min_ex = None; max_inc = None; max_ex = None }
 
 
-      let of_min_ex (it : IT.t) : t =
+      let of_min_ex (it : T.t) : t =
         { min_inc = None; min_ex = Some it; max_inc = None; max_ex = None }
 
 
-      let of_max_inc (it : IT.t) : t =
+      let of_max_inc (it : T.t) : t =
         { min_inc = None; min_ex = None; max_inc = Some it; max_ex = None }
 
 
-      let of_max_ex (it : IT.t) : t =
+      let of_max_ex (it : T.t) : t =
         { min_inc = None; min_ex = None; max_inc = None; max_ex = Some it }
 
 
-      let of_it (x : Sym.t) (it : IT.t) : t option =
+      let of_it (x : Sym.t) (it : T.t) : t option =
         let (IT (it_, _, _)) = it in
         match it_ with
         | (Binop (LT, IT (Sym x', _, _), it') | Binop (LTPointer, IT (Sym x', _, _), it'))
-          when Sym.equal x x' && not (Sym.Set.mem x (IT.free_vars it')) ->
+          when Sym.equal x x' && not (Sym.Set.mem x (T.free_vars it')) ->
           (* x < it' -> max_ex = it' *)
           Some (of_max_ex it')
         | (Binop (LE, IT (Sym x', _, _), it') | Binop (LEPointer, IT (Sym x', _, _), it'))
-          when Sym.equal x x' && not (Sym.Set.mem x (IT.free_vars it')) ->
+          when Sym.equal x x' && not (Sym.Set.mem x (T.free_vars it')) ->
           (* x <= it' -> max_inc = it' *)
           Some (of_max_inc it')
         | (Binop (LT, it', IT (Sym x', _, _)) | Binop (LTPointer, it', IT (Sym x', _, _)))
-          when Sym.equal x x' && not (Sym.Set.mem x (IT.free_vars it')) ->
+          when Sym.equal x x' && not (Sym.Set.mem x (T.free_vars it')) ->
           (* it' < x -> min_ex = it' *)
           Some (of_min_ex it')
         | (Binop (LE, it', IT (Sym x', _, _)) | Binop (LEPointer, it', IT (Sym x', _, _)))
-          when Sym.equal x x' && not (Sym.Set.mem x (IT.free_vars it')) ->
+          when Sym.equal x x' && not (Sym.Set.mem x (T.free_vars it')) ->
           (* it' <= x, i.e., x >= it' -> min_inc = it' *)
           Some (of_min_inc it')
         | _ -> None
@@ -56,7 +57,7 @@ module Make (AD : Domain.T) = struct
 
       (* Helper to cast pointer to integer for arithmetic *)
       let to_numeric it =
-        match IT.get_bt it with
+        match T.get_bt it with
         | BT.Loc () -> IT.addr_ it (Locations.other __LOC__)
         | _ -> it
 
@@ -143,7 +144,7 @@ module Make (AD : Domain.T) = struct
       | `Asgn (_, _, gt_rest) -> collect_and_extract_constraints vars x gt_rest
       | `LetStar (_, gt_rest) -> collect_and_extract_constraints vars x gt_rest
       | `Assert (T it, gt_rest)
-        when Sym.Set.subset (Sym.Set.remove x (IT.free_vars it)) vars ->
+        when Sym.Set.subset (Sym.Set.remove x (T.free_vars it)) vars ->
         let rep = collect_and_extract_constraints vars x gt_rest in
         (match Rep.of_it x it with
          | Some rep' ->

--- a/lib/testGeneration/bennet/stage4/term.ml
+++ b/lib/testGeneration/bennet/stage4/term.ml
@@ -16,8 +16,7 @@ module Make (AD : Domain.T) = struct
       type 'recur ast =
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
-        | `ArbitrarySpecialized of
-            (T.t option * T.t option) * (T.t option * T.t option)
+        | `ArbitrarySpecialized of (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t
         | `Call of Sym.t * T.t list

--- a/lib/testGeneration/bennet/stage4/term.ml
+++ b/lib/testGeneration/bennet/stage4/term.ml
@@ -1,4 +1,5 @@
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module CF = Cerb_frontend
@@ -16,20 +17,20 @@ module Make (AD : Domain.T) = struct
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
         | `ArbitrarySpecialized of
-            (IT.t option * IT.t option) * (IT.t option * IT.t option)
+            (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t
-        | `Call of Sym.t * IT.t list
-          (** `Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `Asgn of (IT.t * Sctypes.t) * IT.t * 'recur annot
+        | `Call of Sym.t * T.t list
+          (** `Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `Asgn of (T.t * Sctypes.t) * T.t * 'recur annot
           (** Claim ownership and assign a value to a memory location *)
         | `LetStar of (Sym.t * 'recur annot) * 'recur annot (** Backtrack point *)
-        | `Return of IT.t (** Monadic return *)
+        | `Return of T.t (** Monadic return *)
         | `Assert of LC.t * 'recur annot
           (** `Assert some [LC.t] are true, backtracking otherwise *)
         | `AssertDomain of AD.t * 'recur annot
-        | `ITE of IT.t * 'recur annot * 'recur annot (** If-then-else *)
-        | `Map of (Sym.t * BT.t * IT.t) * 'recur annot
+        | `ITE of T.t * 'recur annot * 'recur annot (** If-then-else *)
+        | `Map of (Sym.t * BT.t * T.t) * 'recur annot
         | `Pick of 'recur annot list
         ]
       [@@deriving eq, ord]
@@ -64,7 +65,7 @@ module Make (AD : Domain.T) = struct
 
 
       let arbitrary_specialized_
-            ((mins, maxs) : (IT.t option * IT.t option) * (IT.t option * IT.t option))
+            ((mins, maxs) : (T.t option * T.t option) * (T.t option * T.t option))
             (tag : tag_t)
             (bt : BT.t)
             (loc : Locations.t)
@@ -73,12 +74,12 @@ module Make (AD : Domain.T) = struct
         Annot (`ArbitrarySpecialized (mins, maxs), tag, bt, loc)
 
 
-      let call_ ((fsym, its) : Sym.t * IT.t list) (tag : tag_t) (bt : BT.t) loc : t =
+      let call_ ((fsym, its) : Sym.t * T.t list) (tag : tag_t) (bt : BT.t) loc : t =
         Annot (`Call (fsym, its), tag, bt, loc)
 
 
       let asgn_
-            (((it_addr, ct), it_val, gt') : (IT.t * Sctypes.t) * IT.t * t)
+            (((it_addr, ct), it_val, gt') : (T.t * Sctypes.t) * T.t * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -92,8 +93,8 @@ module Make (AD : Domain.T) = struct
         Annot (`LetStar ((x, gt1), gt2), tag, basetype gt2, loc)
 
 
-      let return_ (it : IT.t) (tag : tag_t) (loc : Locations.t) : t =
-        Annot (`Return it, tag, IT.get_bt it, loc)
+      let return_ (it : T.t) (tag : tag_t) (loc : Locations.t) : t =
+        Annot (`Return it, tag, T.get_bt it, loc)
 
 
       let assert_ ((lc, gt') : LC.t * t) (tag : tag_t) (loc : Locations.t) : t =
@@ -104,14 +105,14 @@ module Make (AD : Domain.T) = struct
         Annot (`AssertDomain (ad, gt'), tag, basetype gt', loc)
 
 
-      let ite_ ((it_if, gt_then, gt_else) : IT.t * t * t) (tag : tag_t) loc : t =
+      let ite_ ((it_if, gt_then, gt_else) : T.t * t * t) (tag : tag_t) loc : t =
         let bt = basetype gt_then in
         assert (BT.equal bt (basetype gt_else));
         Annot (`ITE (it_if, gt_then, gt_else), tag, bt, loc)
 
 
       let map_
-            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * IT.t) * t)
+            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * T.t) * t)
             (tag : tag_t)
             loc
         : t

--- a/lib/testGeneration/bennet/stage5/convert.ml
+++ b/lib/testGeneration/bennet/stage5/convert.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module StringMap = Map.Make (String)
@@ -90,7 +91,7 @@ module Make (AD : Domain.T) = struct
       let (Annot (gr_, (), bt, loc)) = gr in
       match gr_ with
       | `ITE (cond, t, f) ->
-        let path_vars = Sym.Set.union path_vars (IT.free_vars cond) in
+        let path_vars = Sym.Set.union path_vars (T.free_vars cond) in
         GenTerms.Annot (`ITE (cond, aux path_vars t, aux path_vars f), (), bt, loc)
       | `Pick gts ->
         GenTerms.Annot

--- a/lib/testGeneration/bennet/stage5/liftCallArgs.ml
+++ b/lib/testGeneration/bennet/stage5/liftCallArgs.ml
@@ -21,8 +21,7 @@ module Make (AD : Domain.T) = struct
   module Def = Def.Make (AD)
   module Term = Term.Make (AD)
 
-  let lift_iargs (iargs : T.t list) (loc : Locations.t) : (Sym.t * T.t) list * T.t list
-    =
+  let lift_iargs (iargs : T.t list) (loc : Locations.t) : (Sym.t * T.t) list * T.t list =
     let lets, iargs' =
       iargs
       |> List.map (fun it ->

--- a/lib/testGeneration/bennet/stage5/liftCallArgs.ml
+++ b/lib/testGeneration/bennet/stage5/liftCallArgs.ml
@@ -1,3 +1,4 @@
+module T = Terms.Normal
 module IT = IndexTerms
 
 (** Lift compound call arguments into pure bindings:
@@ -20,22 +21,22 @@ module Make (AD : Domain.T) = struct
   module Def = Def.Make (AD)
   module Term = Term.Make (AD)
 
-  let lift_iargs (iargs : IT.t list) (loc : Locations.t) : (Sym.t * IT.t) list * IT.t list
+  let lift_iargs (iargs : T.t list) (loc : Locations.t) : (Sym.t * T.t) list * T.t list
     =
     let lets, iargs' =
       iargs
       |> List.map (fun it ->
-        match IT.is_sym it with
+        match Terms.is_sym it with
         | Some _ -> (None, it)
         | None ->
           let t = Sym.fresh_anon () in
-          (Some (t, it), IT.sym_ (t, IT.get_bt it, loc)))
+          (Some (t, it), IT.sym_ (t, T.get_bt it, loc)))
       |> List.split
     in
     (List.filter_map (fun x -> x) lets, iargs')
 
 
-  let wrap_lets (lets : (Sym.t * IT.t) list) (gt : Term.t) (loc : Locations.t) : Term.t =
+  let wrap_lets (lets : (Sym.t * T.t) list) (gt : Term.t) (loc : Locations.t) : Term.t =
     List.fold_right
       (fun (t, it) gt' -> Term.let_star_ ((t, Term.return_ it () loc), gt') () loc)
       lets

--- a/lib/testGeneration/bennet/stage5/term.ml
+++ b/lib/testGeneration/bennet/stage5/term.ml
@@ -17,8 +17,7 @@ module Make (AD : Domain.T) = struct
       type 'recur ast =
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
-        | `ArbitrarySpecialized of
-            (T.t option * T.t option) * (T.t option * T.t option)
+        | `ArbitrarySpecialized of (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t (** Generate arbitrary values from domain *)
         | `PickSized of (Z.t * 'recur annot) list

--- a/lib/testGeneration/bennet/stage5/term.ml
+++ b/lib/testGeneration/bennet/stage5/term.ml
@@ -1,7 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module LC = LogicalConstraints
 module StringMap = Map.Make (String)
 
@@ -18,24 +18,24 @@ module Make (AD : Domain.T) = struct
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
         | `ArbitrarySpecialized of
-            (IT.t option * IT.t option) * (IT.t option * IT.t option)
+            (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t (** Generate arbitrary values from domain *)
         | `PickSized of (Z.t * 'recur annot) list
           (** Pick among a list of options, weighted by the provided [Z.t]s *)
-        | `Call of Sym.t * IT.t list
-          (** Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `CallSized of Sym.t * IT.t list * (int * Sym.t)
-          (** Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `Asgn of (IT.t * Sctypes.t) * IT.t * 'recur annot
+        | `Call of Sym.t * T.t list
+          (** Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `CallSized of Sym.t * T.t list * (int * Sym.t)
+          (** Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `Asgn of (T.t * Sctypes.t) * T.t * 'recur annot
           (** Claim ownership and assign a value to a memory location *)
         | `LetStar of (Sym.t * 'recur annot) * 'recur annot (** Backtrack point *)
-        | `Return of IT.t (** Monadic return *)
+        | `Return of T.t (** Monadic return *)
         | `Assert of LC.t * 'recur annot
           (** Assert some [LC.t] are true, backtracking otherwise *)
         | `AssertDomain of AD.t * 'recur annot (** Assert domain constraints *)
-        | `ITE of IT.t * 'recur annot * 'recur annot (** If-then-else *)
-        | `Map of (Sym.t * BT.t * IT.t) * 'recur annot
+        | `ITE of T.t * 'recur annot * 'recur annot (** If-then-else *)
+        | `Map of (Sym.t * BT.t * T.t) * 'recur annot
         | `SplitSize of Sym.Set.t * 'recur annot
         ]
       [@@deriving eq, ord]
@@ -61,7 +61,7 @@ module Make (AD : Domain.T) = struct
 
       let arbitrary_specialized_
             (((min_inc, min_ex), (max_inc, max_ex)) :
-              (IT.t option * IT.t option) * (IT.t option * IT.t option))
+              (T.t option * T.t option) * (T.t option * T.t option))
             (tag : tag_t)
             (bt : BT.t)
             (loc : Locations.t)
@@ -80,12 +80,12 @@ module Make (AD : Domain.T) = struct
         Annot (`ArbitraryDomain d, tag, bt, loc)
 
 
-      let call_ ((fsym, its) : Sym.t * IT.t list) (tag : tag_t) (bt : BT.t) loc : t =
+      let call_ ((fsym, its) : Sym.t * T.t list) (tag : tag_t) (bt : BT.t) loc : t =
         Annot (`Call (fsym, its), tag, bt, loc)
 
 
       let asgn_
-            (((it_addr, ct), it_val, gt') : (IT.t * Sctypes.t) * IT.t * t)
+            (((it_addr, ct), it_val, gt') : (T.t * Sctypes.t) * T.t * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -99,8 +99,8 @@ module Make (AD : Domain.T) = struct
         Annot (`LetStar ((x, gt1), gt2), tag, basetype gt2, loc)
 
 
-      let return_ (it : IT.t) (tag : tag_t) (loc : Locations.t) : t =
-        Annot (`Return it, tag, IT.get_bt it, loc)
+      let return_ (it : T.t) (tag : tag_t) (loc : Locations.t) : t =
+        Annot (`Return it, tag, T.get_bt it, loc)
 
 
       let assert_ ((lc, gt') : LC.t * t) (tag : tag_t) (loc : Locations.t) : t =
@@ -111,14 +111,14 @@ module Make (AD : Domain.T) = struct
         Annot (`AssertDomain (ad, gt'), tag, basetype gt', loc)
 
 
-      let ite_ ((it_if, gt_then, gt_else) : IT.t * t * t) (tag : tag_t) loc : t =
+      let ite_ ((it_if, gt_then, gt_else) : T.t * t * t) (tag : tag_t) loc : t =
         let bt = basetype gt_then in
         assert (BT.equal bt (basetype gt_else));
         Annot (`ITE (it_if, gt_then, gt_else), tag, bt, loc)
 
 
       let map_
-            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * IT.t) * t)
+            (((i, i_bt, it_perm), gt_inner) : (Sym.t * BT.t * T.t) * t)
             (tag : tag_t)
             loc
         : t
@@ -147,7 +147,7 @@ module Make (AD : Domain.T) = struct
 
 
       let call_sized_
-            ((fsym, its, sz) : Sym.t * IT.t list * (int * Sym.t))
+            ((fsym, its, sz) : Sym.t * T.t list * (int * Sym.t))
             (tag : tag_t)
             (bt : BT.t)
             (loc : Locations.t)

--- a/lib/testGeneration/bennet/stage6/convert.ml
+++ b/lib/testGeneration/bennet/stage6/convert.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module StringMap = Map.Make (String)
@@ -75,7 +76,7 @@ module Make (AD : Domain.T) = struct
         let gt_rest = aux vars path_vars gt_rest in
         GenTerms.Annot (`AssertDomain (ad, gt_rest), (path_vars, last_var), bt, loc)
       | `ITE (it_if, gt_then, gt_else) ->
-        let path_vars = Sym.Set.union path_vars (IT.free_vars it_if) in
+        let path_vars = Sym.Set.union path_vars (T.free_vars it_if) in
         let gt_then = aux vars path_vars gt_then in
         let gt_else = aux vars path_vars gt_else in
         Annot (`ITE (it_if, gt_then, gt_else), (path_vars, last_var), bt, loc)

--- a/lib/testGeneration/bennet/stage6/term.ml
+++ b/lib/testGeneration/bennet/stage6/term.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 module StringMap = Map.Make (String)
@@ -18,23 +19,23 @@ module Make (AD : Domain.T) = struct
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
         | `ArbitrarySpecialized of
-            (IT.t option * IT.t option) * (IT.t option * IT.t option)
+            (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t (** Generate arbitrary values from domain *)
         | `PickSizedElab of Sym.t * (Z.t * 'recur annot) list
           (** Pick among a list of options, weighted by the provided [Z.t]s *)
-        | `Call of Sym.t * IT.t list
-          (** Call a defined generator according to a [Sym.t] with arguments [IT.t list] *)
-        | `CallSized of Sym.t * IT.t list * (int * Sym.t)
-        | `AsgnElab of Sym.t * (((Sym.t * BT.t) * IT.t) * Sctypes.t) * IT.t * 'recur annot
+        | `Call of Sym.t * T.t list
+          (** Call a defined generator according to a [Sym.t] with arguments [T.t list] *)
+        | `CallSized of Sym.t * T.t list * (int * Sym.t)
+        | `AsgnElab of Sym.t * (((Sym.t * BT.t) * T.t) * Sctypes.t) * T.t * 'recur annot
           (** Claim ownership and assign a value to a memory location *)
         | `LetStar of (Sym.t * 'recur annot) * 'recur annot (** Backtrack point *)
-        | `Return of IT.t (** Monadic return *)
+        | `Return of T.t (** Monadic return *)
         | `Assert of LC.t * 'recur annot
           (** Assert some [LC.t] are true, backtracking otherwise *)
         | `AssertDomain of AD.t * 'recur annot (** Assert domain constraints *)
-        | `ITE of IT.t * 'recur annot * 'recur annot (** If-then-else *)
-        | `MapElab of (Sym.t * BT.t * (IT.t * IT.t) * IT.t) * 'recur annot
+        | `ITE of T.t * 'recur annot * 'recur annot (** If-then-else *)
+        | `MapElab of (Sym.t * BT.t * (T.t * T.t) * T.t) * 'recur annot
         | `SplitSizeElab of Sym.t * Sym.Set.t * 'recur annot
         ]
       [@@deriving eq, ord]
@@ -60,7 +61,7 @@ module Make (AD : Domain.T) = struct
 
       let arbitrary_specialized_
             (((min_inc, min_ex), (max_inc, max_ex)) :
-              (IT.t option * IT.t option) * (IT.t option * IT.t option))
+              (T.t option * T.t option) * (T.t option * T.t option))
             (tag : tag_t)
             (bt : BT.t)
             (loc : Locations.t)
@@ -79,7 +80,7 @@ module Make (AD : Domain.T) = struct
         Annot (`ArbitraryDomain d, tag, bt, loc)
 
 
-      let call_ ((fsym, its) : Sym.t * IT.t list) (tag : tag_t) (bt : BT.t) loc : t =
+      let call_ ((fsym, its) : Sym.t * T.t list) (tag : tag_t) (bt : BT.t) loc : t =
         Annot (`Call (fsym, its), tag, bt, loc)
 
 
@@ -89,8 +90,8 @@ module Make (AD : Domain.T) = struct
         Annot (`LetStar ((x, gt1), gt2), tag, basetype gt2, loc)
 
 
-      let return_ (it : IT.t) (tag : tag_t) (loc : Locations.t) : t =
-        Annot (`Return it, tag, IT.get_bt it, loc)
+      let return_ (it : T.t) (tag : tag_t) (loc : Locations.t) : t =
+        Annot (`Return it, tag, T.get_bt it, loc)
 
 
       let assert_ ((lc, gt') : LC.t * t) (tag : tag_t) (loc : Locations.t) : t =
@@ -101,7 +102,7 @@ module Make (AD : Domain.T) = struct
         Annot (`AssertDomain (ad, gt'), tag, basetype gt', loc)
 
 
-      let ite_ ((it_if, gt_then, gt_else) : IT.t * t * t) (tag : tag_t) loc : t =
+      let ite_ ((it_if, gt_then, gt_else) : T.t * t * t) (tag : tag_t) loc : t =
         let bt = basetype gt_then in
         assert (BT.equal bt (basetype gt_else));
         Annot (`ITE (it_if, gt_then, gt_else), tag, bt, loc)
@@ -128,7 +129,7 @@ module Make (AD : Domain.T) = struct
 
       let asgn_elab_
             ((backtrack_var, pointer_info, it_val, gt') :
-              Sym.t * (((Sym.t * BT.t) * IT.t) * Sctypes.t) * IT.t * t)
+              Sym.t * (((Sym.t * BT.t) * T.t) * Sctypes.t) * T.t * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -148,7 +149,7 @@ module Make (AD : Domain.T) = struct
 
       let map_elab_
             (((i, i_bt, (it_min, it_max), it_perm), gt_inner) :
-              (Sym.t * BT.t * (IT.t * IT.t) * IT.t) * t)
+              (Sym.t * BT.t * (T.t * T.t) * T.t) * t)
             (tag : tag_t)
             (loc : Locations.t)
         : t
@@ -161,7 +162,7 @@ module Make (AD : Domain.T) = struct
 
 
       let call_sized_
-            ((fsym, its, sz) : Sym.t * IT.t list * (int * Sym.t))
+            ((fsym, its, sz) : Sym.t * T.t list * (int * Sym.t))
             (tag : tag_t)
             (bt : BT.t)
             (loc : Locations.t)

--- a/lib/testGeneration/bennet/stage6/term.ml
+++ b/lib/testGeneration/bennet/stage6/term.ml
@@ -18,8 +18,7 @@ module Make (AD : Domain.T) = struct
       type 'recur ast =
         [ `Arbitrary (** Generate arbitrary values *)
         | `Symbolic (** Generate symbolic values *)
-        | `ArbitrarySpecialized of
-            (T.t option * T.t option) * (T.t option * T.t option)
+        | `ArbitrarySpecialized of (T.t option * T.t option) * (T.t option * T.t option)
           (** Generate arbitrary values: ((min_inc, min_ex), (max_inc, max_ex)) *)
         | `ArbitraryDomain of AD.Relative.t (** Generate arbitrary values from domain *)
         | `PickSizedElab of Sym.t * (Z.t * 'recur annot) list

--- a/lib/testGeneration/bennet/stage7/convert.ml
+++ b/lib/testGeneration/bennet/stage7/convert.ml
@@ -5,6 +5,7 @@ module CtA = Fulminate.Cn_to_ail
 module Utils = Fulminate.Utils
 module Records = Fulminate.Records
 module BT = BaseTypes
+module T = Terms.Normal
 module IT = IndexTerms
 module LC = LogicalConstraints
 
@@ -49,10 +50,10 @@ module Make (AD : Domain.T) = struct
         filename
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (name : Sym.t)
-        (it : IT.t)
+        (it : T.t)
     =
     let var = Sym.fresh_anon () in
-    let it_bt = IT.get_bt it in
+    let it_bt = T.get_bt it in
     let bs, ss, e =
       match it_bt with
       | BT.Unit ->
@@ -199,7 +200,7 @@ module Make (AD : Domain.T) = struct
         List.fold_left
           Sym.Set.union
           Sym.Set.empty
-          (List.filter_map (Option.map IT.free_vars) [ min_inc; min_ex; max_inc; max_ex ])
+          (List.filter_map (Option.map T.free_vars) [ min_inc; min_ex; max_inc; max_ex ])
       in
       ( [],
         [],
@@ -443,12 +444,12 @@ module Make (AD : Domain.T) = struct
                                     (pp_ctype C.no_qualifiers)
                                     (Sctypes.to_ctype sct))));
                         mk_expr
-                          (CtA.wrap_with_convert_from ~sct e_value_ (IT.get_bt it_val));
+                          (CtA.wrap_with_convert_from ~sct e_value_ (T.get_bt it_val));
                         mk_expr (AilEident last_var)
                       ]
                       @ List.map
                           (fun x -> mk_expr (AilEident x))
-                          (List.of_seq (Sym.Set.to_seq (IT.free_vars it_addr)))
+                          (List.of_seq (Sym.Set.to_seq (T.free_vars it_addr)))
                       @ [ mk_expr (AilEconst ConstantNull) ] )))
           ]
       in
@@ -512,7 +513,7 @@ module Make (AD : Domain.T) = struct
             Sym.Set.union
             Sym.Set.empty
             (List.filter_map
-               (Option.map IT.free_vars)
+               (Option.map T.free_vars)
                [ min_inc; min_ex; max_inc; max_ex ])
         in
         [ A.AilSexpr
@@ -613,7 +614,7 @@ module Make (AD : Domain.T) = struct
             Sym.Set.union
             Sym.Set.empty
             (List.filter_map
-               (Option.map IT.free_vars)
+               (Option.map T.free_vars)
                [ min_inc; min_ex; max_inc; max_ex ])
         in
         [ A.AilSexpr
@@ -715,7 +716,7 @@ module Make (AD : Domain.T) = struct
                      ]
                      @ List.map
                          (fun x -> mk_expr (AilEident x))
-                         (List.of_seq (Sym.Set.to_seq (IT.free_vars it)))
+                         (List.of_seq (Sym.Set.to_seq (T.free_vars it)))
                      @ [ mk_expr (AilEconst ConstantNull) ])))
           ]
       in
@@ -908,7 +909,7 @@ module Make (AD : Domain.T) = struct
                         @ List.map
                             (fun x -> mk_expr (AilEident x))
                             (List.of_seq
-                               (Sym.Set.to_seq (Sym.Set.remove i (IT.free_vars it_perm))))
+                               (Sym.Set.to_seq (Sym.Set.remove i (T.free_vars it_perm))))
                         @ [ mk_expr (AilEconst ConstantNull) ] )))
             ])
       in

--- a/lib/testGeneration/bennet/symbolic/concretize.ml
+++ b/lib/testGeneration/bennet/symbolic/concretize.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module C = CF.Ctype
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 module LC = LogicalConstraints
@@ -78,14 +79,14 @@ module Make (AD : Domain.T) = struct
       let convert_fn_doc =
         !^(Option.get (CtA.get_conversion_from_fn_str (Memory.bt_of_sct sct)))
       in
-      let subst_i_in_addr it = f (IT.subst (IT.make_subst [ (i_sym, it) ]) it_addr) in
+      let subst_i_in_addr it = f (T.subst (T.make_subst [ (i_sym, it) ]) it_addr) in
       let conditional_stmts =
         max_array_length
         |> Z.to_int
         |> List.range 0
         |> List.map (fun idx ->
           let idx_it = IT.num_lit_ (Z.of_int idx) i_bt here in
-          let guard_it = f (IT.subst (IT.make_subst [ (i_sym, idx_it) ]) it_perm) in
+          let guard_it = f (T.subst (T.make_subst [ (i_sym, idx_it) ]) it_perm) in
           let cond_doc =
             !^"convert_from_cn_bool"
             ^^ parens
@@ -311,7 +312,7 @@ module Make (AD : Domain.T) = struct
       let convert_fn_doc =
         !^(Option.get (CtA.get_conversion_from_fn_str (Memory.bt_of_sct sct)))
       in
-      let subst_i_in_addr it = f (IT.subst (IT.make_subst [ (i_sym, it) ]) it_addr) in
+      let subst_i_in_addr it = f (T.subst (T.make_subst [ (i_sym, it) ]) it_addr) in
       let map_init_stmt =
         !^"cn_term*" ^^^ map_var_doc ^^^ !^"=" ^^^ !^"cn_smt_default" ^^ parens result_ty
       in
@@ -319,7 +320,7 @@ module Make (AD : Domain.T) = struct
         elem_docs
         |> List.mapi (fun idx value_doc ->
           let idx_it = IT.num_lit_ (Z.of_int idx) i_bt here in
-          let guard_it = f (IT.subst (IT.make_subst [ (i_sym, idx_it) ]) it_perm) in
+          let guard_it = f (T.subst (T.make_subst [ (i_sym, idx_it) ]) it_perm) in
           let cond_doc =
             !^"convert_from_cn_bool"
             ^^ parens
@@ -389,8 +390,8 @@ module Make (AD : Domain.T) = struct
         |> List.range 0
         |> List.map (fun idx ->
           let idx_it = IT.num_lit_ (Z.of_int idx) i_bt here in
-          let guard_it = f (IT.subst (IT.make_subst [ (i_sym, idx_it) ]) it_perm) in
-          let subst_body = Term.subst (IT.make_subst [ (i_sym, idx_it) ]) body_term in
+          let guard_it = f (T.subst (T.make_subst [ (i_sym, idx_it) ]) it_perm) in
+          let subst_body = Term.subst (T.make_subst [ (i_sym, idx_it) ]) body_term in
           let body_result = concretize_term sigma subst_body in
           let elem_var = Pp.string (Printf.sprintf "%s_elem_%d" prefix idx) in
           let elem_stmt =

--- a/lib/testGeneration/bennet/symbolic/gather.ml
+++ b/lib/testGeneration/bennet/symbolic/gather.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module A = CF.AilSyntax
 module C = CF.Ctype
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 module LC = LogicalConstraints
@@ -63,7 +64,7 @@ module Make (AD : Domain.T) = struct
       in
       let f = Simplify.IndexTerms.simp (Simplify.default Global.empty) in
       let it_min, it_max = (f it_min, f it_max) in
-      let subst_i_in_addr it = f (IT.subst (IT.make_subst [ (i_sym, it) ]) it_addr) in
+      let subst_i_in_addr it = f (T.subst (T.make_subst [ (i_sym, it) ]) it_addr) in
       let start_addr_smt = Smt.convert_indexterm sigma (subst_i_in_addr it_min) in
       let end_addr_smt =
         let here = Locations.other __LOC__ in
@@ -202,7 +203,7 @@ module Make (AD : Domain.T) = struct
           elem_docs
       in
       (* Memory constraint *)
-      let subst_i_in_addr it = f (IT.subst (IT.make_subst [ (i_sym, it) ]) it_addr) in
+      let subst_i_in_addr it = f (T.subst (T.make_subst [ (i_sym, it) ]) it_addr) in
       let start_addr_smt = Smt.convert_indexterm sigma (subst_i_in_addr it_min) in
       let end_addr_smt =
         let here = Locations.other __LOC__ in
@@ -360,7 +361,7 @@ module Make (AD : Domain.T) = struct
         |> List.range 0
         |> List.map (fun idx ->
           let idx_it = f (IT.add_ (it_min, IT.num_lit_ (Z.of_int idx) i_bt here) here) in
-          let subst_body = Term.subst (IT.make_subst [ (i_sym, idx_it) ]) body_term in
+          let subst_body = Term.subst (T.make_subst [ (i_sym, idx_it) ]) body_term in
           let body_result = gather_term sigma subst_body in
           (idx_it, body_result))
       in

--- a/lib/testGeneration/bennet/symbolic/setup_.ml
+++ b/lib/testGeneration/bennet/symbolic/setup_.ml
@@ -893,7 +893,7 @@ module Make (AD : Domain.T) = struct
     let get_function_calls (fn_def : Definition.Function.t) : Sym.Set.t =
       match fn_def.Definition.Function.body with
       | Definition.Function.Def body | Definition.Function.Rec_Def body ->
-        IT.preds_of body
+        Terms.preds_of body
       | Definition.Function.Uninterp -> Sym.Set.empty
     in
     let module G = Graph.Persistent.Digraph.Concrete (Sym) in

--- a/lib/testGeneration/bennet/symbolic/smt.ml
+++ b/lib/testGeneration/bennet/symbolic/smt.ml
@@ -1,6 +1,7 @@
 module CF = Cerb_frontend
 module C = CF.Ctype
 module A = CF.AilSyntax
+module T = Terms.Normal
 module IT = IndexTerms
 module BT = BaseTypes
 module LC = LogicalConstraints
@@ -257,7 +258,7 @@ module Make (AD : Domain.T) = struct
 
 
   (** Compute free variables in an index term, excluding the given bound variables *)
-  let rec free_vars_it (bound : Sym.Set.t) (it : IT.t) : (Sym.t * BT.t) list =
+  let rec free_vars_it (bound : Sym.Set.t) (it : T.t) : (Sym.t * BT.t) list =
     let (IT (term, bt, _)) = it in
     match term with
     | Const _ -> []
@@ -342,7 +343,7 @@ module Make (AD : Domain.T) = struct
 
 
   (** Generate CN-SMT term creation code for IndexTerms.t *)
-  let rec convert_indexterm (sigma : CF.GenTypes.genTypeCategory A.sigma) (it : IT.t)
+  let rec convert_indexterm (sigma : CF.GenTypes.genTypeCategory A.sigma) (it : T.t)
     : Pp.document
     =
     let (IT (term, bt, loc)) = it in
@@ -384,10 +385,10 @@ module Make (AD : Domain.T) = struct
       let expanded =
         match
           ( Builtins.apply_builtin_fun_defs func_sym args loc,
-            Builtins.apply_builtin_funs func_sym (List.map IT.Surface.inj args) loc )
+            Builtins.apply_builtin_funs func_sym (List.map Terms.Surface.inj args) loc )
         with
         | Some it, _ -> Some it
-        | None, Ok (Some it_surface) -> Some (IT.Surface.proj it_surface)
+        | None, Ok (Some it_surface) -> Some (Terms.Surface.proj it_surface)
         | _ -> None
       in
       (match expanded with
@@ -400,7 +401,7 @@ module Make (AD : Domain.T) = struct
     | CN_Some term -> convert_cn_some sigma term
     | Good _ | Representable _ ->
       Pp.string "cn_smt_bool(true)" (* FIXME: Fulminate also doesn't enforce *)
-    | _ -> failwith ("TODO (" ^ Pp.plain (IT.pp it) ^ ") @ " ^ __LOC__)
+    | _ -> failwith ("TODO (" ^ Pp.plain (T.pp it) ^ ") @ " ^ __LOC__)
 
 
   and convert_const (c : Terms.const) : Pp.document =
@@ -463,7 +464,7 @@ module Make (AD : Domain.T) = struct
   and convert_unop
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (op : Terms.unop)
-        (t : IT.t)
+        (t : T.t)
     : Pp.document
     =
     let open Pp in
@@ -481,8 +482,8 @@ module Make (AD : Domain.T) = struct
   and convert_binop
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (op : Terms.binop)
-        (t1 : IT.t)
-        (t2 : IT.t)
+        (t1 : T.t)
+        (t2 : T.t)
     : Pp.document
     =
     let open Pp in
@@ -524,9 +525,9 @@ module Make (AD : Domain.T) = struct
 
   and convert_ite
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (cond : IT.t)
-        (then_term : IT.t)
-        (else_term : IT.t)
+        (cond : T.t)
+        (then_term : T.t)
+        (else_term : T.t)
     : Pp.document
     =
     let cond_smt = convert_indexterm sigma cond in
@@ -541,7 +542,7 @@ module Make (AD : Domain.T) = struct
         (var_sym : Sym.t)
         (var_bt : BT.t)
         (end_i : int)
-        (body : IT.t)
+        (body : T.t)
     : Pp.document
     =
     let body_smt = convert_indexterm sigma body in
@@ -561,7 +562,7 @@ module Make (AD : Domain.T) = struct
             ^^^ body_smt))
 
 
-  and convert_tuple (sigma : CF.GenTypes.genTypeCategory A.sigma) (terms : IT.t list)
+  and convert_tuple (sigma : CF.GenTypes.genTypeCategory A.sigma) (terms : T.t list)
     : Pp.document
     =
     let terms_smt = List.map (convert_indexterm sigma) terms in
@@ -574,7 +575,7 @@ module Make (AD : Domain.T) = struct
   and convert_nthtuple
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (n : int)
-        (tuple_term : IT.t)
+        (tuple_term : T.t)
     : Pp.document
     =
     let tuple_smt = convert_indexterm sigma tuple_term in
@@ -584,7 +585,7 @@ module Make (AD : Domain.T) = struct
   and convert_struct
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (tag : Sym.t)
-        (members : (Id.t * IT.t) list)
+        (members : (Id.t * T.t) list)
     : Pp.document
     =
     let open Pp in
@@ -619,7 +620,7 @@ module Make (AD : Domain.T) = struct
 
   and convert_structmember
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (struct_term : IT.t)
+        (struct_term : T.t)
         (member : Id.t)
         (bt : BT.t)
     : Pp.document
@@ -633,9 +634,9 @@ module Make (AD : Domain.T) = struct
 
   and convert_structupdate
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (struct_term : IT.t)
+        (struct_term : T.t)
         (member : Id.t)
-        (value : IT.t)
+        (value : T.t)
     : Pp.document
     =
     let open Pp in
@@ -647,7 +648,7 @@ module Make (AD : Domain.T) = struct
 
   and convert_record
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (members : (Id.t * IT.t) list)
+        (members : (Id.t * T.t) list)
     : Pp.document
     =
     let open Pp in
@@ -669,7 +670,7 @@ module Make (AD : Domain.T) = struct
 
   and convert_recordmember
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (record_term : IT.t)
+        (record_term : T.t)
         (member : Id.t)
     : Pp.document
     =
@@ -680,9 +681,9 @@ module Make (AD : Domain.T) = struct
 
   and convert_recordupdate
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (record_term : IT.t)
+        (record_term : T.t)
         (member : Id.t)
-        (value : IT.t)
+        (value : T.t)
     : Pp.document
     =
     let record_smt = convert_indexterm sigma record_term in
@@ -696,7 +697,7 @@ module Make (AD : Domain.T) = struct
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (bt : BT.t)
         (constr : Sym.t)
-        (args : (Id.t * IT.t) list)
+        (args : (Id.t * T.t) list)
     : Pp.document
     =
     let constr_name = Sym.pp constr in
@@ -743,7 +744,7 @@ module Make (AD : Domain.T) = struct
 
   and convert_membershift
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (term : IT.t)
+        (term : T.t)
         (tag : Sym.t)
         (member : Id.t)
     : Pp.document
@@ -760,9 +761,9 @@ module Make (AD : Domain.T) = struct
 
   and convert_arrayshift
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (base : IT.t)
+        (base : T.t)
         (ct : Sctypes.t)
-        (index : IT.t)
+        (index : T.t)
     : Pp.document
     =
     let base_smt = convert_indexterm sigma base in
@@ -782,8 +783,8 @@ module Make (AD : Domain.T) = struct
 
   and convert_copyallocid
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (addr : IT.t)
-        (loc : IT.t)
+        (addr : T.t)
+        (loc : T.t)
     : Pp.document
     =
     let addr_smt = convert_indexterm sigma addr in
@@ -791,7 +792,7 @@ module Make (AD : Domain.T) = struct
     Pp.(!^"cn_smt_copy_alloc_id" ^^ parens (addr_smt ^^ comma ^^^ loc_smt))
 
 
-  and convert_hasallocid (sigma : CF.GenTypes.genTypeCategory A.sigma) (loc : IT.t)
+  and convert_hasallocid (sigma : CF.GenTypes.genTypeCategory A.sigma) (loc : T.t)
     : Pp.document
     =
     let loc_smt = convert_indexterm sigma loc in
@@ -834,8 +835,8 @@ module Make (AD : Domain.T) = struct
 
   and convert_aligned
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (t : IT.t)
-        (align : IT.t)
+        (t : T.t)
+        (align : T.t)
     : Pp.document
     =
     let t_smt = convert_indexterm sigma t in
@@ -846,7 +847,7 @@ module Make (AD : Domain.T) = struct
   and convert_wrapi
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (int_type : Sctypes.IntegerTypes.t)
-        (term : IT.t)
+        (term : T.t)
     : Pp.document
     =
     let open Pp in
@@ -858,7 +859,7 @@ module Make (AD : Domain.T) = struct
   and convert_mapconst
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (base_type : BT.t)
-        (term : IT.t)
+        (term : T.t)
     : Pp.document
     =
     let open Pp in
@@ -869,9 +870,9 @@ module Make (AD : Domain.T) = struct
 
   and convert_mapset
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (map_term : IT.t)
-        (key_term : IT.t)
-        (value_term : IT.t)
+        (map_term : T.t)
+        (key_term : T.t)
+        (value_term : T.t)
     : Pp.document
     =
     let open Pp in
@@ -883,8 +884,8 @@ module Make (AD : Domain.T) = struct
 
   and convert_mapget
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (map_term : IT.t)
-        (key_term : IT.t)
+        (map_term : T.t)
+        (key_term : T.t)
     : Pp.document
     =
     let open Pp in
@@ -897,7 +898,7 @@ module Make (AD : Domain.T) = struct
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (var_sym : Sym.t)
         (var_bt : BT.t)
-        (body : IT.t)
+        (body : T.t)
     : Pp.document
     =
     let open Pp in
@@ -911,7 +912,7 @@ module Make (AD : Domain.T) = struct
   and convert_apply
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (func_sym : Sym.t)
-        (args : IT.t list)
+        (args : T.t list)
         (result_bt : BT.t)
     : Pp.document
     =
@@ -940,8 +941,8 @@ module Make (AD : Domain.T) = struct
   and convert_let
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (var_sym : Sym.t)
-        (binding : IT.t)
-        (body : IT.t)
+        (binding : T.t)
+        (body : T.t)
     : Pp.document
     =
     let open Pp in
@@ -984,8 +985,8 @@ module Make (AD : Domain.T) = struct
 
   and convert_match
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
-        (scrutinee : IT.t)
-        (cases : (BT.t Terms.pattern * IT.t) list)
+        (scrutinee : T.t)
+        (cases : (BT.t Terms.pattern * T.t) list)
     : Pp.document
     =
     let open Pp in
@@ -1004,11 +1005,11 @@ module Make (AD : Domain.T) = struct
     in
     (* Step 2.5: Collect free variable names from scrutinee and case bodies to avoid shadowing *)
     let free_var_names =
-      let scrutinee_fvs = IT.free_vars_bts scrutinee in
+      let scrutinee_fvs = T.free_vars_bts scrutinee in
       let body_fvs =
         List.fold_left
           (fun acc (_pat, body) ->
-             let body_free_vars = IT.free_vars_bts body in
+             let body_free_vars = T.free_vars_bts body in
              Sym.Map.union (fun _k v1 _v2 -> Some v1) acc body_free_vars)
           Sym.Map.empty
           cases
@@ -1087,7 +1088,7 @@ module Make (AD : Domain.T) = struct
            let renamed_body =
              Sym.Map.fold
                (fun old_sym new_sym acc_body ->
-                  IT.subst (IT.make_rename ~from:old_sym ~to_:new_sym) acc_body)
+                  T.subst (T.make_rename ~from:old_sym ~to_:new_sym) acc_body)
                renaming_map
                body
            in
@@ -1210,7 +1211,7 @@ module Make (AD : Domain.T) = struct
   and convert_cast
         (sigma : CF.GenTypes.genTypeCategory A.sigma)
         (target_bt : BT.t)
-        (term : IT.t)
+        (term : T.t)
     : Pp.document
     =
     let open Pp in
@@ -1225,7 +1226,7 @@ module Make (AD : Domain.T) = struct
     !^"cn_smt_none" ^^ parens bt_smt
 
 
-  and convert_cn_some (sigma : CF.GenTypes.genTypeCategory A.sigma) (term : IT.t)
+  and convert_cn_some (sigma : CF.GenTypes.genTypeCategory A.sigma) (term : T.t)
     : Pp.document
     =
     let open Pp in

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -1,4 +1,3 @@
-module IT = IndexTerms
 module CF = Cerb_frontend
 module Res = Resource
 module LC = LogicalConstraints
@@ -109,21 +108,21 @@ type message =
         model : Solver.model_with_q
       }
   | Illtyped_binary_it of
-      { left : IT.Surface.t;
-        right : IT.Surface.t;
+      { left : Terms.Surface.t;
+        right : Terms.Surface.t;
         binop : CF.Cn.cn_binop
       }
-  | TooBigExponent : { it : IT.t } -> message
-  | NegativeExponent : { it : IT.t } -> message
+  | TooBigExponent : { it : Terms.Normal.t } -> message
+  | NegativeExponent : { it : Terms.Normal.t } -> message
   | Write_value_unrepresentable of
       { ct : Sctypes.t;
-        location : IT.t;
-        value : IT.t;
+        location : Terms.Normal.t;
+        value : Terms.Normal.t;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
   | Int_unrepresentable of
-      { value : IT.t;
+      { value : Terms.Normal.t;
         ict : Sctypes.t;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
@@ -141,14 +140,14 @@ type message =
         model : Solver.model_with_q
       }
   | Needs_alloc_id of
-      { ptr : IT.t;
+      { ptr : Terms.Normal.t;
         ub : CF.Undefined.undefined_behaviour;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
   | Alloc_out_of_bounds of
-      { term : IT.t;
-        constr : IT.t;
+      { term : Terms.Normal.t;
+        constr : Terms.Normal.t;
         ub : CF.Undefined.undefined_behaviour;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
@@ -156,9 +155,9 @@ type message =
   | Allocation_not_live of
       { reason :
           [ `Copy_alloc_id | `Ptr_cmp | `Ptr_diff | `ISO_array_shift | `ISO_member_shift ];
-        ptr : IT.t;
+        ptr : Terms.Normal.t;
         ctxt : Context.t * Explain.log;
-        model_constr : (Solver.model_with_q * IT.t) option
+        model_constr : (Solver.model_with_q * Terms.Normal.t) option
       }
   (* | Implementation_defined_behaviour of document * state_report *)
   | Unspecified of CF.Ctype.ctype
@@ -218,13 +217,13 @@ let pp_illtyped_binary_it ~left ~right binop =
   in
   let descr =
     Some
-      (squotes (IT.pp left)
+      (squotes (Terms.pp left)
        ^^^ !^"has type"
-       ^^^ squotes (BaseTypes.Surface.pp (IT.get_bt left))
+       ^^^ squotes (BaseTypes.Surface.pp (Terms.get_bt left))
        ^^ comma
-       ^^^ squotes (IT.pp right)
+       ^^^ squotes (Terms.pp right)
        ^^^ !^"has type"
-       ^^^ squotes (BaseTypes.Surface.pp (IT.get_bt right))
+       ^^^ squotes (BaseTypes.Surface.pp (Terms.get_bt right))
        ^^ dot)
   in
   { short; descr; state = None }
@@ -320,7 +319,7 @@ let pp_welltyped = function
     in
     { short; descr = Some descr; state = None }
   | NIA { it; hint } ->
-    let it = IT.pp it in
+    let it = Terms.pp it in
     let short = !^"Non-linear integer arithmetic." in
     let descr =
       !^"Illtyped expression"
@@ -364,7 +363,7 @@ let pp_builtins : Builtins.message -> _ = function
 (* | Array_to_list arr -> *)
 (*   let short = *)
 (*     !^"array_to_list first arguments" *)
-(*     ^^^ squotes (IT.pp arr) *)
+(*     ^^^ squotes (Terms.pp arr) *)
 (*     ^^^ !^"expects type map/array, but has type" *)
 (*     ^^^ BaseTypes.Surface.pp (IT.get_bt arr) *)
 (*   in *)
@@ -437,7 +436,7 @@ let pp_compile : Compile.message -> _ = function
     { short; descr = None; state = None }
   | No_pointee_ctype it ->
     let short =
-      !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (IndexTerms.pp it) ^^ Pp.dot
+      !^"Cannot tell pointee C-type of" ^^^ Pp.squotes (Terms.pp it) ^^ Pp.dot
     in
     { short; descr = None; state = None }
   | Each_quantifier_not_numeric (sym, sbt) ->
@@ -485,7 +484,7 @@ let pp_message = function
     let state = Explain.trace ctxt model Explain.no_ex in
     { short; descr = None; state = Some state }
   | TooBigExponent { it } ->
-    let it = IT.pp it in
+    let it = Terms.pp it in
     let short = !^"Exponent too big" in
     let descr =
       !^"Illtyped expression"
@@ -498,7 +497,7 @@ let pp_message = function
     in
     { short; descr = Some descr; state = None }
   | NegativeExponent { it } ->
-    let it = IT.pp it in
+    let it = Terms.pp it in
     let short = !^"Negative exponent" in
     let descr =
       !^"Illtyped expression"
@@ -512,8 +511,8 @@ let pp_message = function
     { short; descr = Some descr; state = None }
   | Write_value_unrepresentable { ct; location; value; ctxt; model } ->
     let short = !^"Write value not representable at type" ^^^ Sctypes.pp ct in
-    let location = IT.pp location in
-    let value = IT.pp value in
+    let location = Terms.pp location in
+    let value = Terms.pp value in
     let state = Explain.trace ctxt model Explain.no_ex in
     let descr =
       !^"Location" ^^ colon ^^^ location ^^ comma ^^^ !^"value" ^^ colon ^^^ value ^^ dot
@@ -521,7 +520,7 @@ let pp_message = function
     { short; descr = Some descr; state = Some state }
   | Int_unrepresentable { value; ict; ctxt; model } ->
     let short = !^"integer value not representable at type" ^^^ Sctypes.pp ict in
-    let value = IT.pp value in
+    let value = Terms.pp value in
     let descr = !^"Value" ^^ colon ^^^ value in
     let state = Explain.trace ctxt model Explain.no_ex in
     { short; descr = Some descr; state = Some state }
@@ -553,7 +552,7 @@ let pp_message = function
     in
     { short; descr = Some descr; state = Some state }
   | Needs_alloc_id { ptr; ub; ctxt; model } ->
-    let short = !^"Pointer " ^^ bquotes (IT.pp ptr) ^^ !^" needs allocation ID" in
+    let short = !^"Pointer " ^^ bquotes (Terms.pp ptr) ^^ !^" needs allocation ID" in
     let state = Explain.trace ctxt model Explain.no_ex in
     let descr =
       match CF.Undefined.std_of_undefined_behaviour ub with
@@ -562,7 +561,7 @@ let pp_message = function
     in
     { short; descr = Some descr; state = Some state }
   | Alloc_out_of_bounds { constr; term; ub; ctxt; model } ->
-    let short = bquotes (IT.pp term) ^^ !^" out of bounds" in
+    let short = bquotes (Terms.pp term) ^^ !^" out of bounds" in
     let state =
       Explain.trace
         ctxt
@@ -577,9 +576,9 @@ let pp_message = function
     { short; descr = Some descr; state = Some state }
   | Allocation_not_live { reason; ptr; ctxt; model_constr } ->
     let adjust = function
-      | IT.IT (CopyAllocId { loc; _ }, _, _) -> loc
-      | IT.IT (ArrayShift { base; _ }, _, _) -> base
-      | IT.IT (MemberShift (ptr, _, _), _, _) -> ptr
+      | Terms.IT (CopyAllocId { loc; _ }, _, _) -> loc
+      | Terms.IT (ArrayShift { base; _ }, _, _) -> base
+      | Terms.IT (MemberShift (ptr, _, _), _, _) -> ptr
       | _ -> assert false
     in
     let reason, ptr =
@@ -591,7 +590,7 @@ let pp_message = function
       | `ISO_member_shift -> ("member shift", adjust ptr)
     in
     let short =
-      !^"Pointer " ^^ bquotes (IT.pp ptr) ^^^ !^"needs to be live for" ^^^ !^reason
+      !^"Pointer " ^^ bquotes (Terms.pp ptr) ^^^ !^"needs to be live for" ^^^ !^reason
     in
     let state =
       Option.map

--- a/lib/typeErrors.mli
+++ b/lib/typeErrors.mli
@@ -52,21 +52,21 @@ type message =
         model : Solver.model_with_q
       }
   | Illtyped_binary_it of
-      { left : IndexTerms.Surface.t;
-        right : IndexTerms.Surface.t;
+      { left : Terms.Surface.t;
+        right : Terms.Surface.t;
         binop : Cerb_frontend.Cn.cn_binop
       }
-  | TooBigExponent : { it : IndexTerms.t } -> message
-  | NegativeExponent : { it : IndexTerms.t } -> message
+  | TooBigExponent : { it : Terms.Normal.t } -> message
+  | NegativeExponent : { it : Terms.Normal.t } -> message
   | Write_value_unrepresentable of
       { ct : Sctypes.t;
-        location : IndexTerms.t;
-        value : IndexTerms.t;
+        location : Terms.Normal.t;
+        value : Terms.Normal.t;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
   | Int_unrepresentable of
-      { value : IndexTerms.t;
+      { value : Terms.Normal.t;
         ict : Sctypes.t;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
@@ -84,14 +84,14 @@ type message =
         model : Solver.model_with_q
       }
   | Needs_alloc_id of
-      { ptr : IndexTerms.t;
+      { ptr : Terms.Normal.t;
         ub : Cerb_frontend.Undefined.undefined_behaviour;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
       }
   | Alloc_out_of_bounds of
-      { term : IndexTerms.t;
-        constr : IndexTerms.t;
+      { term : Terms.Normal.t;
+        constr : Terms.Normal.t;
         ub : Cerb_frontend.Undefined.undefined_behaviour;
         ctxt : Context.t * Explain.log;
         model : Solver.model_with_q
@@ -99,9 +99,9 @@ type message =
   | Allocation_not_live of
       { reason :
           [ `Copy_alloc_id | `ISO_array_shift | `ISO_member_shift | `Ptr_cmp | `Ptr_diff ];
-        ptr : IndexTerms.t;
+        ptr : Terms.Normal.t;
         ctxt : Context.t * Explain.log;
-        model_constr : (Solver.model_with_q * IndexTerms.t) option
+        model_constr : (Solver.model_with_q * Terms.Normal.t) option
       }
   | Unspecified of Cerb_frontend.Ctype.ctype
   | StaticError of

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -11,8 +11,8 @@ type solver = Solver.solver
 type s =
   { typing_context : Context.t;
     solver : solver option;
-    sym_eqs : IT.t Sym.Map.t;
-    movable_indices : (Req.name * IT.t) list;
+    sym_eqs : Terms.Normal.t Sym.Map.t;
+    movable_indices : (Req.name * Terms.Normal.t) list;
     log : Explain.log
   }
 
@@ -435,7 +435,7 @@ let model () =
 
 
 let _model_has_prop () =
-  let is_some_true t = Option.is_some t && IT.is_true (Option.get t) in
+  let is_some_true t = Option.is_some t && Terms.is_true (Option.get t) in
   return (fun prop m -> is_some_true (Solver.eval (fst m) prop))
 
 
@@ -487,12 +487,12 @@ let bind_logical_return_internal loc prefix =
   let rec aux lrt =
     match lrt with
     | LogicalReturnTypes.Define ((s, it), _, lrt) ->
-      aux (LogicalReturnTypes.subst (IT.make_subst [ (s, it) ]) lrt)
+      aux (LogicalReturnTypes.subst (Terms.Normal.make_subst [ (s, it) ]) lrt)
     | Resource ((s, (re, bt)), _, lrt) ->
       let s' = Sym.fresh_make_uniq_kind ~prefix (Sym.pp_string s) in
       let@ () = add_l s' bt (loc, lazy (Sym.pp s')) in
       let@ () = add_r_internal loc (re, Res.O (IT.sym_ (s', bt, loc))) in
-      aux (LogicalReturnTypes.subst (IT.make_rename ~from:s ~to_:s') lrt)
+      aux (LogicalReturnTypes.subst (Terms.Normal.make_rename ~from:s ~to_:s') lrt)
     | Constraint (lc, _, lrt) ->
       let@ () = add_c_internal lc in
       aux lrt

--- a/lib/typing.mli
+++ b/lib/typing.mli
@@ -66,11 +66,11 @@ val remove_as : Sym.t list -> unit m
 
 val add_a : Sym.t -> BaseTypes.t -> Context.l_info -> unit m
 
-val add_a_value : Sym.t -> IndexTerms.t -> Context.l_info -> unit m
+val add_a_value : Sym.t -> Terms.Normal.t -> Context.l_info -> unit m
 
 val add_l : Sym.t -> BaseTypes.t -> Context.l_info -> unit m
 
-val add_l_value : Sym.t -> IndexTerms.t -> Context.l_info -> unit m
+val add_l_value : Sym.t -> Terms.Normal.t -> Context.l_info -> unit m
 
 val add_ls : (Sym.t * BaseTypes.t * Context.l_info) list -> unit m
 
@@ -177,10 +177,10 @@ val bind_logical_return : Locations.t -> string -> LogicalReturnTypes.t -> unit 
 val add_movable_index
   :  Locations.t ->
   (* verbose:bool -> *)
-  Request.name * IndexTerms.t ->
+  Request.name * Terms.Normal.t ->
   unit m
 
-val get_movable_indices : unit -> (Request.name * IndexTerms.t) list m
+val get_movable_indices : unit -> (Request.name * Terms.Normal.t) list m
 
 val record_action : Explain.action * Locations.t -> unit m
 

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -1,6 +1,6 @@
 module CF = Cerb_frontend
 module BT = BaseTypes
-module IT = IndexTerms
+module T = Terms.Normal
 module Loc = Locations
 module IdSet = Set.Make (Id)
 open Pp.Infix
@@ -49,7 +49,7 @@ type message =
   | Unexpected_computational_args_in_lemma
   | Missing_member of Id.t
   | NIA of
-      { it : IT.t;
+      { it : T.t;
         hint : string
       }
   | Empty_pattern
@@ -132,7 +132,7 @@ let illtyped_index_term (loc : Locations.t) it has ~expected ~reason =
       head ^ "\n" ^ pos
     | Either.Right reason -> reason
   in
-  { loc; msg = Illtyped_it { it = IT.pp it; has = BT.pp has; expected; reason } }
+  { loc; msg = Illtyped_it { it = T.pp it; has = BT.pp has; expected; reason } }
 
 
 let ensure_bits_type (loc : Loc.t) (has : BT.t) =
@@ -151,90 +151,90 @@ let ensure_z_fits_bits_type loc (sign, n) v =
 
 let ensure_integer_or_bits_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | Integer | Bits _ -> return ()
   | _ ->
     let expected = "integer or bitvector type" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
 
 let ensure_arith_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | Integer | Real | Bits _ -> return ()
   | _ ->
     let expected = "integer, real or bitvector type" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
 
 let ensure_set_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | Set _ -> return ()
   | _ ->
     let expected = "set" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
 
 let ensure_list_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | List bt -> return bt
   | _ ->
     let expected = "list" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
 
 let ensure_map_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | Map (abt, rbt) -> return (abt, rbt)
   | _ ->
     let expected = "map/array" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
 
 let ensure_option_type ~reason it =
   let open BT in
-  match IT.get_bt it with
+  match T.get_bt it with
   | Option bt -> return bt
   | _ ->
     let expected = "option" in
     fail
       (illtyped_index_term
-         (IT.get_loc it)
+         (T.get_loc it)
          it
-         (IT.get_bt it)
+         (T.get_bt it)
          ~expected
          ~reason:(Either.Left reason))
 
@@ -365,9 +365,9 @@ end
 
 type 'a m = 'a t
 
-module WIT = struct
+module WT = struct
   open BaseTypes
-  open IndexTerms
+  open Terms
 
   (* let rec check_and_bind_pattern loc bt pat =  *)
   (*   match pat with *)
@@ -507,37 +507,37 @@ module WIT = struct
       let@ def = get_logical_function_def loc name in
       return def.loc
     | IT ((MapSet (t, _, _) | Let (_, t)), _, _) -> get_location_for_type t
-    | IT (Cons (it, _), _, _) | it -> return @@ IT.get_loc it
+    | IT (Cons (it, _), _, _) | it -> return @@ T.get_loc it
 
 
   let binop_nia_checks it =
     match it with
     | IT (Binop (bop, t, t'), _, loc) ->
-      (match (bop, IT.get_bt t, is_const t, is_const t') with
+      (match (bop, T.get_bt t, is_const t, is_const t') with
        | Mul, Integer, None, None ->
          let msg =
            !^"Neither side of the integer multiplication"
-           ^^^ squotes (IT.pp it)
+           ^^^ squotes (T.pp it)
            ^^^ !^"is a constant."
          in
          (fail { loc; msg = Generic msg } [@alert "-deprecated"])
        | (Div | Rem | Mod | ShiftLeft | ShiftRight), Integer, _, None ->
          let op = match bop with ShiftLeft | ShiftRight -> "Shift" | _ -> "Division" in
          let msg =
-           !^op ^^^ squotes (IT.pp it) ^^^ !^"does not have constant right-hand argument."
+           !^op ^^^ squotes (T.pp it) ^^^ !^"does not have constant right-hand argument."
          in
          (fail { loc; msg = Generic msg } [@alert "-deprecated"])
        | (Div | Rem | Mod | ShiftLeft | ShiftRight), Integer, _, Some (Z z', _)
          when Z.leq z' Z.zero ->
          let op = match bop with ShiftLeft | ShiftRight -> "Shift" | _ -> "Division" in
          let msg =
-           !^op ^^^ squotes (IT.pp it) ^^^ !^"does not have positive right-hand argument."
+           !^op ^^^ squotes (T.pp it) ^^^ !^"does not have positive right-hand argument."
          in
          (fail { loc; msg = Generic msg } [@alert "-deprecated"])
        | Exp, (Integer | Bits _), None, _ | Exp, (Integer | Bits _), _, None ->
          let msg =
            !^"Exponentiation"
-           ^^^ squotes (IT.pp it)
+           ^^^ squotes (T.pp it)
            ^^^ !^"does not have constant left and right-hand arguments."
          in
          (fail { loc; msg = Generic msg } [@alert "-deprecated"])
@@ -548,9 +548,9 @@ module WIT = struct
   (* NOTE: This cannot _check_ what the root type of term is (the type is
      universally quantified) and so is not suitable for catching incorrect
      type annotations. *)
-  let rec infer : 'bt. 'bt annot -> IT.t m =
+  let rec infer : 'bt. 'bt annot -> T.t m =
     fun it ->
-    Pp.debug 22 (lazy (Pp.item "Welltyped.WIT.infer" (IT.pp it)));
+    Pp.debug 22 (lazy (Pp.item "Welltyped.WT.infer" (T.pp it)));
     let (IT (it, _, loc)) = it in
     let@ result =
       match it with
@@ -601,35 +601,35 @@ module WIT = struct
           | Negate ->
             let@ t = infer t in
             let@ () = ensure_arith_type ~reason:loc t in
-            return (t, IT.get_bt t)
+            return (t, T.get_bt t)
           | BW_CLZ_NoSMT | BW_CTZ_NoSMT | BW_FFS_NoSMT | BW_FLS_NoSMT | BW_Compl ->
             let@ t = infer t in
-            let@ () = ensure_bits_type (IT.get_loc t) (IT.get_bt t) in
-            return (t, IT.get_bt t)
+            let@ () = ensure_bits_type (T.get_loc t) (T.get_bt t) in
+            return (t, T.get_bt t)
         in
         return (IT (Unop (unop, t), ret_bt, loc))
       | Binop (SetMember, t, t') ->
         let@ t = infer t in
-        let@ t' = check loc (Set (IT.get_bt t)) t' in
+        let@ t' = check loc (Set (T.get_bt t)) t' in
         return (IT (Binop (SetMember, t, t'), BT.Bool, loc))
       | Binop (bop, t, t') ->
         let@ t = infer t in
-        let@ t' = check (IT.get_loc t) (IT.get_bt t) t' in
+        let@ t' = check (T.get_loc t) (T.get_bt t) t' in
         let arg_check, rbt =
           match bop with
           | Add | Sub | Mul | MulNoSMT | Div | DivNoSMT | Exp | ExpNoSMT | Min | Max ->
-            (ensure_arith_type ~reason:loc t, IT.get_bt t)
+            (ensure_arith_type ~reason:loc t, T.get_bt t)
           | Rem | RemNoSMT | Mod | ModNoSMT | ShiftLeft | ShiftRight ->
-            (ensure_integer_or_bits_type ~reason:loc t, IT.get_bt t)
-          | BW_And | BW_Or | BW_Xor -> (ensure_bits_type loc (IT.get_bt t), IT.get_bt t)
+            (ensure_integer_or_bits_type ~reason:loc t, T.get_bt t)
+          | BW_And | BW_Or | BW_Xor -> (ensure_bits_type loc (T.get_bt t), T.get_bt t)
           | LT | LE -> (ensure_arith_type ~reason:loc t, BT.Bool)
           | EQ -> (return (), BT.Bool)
           | LTPointer | LEPointer ->
-            (ensure_base_type loc ~expect:(Loc ()) (IT.get_bt t), BT.Bool)
+            (ensure_base_type loc ~expect:(Loc ()) (T.get_bt t), BT.Bool)
           | And | Or | Implies ->
-            (ensure_base_type loc ~expect:Bool (IT.get_bt t), BT.Bool)
+            (ensure_base_type loc ~expect:Bool (T.get_bt t), BT.Bool)
           | SetUnion | SetIntersection | SetDifference ->
-            (ensure_set_type ~reason:loc t, IT.get_bt t)
+            (ensure_set_type ~reason:loc t, T.get_bt t)
           | Subset -> (ensure_set_type ~reason:loc t, BT.Bool)
           | SetMember -> assert false
         in
@@ -640,8 +640,8 @@ module WIT = struct
       | ITE (t, t', t'') ->
         let@ t = check loc Bool t in
         let@ t' = infer t' in
-        let@ t'' = check (IT.get_loc t') (IT.get_bt t') t'' in
-        return (IT (ITE (t, t', t''), IT.get_bt t', loc))
+        let@ t'' = check (T.get_loc t') (T.get_bt t') t'' in
+        return (IT (ITE (t, t', t''), T.get_bt t', loc))
       | EachI ((i1, (s, bt), i2), t) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
         let@ bt = WBT.is_bt loc bt in
@@ -662,12 +662,12 @@ module WIT = struct
         return (IT (EachI ((i1, (s, bt), i2), t), BT.Bool, loc))
       | Tuple ts ->
         let@ ts = ListM.mapM infer ts in
-        let bts = List.map IT.get_bt ts in
+        let bts = List.map T.get_bt ts in
         return (IT (Tuple ts, BT.Tuple bts, loc))
       | NthTuple (n, t') ->
         let@ t' = infer t' in
         let@ item_bt =
-          match IT.get_bt t' with
+          match T.get_bt t' with
           | Tuple bts ->
             (match List.nth_opt bts n with
              | Some t -> return t
@@ -709,7 +709,7 @@ module WIT = struct
       | StructMember (t, member) ->
         let@ t = infer t in
         let@ tag =
-          match IT.get_bt t with
+          match T.get_bt t with
           | Struct tag -> return tag
           | has ->
             let expected = "struct" in
@@ -721,16 +721,16 @@ module WIT = struct
       | StructUpdate ((t, member), v) ->
         let@ t = infer t in
         let@ tag =
-          match IT.get_bt t with
+          match T.get_bt t with
           | Struct tag -> return tag
           | has ->
             (* this case should have been caught by compile.ml *)
             let expected = "struct" in
-            let reason = Either.Left (IT.get_loc t) in
+            let reason = Either.Left (T.get_loc t) in
             fail (illtyped_index_term loc t has ~expected ~reason)
         in
         let@ field_ct = get_struct_member_type loc tag member in
-        let@ v = check (IT.get_loc t) (Memory.bt_of_sct field_ct) v in
+        let@ v = check (T.get_loc t) (Memory.bt_of_sct field_ct) v in
         return (IT (StructUpdate ((t, member), v), BT.Struct tag, loc))
       | Record members ->
         assert (List.sorted_and_unique compare_by_fst_id members);
@@ -741,12 +741,12 @@ module WIT = struct
                return (id, t))
             members
         in
-        let member_types = List.map (fun (id, t) -> (id, IT.get_bt t)) members in
-        return (IT (IT.Record members, BT.Record member_types, loc))
+        let member_types = List.map (fun (id, t) -> (id, T.get_bt t)) members in
+        return (IT (Terms.Record members, BT.Record member_types, loc))
       | RecordMember (t, member) ->
         let@ t = infer t in
         let@ members =
-          match IT.get_bt t with
+          match T.get_bt t with
           | Record members -> return members
           | has ->
             let expected = "struct" in
@@ -759,13 +759,13 @@ module WIT = struct
           | None ->
             let expected = "struct with member " ^ Id.get_string member in
             let reason = Either.Left loc in
-            fail (illtyped_index_term loc t (IT.get_bt t) ~expected ~reason)
+            fail (illtyped_index_term loc t (T.get_bt t) ~expected ~reason)
         in
         return (IT (RecordMember (t, member), bt, loc))
       | RecordUpdate ((t, member), v) ->
         let@ t = infer t in
         let@ members =
-          match IT.get_bt t with
+          match T.get_bt t with
           | Record members -> return members
           | has ->
             let expected = "struct" in
@@ -778,13 +778,13 @@ module WIT = struct
           | None ->
             let expected = "struct with member " ^ Id.get_string member in
             let reason = Either.Left loc in
-            fail (illtyped_index_term loc t (IT.get_bt t) ~expected ~reason)
+            fail (illtyped_index_term loc t (T.get_bt t) ~expected ~reason)
         in
-        let@ v = check (IT.get_loc t) bt v in
-        return (IT (RecordUpdate ((t, member), v), IT.get_bt t, loc))
+        let@ v = check (T.get_loc t) bt v in
+        return (IT (RecordUpdate ((t, member), v), T.get_bt t, loc))
       | Cast (target_bt, t) ->
         let@ t = infer t in
-        let source_bt = IT.get_bt t in
+        let source_bt = T.get_bt t in
         let@ target_bt = WBT.is_bt loc target_bt in
         let cast_ok =
           match (source_bt, target_bt) with
@@ -830,10 +830,10 @@ module WIT = struct
         let@ index = infer index in
         let@ index =
           if !cnBV then
-            let@ () = ensure_bits_type loc (IT.get_bt index) in
-            return (cast_ Memory.uintptr_bt index loc)
+            let@ () = ensure_bits_type loc (T.get_bt index) in
+            return Terms.(IT (Cast (Memory.uintptr_bt, index), Memory.uintptr_bt, loc))
           else
-            let@ () = ensure_base_type loc ~expect:Integer (IT.get_bt index) in
+            let@ () = ensure_base_type loc ~expect:Integer (T.get_bt index) in
             return index
         in
         return (IT (ArrayShift { base; ct; index }, BT.Loc (), loc))
@@ -885,9 +885,9 @@ module WIT = struct
         let@ t = infer t in
         let@ () =
           if !cnBV then
-            ensure_bits_type loc (IT.get_bt t)
+            ensure_bits_type loc (T.get_bt t)
           else
-            ensure_base_type loc ~expect:Integer (IT.get_bt t)
+            ensure_base_type loc ~expect:Integer (T.get_bt t)
         in
         return (IT (WrapI (ity, t), Memory.bt_of_sct (Integer ity), loc))
       | Nil bt ->
@@ -895,8 +895,8 @@ module WIT = struct
         return (IT (Nil bt, BT.List bt, loc))
       | Cons (t1, t2) ->
         let@ t1 = infer t1 in
-        let t1_loc = IT.get_loc t1 in
-        let t1_bt = IT.get_bt t1 in
+        let t1_loc = T.get_loc t1 in
+        let t1_bt = T.get_bt t1 in
         (* This is all a little more complicated than ideal because we use the type of the
            first element of a list literal (currently always non-empty) is used to
            annotate the (Nil bt), and so _its_ location is the one which must be passed to
@@ -934,17 +934,17 @@ module WIT = struct
       | MapConst (index_bt, t) ->
         let@ index_bt = WBT.is_bt loc index_bt in
         let@ t = infer t in
-        return (IT (MapConst (index_bt, t), BT.Map (index_bt, IT.get_bt t), loc))
+        return (IT (MapConst (index_bt, t), BT.Map (index_bt, T.get_bt t), loc))
       | MapSet (t1, t2, t3) ->
         let@ t1 = infer t1 in
         let@ abt, rbt = ensure_map_type ~reason:loc t1 in
-        let@ t2 = check (IT.get_loc t1) abt t2 in
-        let@ t3 = check (IT.get_loc t1) rbt t3 in
-        return (IT (MapSet (t1, t2, t3), IT.get_bt t1, loc))
+        let@ t2 = check (T.get_loc t1) abt t2 in
+        let@ t3 = check (T.get_loc t1) rbt t3 in
+        return (IT (MapSet (t1, t2, t3), T.get_bt t1, loc))
       | MapGet (t, arg) ->
         let@ t = infer t in
         let@ abt, bt = ensure_map_type ~reason:loc t in
-        let@ arg = check (IT.get_loc t) abt arg in
+        let@ arg = check (T.get_loc t) abt arg in
         return (IT (MapGet (t, arg), bt, loc))
       | MapDef ((s, abt), body) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
@@ -952,7 +952,7 @@ module WIT = struct
         pure
           (let@ () = add_l s abt (loc, lazy (Pp.string "map-def-var")) in
            let@ body = infer body in
-           return (IT (MapDef ((s, abt), body), Map (abt, IT.get_bt body), loc)))
+           return (IT (MapDef ((s, abt), body), Map (abt, T.get_bt body), loc)))
       | Apply (name, args) ->
         let@ def = get_logical_function_def loc name in
         let has_args, expect_args = (List.length args, List.length def.args) in
@@ -969,10 +969,10 @@ module WIT = struct
       | Let ((name, t1), t2) ->
         let@ t1 = infer t1 in
         pure
-          (let@ () = add_l name (IT.get_bt t1) (loc, lazy (Pp.string "let-var")) in
-           (* let@ () = add_c loc (LC.T (IT.def_ name t1 loc)) in *)
+          (let@ () = add_l name (T.get_bt t1) (loc, lazy (Pp.string "let-var")) in
+           (* let@ () = add_c loc (LC.T (T.def_ name t1 loc)) in *)
            let@ t2 = infer t2 in
-           return (IT (Let ((name, t1), t2), IT.get_bt t2, loc)))
+           return (IT (Let ((name, t1), t2), T.get_bt t2, loc)))
       | Constructor (s, args) ->
         let@ info = get_datatype_constr loc s in
         let@ args_annotated = correct_members_sorted_annotated loc info.params args in
@@ -991,16 +991,16 @@ module WIT = struct
           ListM.fold_leftM
             (fun (rbt, acc) (pat, body) ->
                pure
-                 (let@ pat = check_and_bind_pattern (IT.get_bt e) pat in
+                 (let@ pat = check_and_bind_pattern (T.get_bt e) pat in
                   let@ body =
                     match rbt with None -> infer body | Some rbt -> check loc rbt body
                   in
-                  return (Some (IT.get_bt body), acc @ [ (pat, body) ])))
+                  return (Some (T.get_bt body), acc @ [ (pat, body) ])))
             (None, [])
             cases
         in
         let@ () =
-          cases_complete loc [ IT.get_bt e ] (List.map (fun (pat, _) -> [ pat ]) cases)
+          cases_complete loc [ T.get_bt e ] (List.map (fun (pat, _) -> [ pat ]) cases)
         in
         let@ () = cases_necessary (List.map (fun (pat, _) -> pat) cases) in
         let@ rbt =
@@ -1014,7 +1014,7 @@ module WIT = struct
         return (IT (CN_None bt, Option bt, loc))
       | CN_Some t ->
         let@ t = infer t in
-        let bt = IT.get_bt t in
+        let bt = T.get_bt t in
         return (IT (CN_Some t, Option bt, loc))
       | IsSome t ->
         let@ t = infer t in
@@ -1024,7 +1024,7 @@ module WIT = struct
         let@ bt = ensure_option_type ~reason:loc t in
         return (IT (GetOpt t, bt, loc))
     in
-    Pp.debug 22 (lazy (Pp.item "Welltyped.WIT.infer: inferred" (IT.pp_with_typ result)));
+    Pp.debug 22 (lazy (Pp.item "Welltyped.WT.infer: inferred" (T.pp_with_typ result)));
     return result
 
 
@@ -1032,12 +1032,12 @@ module WIT = struct
     let@ ls = WBT.is_bt expect_loc expect_ls in
     let@ it = infer it in
     let@ loc = get_location_for_type it in
-    if BT.equal ls (IT.get_bt it) then
+    if BT.equal ls (T.get_bt it) then
       return it
     else (
       let expected = Pp.plain @@ BT.pp ls in
       let reason = Either.Left expect_loc in
-      fail (illtyped_index_term loc it (IT.get_bt it) ~expected ~reason))
+      fail (illtyped_index_term loc it (T.get_bt it) ~expected ~reason))
 end
 
 let default_quantifier_bt =
@@ -1087,7 +1087,7 @@ module WReq = struct
     in
     match r with
     | P p ->
-      let@ pointer = WIT.check loc (BT.Loc ()) p.pointer in
+      let@ pointer = WT.check loc (BT.Loc ()) p.pointer in
       let has_iargs, expect_iargs = (List.length p.iargs, List.length spec_iargs) in
       (* +1 because of pointer argument *)
       let@ () =
@@ -1095,14 +1095,14 @@ module WReq = struct
       in
       let@ iargs =
         ListM.map2M
-          (fun (_, expected) arg -> WIT.check loc expected arg)
+          (fun (_, expected) arg -> WT.check loc expected arg)
           spec_iargs
           p.iargs
       in
       return (Req.P { name = p.name; pointer; iargs })
     | Q p ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-      let@ pointer = WIT.check loc (BT.Loc ()) p.pointer in
+      let@ pointer = WT.check loc (BT.Loc ()) p.pointer in
       let@ qbt = WBT.is_bt loc (snd p.q) in
       let@ () =
         if !cnBV then
@@ -1117,11 +1117,11 @@ module WReq = struct
       (* The location is not quite right here (should point to the
          array_shift<>() itself rather than the pointer) but it's good enough
          for now. *)
-      let@ () = err_if_ct_void (IT.get_loc p.pointer) `Array_shift p.step in
+      let@ () = err_if_ct_void (T.get_loc p.pointer) `Array_shift p.step in
       let@ permission, iargs =
         pure
           (let@ () = add_l (fst p.q) (snd p.q) (loc, lazy (Pp.string "forall-var")) in
-           let@ permission = WIT.check loc BT.Bool p.permission in
+           let@ permission = WT.check loc BT.Bool p.permission in
            let has_iargs, expect_iargs = (List.length p.iargs, List.length spec_iargs) in
            (* +1 because of pointer argument *)
            let@ () =
@@ -1133,7 +1133,7 @@ module WReq = struct
            in
            let@ iargs =
              ListM.map2M
-               (fun (_, expected) arg -> WIT.check loc expected arg)
+               (fun (_, expected) arg -> WT.check loc expected arg)
                spec_iargs
                p.iargs
            in
@@ -1180,14 +1180,14 @@ module WLC = struct
   let welltyped loc lc =
     match lc with
     | LC.T it ->
-      let@ it = WIT.check loc BT.Bool it in
+      let@ it = WT.check loc BT.Bool it in
       return (LC.T it)
     | LC.Forall ((s, bt), it) ->
       (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
       let@ bt = WBT.is_bt loc bt in
       pure
         (let@ () = add_l s bt (loc, lazy (Pp.string "forall-var")) in
-         let@ it = WIT.check loc BT.Bool it in
+         let@ it = WT.check loc BT.Bool it in
          return (LC.Forall ((s, bt), it)))
 end
 
@@ -1198,8 +1198,8 @@ module WLRT = struct
     let rec aux = function
       | LRT.Define ((s, it), ((loc, _) as info), lrt) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-        let@ it = WIT.infer it in
-        let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+        let@ it = WT.infer it in
+        let@ () = add_l s (T.get_bt it) (loc, lazy (Pp.string "let-var")) in
         let@ lrt = aux lrt in
         return (LRT.Define ((s, it), info, lrt))
       | Resource ((s, (re, re_oa_spec)), ((loc, _) as info), lrt) ->
@@ -1252,8 +1252,8 @@ module WLAT = struct
     let rec aux = function
       | LAT.Define ((s, it), info, at) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-        let@ it = WIT.infer it in
-        let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+        let@ it = WT.infer it in
+        let@ () = add_l s (T.get_bt it) (loc, lazy (Pp.string "let-var")) in
         let@ at = aux at in
         return (LAT.Define ((s, it), info, at))
       | LAT.Resource ((s, (re, re_oa_spec)), ((loc, _) as info), at) ->
@@ -1333,8 +1333,8 @@ module WLArgs = struct
     let rec aux = function
       | Mu.Define ((s, it), ((loc, _) as info), at) ->
         (* no need to alpha-rename, because context.ml ensures there's no name clashes *)
-        let@ it = WIT.infer it in
-        let@ () = add_l s (IT.get_bt it) (loc, lazy (Pp.string "let-var")) in
+        let@ it = WT.infer it in
+        let@ () = add_l s (T.get_bt it) (loc, lazy (Pp.string "let-var")) in
         let@ at = aux at in
         return (Mu.Define ((s, it), info, at))
       | Mu.Resource ((s, (re, re_oa_spec)), ((loc, _) as info), at) ->
@@ -2281,7 +2281,7 @@ module BaseTyping = struct
         | I_Good ct -> WCT.is_ct loc ct
         | I_Everything -> return ()
       in
-      let@ it = WIT.infer it in
+      let@ it = WT.infer it in
       return (Instantiate (to_instantiate, it))
     | Extract (attrs, to_extract, it) ->
       let@ () =
@@ -2295,12 +2295,12 @@ module BaseTyping = struct
           return ()
         | E_Everything -> return ()
       in
-      let@ it = WIT.infer it in
+      let@ it = WT.infer it in
       warn_when_not_quantifier_bt
         "focus"
-        (IT.get_loc it)
-        (IT.get_bt it)
-        (IndexTerms.pp it);
+        (T.get_loc it)
+        (T.get_bt it)
+        (T.pp it);
       return (Extract (attrs, to_extract, it))
     | Unfold (f, its) ->
       let@ def = get_logical_function_def loc f in
@@ -2315,7 +2315,7 @@ module BaseTyping = struct
           (List.length its)
           ~expect:(List.length def.args)
       in
-      let@ its = ListM.map2M (fun (_, bt) it -> WIT.check loc bt it) def.args its in
+      let@ its = ListM.map2M (fun (_, bt) it -> WT.check loc bt it) def.args its in
       return (Unfold (f, its))
     | Apply (l, its) ->
       let@ _lemma_loc, lemma_typ = get_lemma loc l in
@@ -2328,7 +2328,7 @@ module BaseTyping = struct
         let rec check_args lemma_typ its =
           match (lemma_typ, its) with
           | AT.Ghost ((_s, bt), _info, lemma_typ'), it :: its' ->
-            let@ it = WIT.check loc bt it in
+            let@ it = WT.check loc bt it in
             let@ its' = check_args lemma_typ' its' in
             return (it :: its')
           | AT.Computational _, _ -> failwith "unexpected computational argument in lemma"
@@ -2345,7 +2345,7 @@ module BaseTyping = struct
       let@ _ = ListM.mapM (get_fun_decl loc) fs in
       return (Inline fs)
     | Print it ->
-      let@ it = WIT.infer it in
+      let@ it = WT.infer it in
       return (Print it)
     | Split_case lc ->
       let@ lc = WLC.welltyped loc lc in
@@ -2357,7 +2357,7 @@ module BaseTyping = struct
     let rec aux = function
       | Let (loc, (s, { ct; pointer }), p') ->
         let@ () = WCT.is_ct loc ct in
-        let@ pointer = WIT.check loc (Loc ()) pointer in
+        let@ pointer = WT.check loc (Loc ()) pointer in
         let@ () = add_l s (Memory.bt_of_sct ct) (loc, lazy (Sym.pp s)) in
         let@ p' = aux p' in
         return (Let (loc, (s, { ct; pointer }), p'))
@@ -2523,7 +2523,7 @@ module BaseTyping = struct
           let arg_bt_specs = List.map (fun ct -> Memory.bt_of_sct ct) arg_cts in
           let@ pes = ListM.map2M check_pexpr arg_bt_specs pes in
           let its = match gargs_opt with None -> [] | Some (_, its) -> its in
-          let@ its = ListM.mapM (check_cnprog (fun _ it -> WIT.infer it)) its in
+          let@ its = ListM.mapM (check_cnprog (fun _ it -> WT.infer it)) its in
           let gargs_opt = Option.map (fun (ghost_loc, _) -> (ghost_loc, its)) gargs_opt in
           return (Memory.bt_of_sct ret_ct, Eccall (act, f_pe, pes, gargs_opt))
         | Eif (c_pe, e1, e2) ->
@@ -2728,12 +2728,12 @@ module WRPD = struct
            let@ clauses =
              ListM.fold_leftM
                (fun acc Def.Clause.{ loc; guard; packing_ft } ->
-                  let@ guard = WIT.check loc BT.Bool guard in
+                  let@ guard = WT.check loc BT.Bool guard in
                   pure
                     (let@ packing_ft =
                        WLAT.welltyped
-                         (fun it -> WIT.check oarg_loc oarg_bt it)
-                         IT.pp
+                         (fun it -> WT.check oarg_loc oarg_bt it)
+                         T.pp
                          "clause"
                          loc
                          packing_ft
@@ -2805,10 +2805,10 @@ module WLFD = struct
        let@ body =
          match body with
          | Def body ->
-           let@ body = WIT.check loc return_bt body in
+           let@ body = WT.check loc return_bt body in
            return (Def body)
          | Rec_Def body ->
-           let@ body = WIT.check loc return_bt body in
+           let@ body = WT.check loc return_bt body in
            return (Rec_Def body)
          | Uninterp -> return Uninterp
        in
@@ -2828,8 +2828,8 @@ module WLFD = struct
         (fun fname fdef graph ->
            let calls =
              match fdef.body with
-             | Def body -> IT.preds_of body
-             | Rec_Def body -> IT.preds_of body
+             | Def body -> Terms.preds_of body
+             | Rec_Def body -> Terms.preds_of body
              | Uninterp -> Sym.Set.empty
            in
            Sym.Set.fold (fun fname' graph -> G.add_edge graph fname fname') calls graph)
@@ -2999,9 +2999,9 @@ let request = WReq.welltyped
 
 let default_quantifier_bt = default_quantifier_bt
 
-let infer_term = WIT.infer
+let infer_term = WT.infer
 
-let check_term = WIT.check
+let check_term = WT.check
 
 let check_ct = WCT.is_ct
 

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -626,8 +626,7 @@ module WT = struct
           | EQ -> (return (), BT.Bool)
           | LTPointer | LEPointer ->
             (ensure_base_type loc ~expect:(Loc ()) (T.get_bt t), BT.Bool)
-          | And | Or | Implies ->
-            (ensure_base_type loc ~expect:Bool (T.get_bt t), BT.Bool)
+          | And | Or | Implies -> (ensure_base_type loc ~expect:Bool (T.get_bt t), BT.Bool)
           | SetUnion | SetIntersection | SetDifference ->
             (ensure_set_type ~reason:loc t, T.get_bt t)
           | Subset -> (ensure_set_type ~reason:loc t, BT.Bool)
@@ -2296,11 +2295,7 @@ module BaseTyping = struct
         | E_Everything -> return ()
       in
       let@ it = WT.infer it in
-      warn_when_not_quantifier_bt
-        "focus"
-        (T.get_loc it)
-        (T.get_bt it)
-        (T.pp it);
+      warn_when_not_quantifier_bt "focus" (T.get_loc it) (T.get_bt it) (T.pp it);
       return (Extract (attrs, to_extract, it))
     | Unfold (f, its) ->
       let@ def = get_logical_function_def loc f in

--- a/lib/wellTyped.mli
+++ b/lib/wellTyped.mli
@@ -27,7 +27,7 @@ type message =
   | Unexpected_computational_args_in_lemma
   | Missing_member of Id.t
   | NIA of
-      { it : IndexTerms.t;
+      { it : Terms.Normal.t;
         hint : string
       }
   | Empty_pattern

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -22,9 +22,9 @@ module type S = sig
     Sctypes.ctype ->
     unit t
 
-  val infer_term : 'bt IndexTerms.annot -> IndexTerms.t t
+  val infer_term : 'bt Terms.annot -> Terms.Normal.t t
 
-  val check_term : Locations.t -> BaseTypes.t -> 'bt IndexTerms.annot -> IndexTerms.t t
+  val check_term : Locations.t -> BaseTypes.t -> 'bt Terms.annot -> Terms.Normal.t t
 
   val default_quantifier_bt : BaseTypes.t
 

--- a/tests/cn/reverse.error.c.verify
+++ b/tests/cn/reverse.error.c.verify
@@ -13,5 +13,5 @@ tests/cn/reverse.error.c:124:3: error: Missing resource for de-allocating
   ^~~~~~~~~ 
 Resource needed: W<struct node>(&n3)
   which requires: W<signed int>(&&n3->head)
-      other location (File "lib/resourceInference.ml", line 238, characters 33-40)  (arg head)
+      other location (File "lib/resourceInference.ml", line 241, characters 33-40)  (arg head)
 State file: file:///tmp/state__reverse.error.c__main.html

--- a/tests/ounit/bennet/abstractDomains/interval.ml
+++ b/tests/ounit/bennet/abstractDomains/interval.ml
@@ -3,9 +3,11 @@
 open OUnit2
 open QCheck
 open Cn.IndexTerms
+open Cn.Terms
 module BT = Cn.BaseTypes
 module Sym = Cn.Sym
 module IT = Cn.IndexTerms
+module T = Cn.Terms.Normal
 
 module NonRelational =
   Cn.TestGeneration.Private.Bennet.Private.AbstractDomains.Private.NonRelational
@@ -60,13 +62,13 @@ let compare_bounds_values bounds_opt interval_opt =
   match (bounds_opt, interval_opt) with
   | None, None -> true
   | Some bounds_term, Some interval_term ->
-    (match (is_bits_const bounds_term, is_bits_const interval_term) with
+    (match (Cn.Terms.is_bits_const bounds_term, is_bits_const interval_term) with
      | Some (_, bz), Some (_, iz) -> Z.equal bz iz
      | _ -> false)
   | _ -> false
 
 
-let pp_bound b = Cn.Pp.plain (Cn.Option.pp IT.pp b)
+let pp_bound b = Cn.Pp.plain (Cn.Option.pp T.pp b)
 
 (** Test comparison between Bounds and NonRelational domain on simple equality *)
 let test_bounds_vs_interval_eq _ =
@@ -211,7 +213,7 @@ let test_interval_add _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 5) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 3) (Z.of_int 7) in
-  let result = IntervalBasis.forward_abs_binop IT.Add i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Add i1 i2 in
   match result with
   | Some interval ->
     assert_equal ~msg:"Add: start should be 5" (Z.of_int 5) interval.start;
@@ -223,7 +225,7 @@ let test_interval_sub _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 5) (Z.of_int 10) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 3) in
-  let result = IntervalBasis.forward_abs_binop IT.Sub i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Sub i1 i2 in
   match result with
   | Some interval ->
     assert_equal ~msg:"Sub: start should be 2" (Z.of_int 2) interval.start;
@@ -235,7 +237,7 @@ let test_interval_mul _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 3) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 4) (Z.of_int 5) in
-  let result = IntervalBasis.forward_abs_binop IT.Mul i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Mul i1 i2 in
   match result with
   | Some interval ->
     assert_equal ~msg:"Mul: start should be 8" (Z.of_int 8) interval.start;
@@ -247,7 +249,7 @@ let test_interval_div _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 8) (Z.of_int 12) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 3) in
-  let result = IntervalBasis.forward_abs_binop IT.Div i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Div i1 i2 in
   match result with
   | Some interval ->
     assert_equal ~msg:"Div: start should be 2" (Z.of_int 2) interval.start;
@@ -259,7 +261,7 @@ let test_interval_div_by_zero _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 5) (Z.of_int 10) in
   let i2 = IntervalBasis.of_interval bt Z.zero Z.zero in
-  let result = IntervalBasis.forward_abs_binop IT.Div i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Div i1 i2 in
   match result with
   | Some interval ->
     assert_bool "Div by zero should result in bottom" (IntervalBasis.is_bottom interval)
@@ -270,7 +272,7 @@ let test_interval_mod _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 5) (Z.of_int 15) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 3) (Z.of_int 7) in
-  let result = IntervalBasis.forward_abs_binop IT.Mod i1 i2 in
+  let result = IntervalBasis.forward_abs_binop Mod i1 i2 in
   match result with
   | Some interval ->
     (* Modulo by [3,7] should give bounds [-6, 6] *)
@@ -283,7 +285,7 @@ let test_interval_bw_and _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 4) (Z.of_int 7) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 6) in
-  let result = IntervalBasis.forward_abs_binop IT.BW_And i1 i2 in
+  let result = IntervalBasis.forward_abs_binop BW_And i1 i2 in
   match result with
   | Some interval ->
     (* Bitwise AND should be conservative *)
@@ -298,7 +300,7 @@ let test_interval_bw_or _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 4) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 1) (Z.of_int 3) in
-  let result = IntervalBasis.forward_abs_binop IT.BW_Or i1 i2 in
+  let result = IntervalBasis.forward_abs_binop BW_Or i1 i2 in
   match result with
   | Some interval ->
     assert_bool
@@ -312,7 +314,7 @@ let test_interval_shift_left _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 2) (Z.of_int 4) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 1) (Z.of_int 2) in
-  let result = IntervalBasis.forward_abs_binop IT.ShiftLeft i1 i2 in
+  let result = IntervalBasis.forward_abs_binop ShiftLeft i1 i2 in
   match result with
   | Some interval ->
     (* [2,4] << [1,2] should give [4,16] *)
@@ -325,7 +327,7 @@ let test_interval_shift_right _ =
   let bt = BT.Bits (Signed, 32) in
   let i1 = IntervalBasis.of_interval bt (Z.of_int 8) (Z.of_int 16) in
   let i2 = IntervalBasis.of_interval bt (Z.of_int 1) (Z.of_int 2) in
-  let result = IntervalBasis.forward_abs_binop IT.ShiftRight i1 i2 in
+  let result = IntervalBasis.forward_abs_binop ShiftRight i1 i2 in
   match result with
   | Some interval ->
     (* [8,16] >> [1,2] should give [2,8] *)
@@ -441,7 +443,7 @@ let arithmetic_soundness_prop =
        let i1 = IntervalBasis.of_interval bt (Z.of_int min_a) (Z.of_int max_a) in
        let i2 = IntervalBasis.of_interval bt (Z.of_int min_b) (Z.of_int max_b) in
        (* Test addition soundness *)
-       let add_result = IntervalBasis.forward_abs_binop IT.Add i1 i2 in
+       let add_result = IntervalBasis.forward_abs_binop Add i1 i2 in
        let add_sound =
          match add_result with
          | Some interval ->
@@ -452,7 +454,7 @@ let arithmetic_soundness_prop =
          | None -> false
        in
        (* Test subtraction soundness *)
-       let sub_result = IntervalBasis.forward_abs_binop IT.Sub i1 i2 in
+       let sub_result = IntervalBasis.forward_abs_binop Sub i1 i2 in
        let sub_sound =
          match sub_result with
          | Some interval ->
@@ -476,7 +478,7 @@ let division_soundness_prop =
        let min_a, max_a = (min a1 a2, max a1 a2) in
        let i1 = IntervalBasis.of_interval bt (Z.of_int min_a) (Z.of_int max_a) in
        let i2 = IntervalBasis.of_interval bt (Z.of_int b) (Z.of_int b) in
-       let div_result = IntervalBasis.forward_abs_binop IT.Div i1 i2 in
+       let div_result = IntervalBasis.forward_abs_binop Div i1 i2 in
        match div_result with
        | Some interval ->
          (not (IntervalBasis.is_bottom interval)) && Z.leq interval.start interval.stop

--- a/tests/ounit/bennet/abstractDomains/tristate.ml
+++ b/tests/ounit/bennet/abstractDomains/tristate.ml
@@ -2,6 +2,7 @@
 
 open OUnit2
 open QCheck
+open Cn.Terms
 module BT = Cn.BaseTypes
 module Sym = Cn.Sym
 module IT = Cn.IndexTerms
@@ -337,7 +338,7 @@ let test_backward_and _ =
   (* (x & 0x0F) == 5 should refine x to have low 4 bits = 0101 *)
   let x_and_mask =
     IT.arith_binop
-      IT.BW_And
+      BW_And
       (IT.sym_ (x, test_bt, test_loc), IT.num_lit_ (Z.of_int 0x0F) test_bt test_loc)
       test_loc
   in
@@ -363,7 +364,7 @@ let test_backward_or _ =
      for the high 4 bits to remain 0 after OR, x must have high 4 bits = 0 *)
   let x_or_mask =
     IT.arith_binop
-      IT.BW_Or
+      BW_Or
       (IT.sym_ (x, test_bt, test_loc), IT.num_lit_ (Z.of_int 0x0F) test_bt test_loc)
       test_loc
   in
@@ -388,7 +389,7 @@ let test_backward_xor _ =
   (* (x ^ 0x0F) == 0x0A means x = 0x0A ^ 0x0F = 0x05 *)
   let x_xor_mask =
     IT.arith_binop
-      IT.BW_Xor
+      BW_Xor
       (IT.sym_ (x, test_bt, test_loc), IT.num_lit_ (Z.of_int 0x0F) test_bt test_loc)
       test_loc
   in
@@ -413,7 +414,7 @@ let test_backward_shl _ =
   (* (x << 2) == 20 means x = 20 >> 2 = 5 *)
   let x_shl =
     IT.arith_binop
-      IT.ShiftLeft
+      ShiftLeft
       (IT.sym_ (x, test_bt, test_loc), IT.num_lit_ (Z.of_int 2) test_bt test_loc)
       test_loc
   in
@@ -438,7 +439,7 @@ let test_backward_lshr _ =
   (* (x >> 2) == 5 means x = 5 << 2 = 20, but low 2 bits are unknown *)
   let x_lshr =
     IT.arith_binop
-      IT.ShiftRight
+      ShiftRight
       (IT.sym_ (x, test_bt, test_loc), IT.num_lit_ (Z.of_int 2) test_bt test_loc)
       test_loc
   in
@@ -478,7 +479,7 @@ let test_backward_le _ =
 let test_backward_not _ =
   let x = make_sym "x" in
   (* ~x == 250 means x = ~250 = 5 (for 8-bit unsigned) *)
-  let not_x = IT.arith_unop IT.BW_Compl (IT.sym_ (x, test_bt, test_loc)) test_loc in
+  let not_x = IT.arith_unop BW_Compl (IT.sym_ (x, test_bt, test_loc)) test_loc in
   let constraint_it =
     IT.eq_ (not_x, IT.num_lit_ (Z.of_int 250) test_bt test_loc) test_loc
   in

--- a/tests/ounit/bennet/abstractDomains/wrappedInterval.ml
+++ b/tests/ounit/bennet/abstractDomains/wrappedInterval.ml
@@ -2,6 +2,7 @@
 
 open OUnit2
 open QCheck
+open Cn.Terms
 module BT = Cn.BaseTypes
 module Sym = Cn.Sym
 module IT = Cn.IndexTerms
@@ -293,14 +294,14 @@ let test_arithmetic_operations _ =
   let a = make_wint bt 10 20 in
   let b = make_wint bt 5 15 in
   (* Test addition *)
-  (match Basis.forward_abs_binop IT.Add a b with
+  (match Basis.forward_abs_binop Add a b with
    | Some result ->
      (* Addition: [10,20] + [5,15] = [15,35] *)
      let expected = make_wint bt 15 35 in
      assert_wint_equal ~msg:"addition" expected result
    | None -> assert_failure "Addition should return Some result");
   (* Test subtraction *)
-  match Basis.forward_abs_binop IT.Sub a b with
+  match Basis.forward_abs_binop Sub a b with
   | Some result ->
     (* Subtraction: [10,20] - [5,15] = [10-15, 20-5] = [-5,15] *)
     (* But in unsigned 8-bit, -5 wraps to 251 *)
@@ -315,7 +316,7 @@ let test_overflow_handling _ =
   let a = make_wint bt 200 250 in
   let b = make_wint bt 100 150 in
   (* This addition should cause overflow: 200+100=300 > 255 *)
-  match Basis.forward_abs_binop IT.Add a b with
+  match Basis.forward_abs_binop Add a b with
   | Some result ->
     (* With wrapped intervals, this should model wraparound, not go to top *)
     assert_bool "Overflow should not result in bottom" (not (is_bottom_wint result))
@@ -339,7 +340,7 @@ let test_bitwise_or _ =
   let bt = test_bt_u8 in
   let a = make_wint bt 2 3 in
   let b = make_wint bt 9 10 in
-  match Basis.forward_abs_binop IT.BW_Or a b with
+  match Basis.forward_abs_binop BW_Or a b with
   | Some result ->
     let expected = make_wint bt 10 11 in
     assert_wint_equal ~msg:"bitwise or" expected result
@@ -351,7 +352,7 @@ let test_bitwise_and _ =
   let bt = test_bt_u8 in
   let a = make_wint bt 2 3 in
   let b = make_wint bt 9 10 in
-  match Basis.forward_abs_binop IT.BW_And a b with
+  match Basis.forward_abs_binop BW_And a b with
   | Some result ->
     let expected = make_wint bt 0 2 in
     assert_wint_equal ~msg:"bitwise and" expected result
@@ -363,7 +364,7 @@ let test_bitwise_xor _ =
   let bt = test_bt_u8 in
   let a = make_wint bt 2 3 in
   let b = make_wint bt 9 10 in
-  match Basis.forward_abs_binop IT.BW_Xor a b with
+  match Basis.forward_abs_binop BW_Xor a b with
   | Some result ->
     let expected = make_wint bt 8 11 in
     assert_wint_equal ~msg:"bitwise xor" expected result
@@ -376,7 +377,7 @@ let test_left_shift_basic _ =
   (* Test shift by 1: [2,3] << 1 = [4,6] *)
   let operand = make_wint bt 2 3 in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     let expected = make_wint bt 4 6 in
     assert_wint_equal ~msg:"left shift by 1" expected result
@@ -389,7 +390,7 @@ let test_left_shift_overflow _ =
   (* Test shift that causes overflow: [64,127] << 2 would exceed 8-bit range *)
   let operand = make_wint bt 64 127 in
   let shift = make_wint bt 2 2 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     (* Should return conservative bounds due to overflow *)
     assert_bool
@@ -403,7 +404,7 @@ let test_left_shift_zero _ =
   let bt = test_bt_u8 in
   let operand = make_wint bt 10 20 in
   let shift = make_wint bt 0 0 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result -> assert_wint_equal ~msg:"left shift by zero" operand result
   | None -> assert_failure "Left shift should return Some result"
 
@@ -414,7 +415,7 @@ let test_logical_right_shift_basic _ =
   (* Test shift by 1: [8,12] >> 1 = [4,6] *)
   let operand = make_wint bt 8 12 in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftRight operand shift with
+  match Basis.forward_abs_binop ShiftRight operand shift with
   | Some result ->
     let expected = make_wint bt 4 6 in
     assert_wint_equal ~msg:"logical right shift by 1" expected result
@@ -427,7 +428,7 @@ let test_logical_right_shift_south_pole _ =
   (* Create interval that crosses south pole: [250, 10] *)
   let operand = make_wint bt 250 10 in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftRight operand shift with
+  match Basis.forward_abs_binop ShiftRight operand shift with
   | Some result ->
     (* Should return conservative bounds [0, 127] for unsigned 8-bit >> 1 *)
     assert_bool
@@ -442,7 +443,7 @@ let test_arithmetic_right_shift_signed _ =
   (* Test positive values: [8,12] >> 1 = [4,6] *)
   let operand = make_wint bt 8 12 in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftRight operand shift with
+  match Basis.forward_abs_binop ShiftRight operand shift with
   | Some result ->
     let expected = make_wint bt 4 6 in
     assert_wint_equal ~msg:"arithmetic right shift positive" expected result
@@ -455,7 +456,7 @@ let test_arithmetic_right_shift_north_pole _ =
   (* Create interval that crosses north pole: [100, -100] (wraps around) *)
   let operand = make_wint bt 100 (-100) in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftRight operand shift with
+  match Basis.forward_abs_binop ShiftRight operand shift with
   | Some result ->
     (* Should return conservative bounds due to north pole crossing *)
     assert_bool
@@ -470,7 +471,7 @@ let test_shift_excessive_amount _ =
   let operand = make_wint bt 10 20 in
   let shift = make_wint bt 8 8 in
   (* Shift by width *)
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     (* Should return top (conservative) for shift by width or more *)
     assert_bool
@@ -485,7 +486,7 @@ let test_non_constant_shift _ =
   let operand = make_wint bt 10 20 in
   let shift = make_wint bt 1 3 in
   (* Non-constant shift amount *)
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     (* Should return top (conservative) for non-constant shift *)
     assert_bool "Non-constant shift should be conservative" (is_top_wint result)
@@ -498,7 +499,7 @@ let test_shift_16bit _ =
   (* Test left shift: [100,200] << 2 = [400,800] *)
   let operand = make_wint bt 100 200 in
   let shift = make_wint bt 2 2 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     let expected = make_wint bt 400 800 in
     assert_wint_equal ~msg:"16-bit left shift" expected result
@@ -511,7 +512,7 @@ let test_shift_max_safe _ =
   (* Test left shift by 7 (max safe for 8-bit): [1,1] << 7 = [128,128] *)
   let operand = make_wint bt 1 1 in
   let shift = make_wint bt 7 7 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     let expected = make_wint bt 128 128 in
     assert_wint_equal ~msg:"max safe left shift" expected result
@@ -525,7 +526,7 @@ let test_enhanced_truncation _ =
   (* [64, 65] << 1 should be [128, 130] with enhanced truncation *)
   let operand = make_wint bt 64 65 in
   let shift = make_wint bt 1 1 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     (* With enhanced truncation, this should be precise since upper bits are consecutive *)
     let expected = make_wint bt 128 130 in
@@ -540,7 +541,7 @@ let test_enhanced_truncation_conservative _ =
   (* [60, 70] << 2 should be conservative due to upper bit differences *)
   let operand = make_wint bt 60 70 in
   let shift = make_wint bt 2 2 in
-  match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+  match Basis.forward_abs_binop ShiftLeft operand shift with
   | Some result ->
     (* Should be conservative bounds, not precise *)
     assert_bool
@@ -555,7 +556,7 @@ let test_arithmetic_right_shift_conservative_bounds _ =
   (* Create interval that crosses signed limit for 8-bit signed: [-100, 100] *)
   let operand = make_wint bt (-100) 100 in
   let shift = make_wint bt 2 2 in
-  match Basis.forward_abs_binop IT.ShiftRight operand shift with
+  match Basis.forward_abs_binop ShiftRight operand shift with
   | Some result ->
     (* Should return precise conservative bounds, not just top *)
     assert_bool "Conservative AShr should not be bottom" (not (is_bottom_wint result));
@@ -569,10 +570,10 @@ let test_shift_left_then_right _ =
   let original = make_wint bt 1 32 in
   let shift_amt = make_wint bt 3 3 in
   (* First shift left by 3: [1, 32] << 3 should give [8, 256] which wraps to [8, 0] *)
-  match Basis.forward_abs_binop IT.ShiftLeft original shift_amt with
+  match Basis.forward_abs_binop ShiftLeft original shift_amt with
   | Some left_shifted ->
     (* Then shift right by 3: [8, 0] >> 3 should give [0, 31] due to conservative handling *)
-    (match Basis.forward_abs_binop IT.ShiftRight left_shifted shift_amt with
+    (match Basis.forward_abs_binop ShiftRight left_shifted shift_amt with
      | Some final_result ->
        (* Due to overflow and conservative right shift, we get [0, 31], not original [1, 32] *)
        let expected = make_wint bt 0 31 in
@@ -590,7 +591,7 @@ let test_remainder_basic _ =
   (* Test unsigned remainder: [10,20] % [3,5] *)
   let dividend = make_wint bt 10 20 in
   let divisor = make_wint bt 3 5 in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* For unsigned, result should be [0, divisor_max-1] = [0, 4] *)
     let expected = make_wint bt 0 4 in
@@ -603,7 +604,7 @@ let test_remainder_zero_dividend _ =
   let bt = test_bt_u8 in
   let zero_dividend = make_wint bt 0 0 in
   let divisor = make_wint bt 5 10 in
-  match Basis.forward_abs_binop IT.Mod zero_dividend divisor with
+  match Basis.forward_abs_binop Mod zero_dividend divisor with
   | Some result ->
     (* 0 % anything = 0 *)
     let expected = make_wint bt 0 0 in
@@ -616,7 +617,7 @@ let test_remainder_zero_divisor _ =
   let bt = test_bt_u8 in
   let dividend = make_wint bt 10 20 in
   let zero_divisor = make_wint bt 0 0 in
-  match Basis.forward_abs_binop IT.Mod dividend zero_divisor with
+  match Basis.forward_abs_binop Mod dividend zero_divisor with
   | Some result ->
     (* Division by zero should result in bottom *)
     assert_bool "Remainder by zero should be bottom" (is_bottom_wint result)
@@ -629,7 +630,7 @@ let test_signed_remainder_positive _ =
   (* Both operands positive: [10,20] % [3,5] *)
   let dividend = make_wint bt 10 20 in
   let divisor = make_wint bt 3 5 in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* For signed with both positive: [0, divisor_max-1] = [0, 4] *)
     let expected = make_wint bt 0 4 in
@@ -643,7 +644,7 @@ let test_signed_remainder_pos_neg _ =
   (* Dividend positive, divisor negative: [10,20] % [-5,-3] *)
   let dividend = make_wint bt 10 20 in
   let divisor = make_wint bt (-5) (-3) in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* For dividend pos, divisor neg: [0, -divisor_min-1] = [0, -(-5)-1] = [0, 4] *)
     let expected = make_wint bt 0 4 in
@@ -660,7 +661,7 @@ let test_signed_remainder_neg_pos _ =
   (* Dividend negative, divisor positive: [-20,-10] % [3,5] *)
   let dividend = make_wint bt (-20) (-10) in
   let divisor = make_wint bt 3 5 in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* For dividend neg, divisor pos: [-divisor_max+1, 0] = [-4, 0] *)
     let expected = make_wint bt (-4) 0 in
@@ -677,7 +678,7 @@ let test_signed_remainder_both_negative _ =
   (* Both operands negative: [-20,-10] % [-5,-3] *)
   let dividend = make_wint bt (-20) (-10) in
   let divisor = make_wint bt (-5) (-3) in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* For both negative: [divisor_min+1, 0] = [-5+1, 0] = [-4, 0] *)
     let expected = make_wint bt (-4) 0 in
@@ -691,7 +692,7 @@ let test_remainder_wrapped _ =
   (* Test with wrapped dividend: [250, 10] % [7, 9] *)
   let wrapped_dividend = make_wint bt 250 10 in
   let divisor = make_wint bt 7 9 in
-  match Basis.forward_abs_binop IT.Mod wrapped_dividend divisor with
+  match Basis.forward_abs_binop Mod wrapped_dividend divisor with
   | Some result ->
     (* Should handle wrapping correctly and not be bottom *)
     assert_bool "Wrapped remainder should not be bottom" (not (is_bottom_wint result));
@@ -707,7 +708,7 @@ let test_remainder_precision _ =
   (* Test case where Crab algorithm should be more precise *)
   let dividend = make_wint bt 100 120 in
   let divisor = make_wint bt 30 40 in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* Should not be top - algorithm should provide meaningful bounds *)
     assert_bool "Remainder should be precise, not top" (not (is_top_wint result));
@@ -721,7 +722,7 @@ let test_remainder_16bit _ =
   (* Test with larger values: [1000,2000] % [100,200] *)
   let dividend = make_wint bt 1000 2000 in
   let divisor = make_wint bt 100 200 in
-  match Basis.forward_abs_binop IT.Mod dividend divisor with
+  match Basis.forward_abs_binop Mod dividend divisor with
   | Some result ->
     (* Should be bounded by [0, 199] for unsigned *)
     let expected_bound = make_wint bt 0 199 in
@@ -1007,7 +1008,7 @@ let prop_left_shift_zero_identity =
     ~print:(fun (start, stop) ->
       let operand = make_wint test_bt_u8 start stop in
       let zero_shift = make_wint test_bt_u8 0 0 in
-      let result_opt = Basis.forward_abs_binop IT.ShiftLeft operand zero_shift in
+      let result_opt = Basis.forward_abs_binop ShiftLeft operand zero_shift in
       String.concat
         "\n"
         [ "\nFailed left shift zero identity test:\n";
@@ -1022,7 +1023,7 @@ let prop_left_shift_zero_identity =
     (fun (start, stop) ->
        let operand = make_wint test_bt_u8 start stop in
        let zero_shift = make_wint test_bt_u8 0 0 in
-       match Basis.forward_abs_binop IT.ShiftLeft operand zero_shift with
+       match Basis.forward_abs_binop ShiftLeft operand zero_shift with
        | Some result -> Basis.equal result operand
        | None -> false)
 
@@ -1036,7 +1037,7 @@ let prop_right_shift_zero_identity =
     (fun (start, stop) ->
        let operand = make_wint test_bt_u8 start stop in
        let zero_shift = make_wint test_bt_u8 0 0 in
-       match Basis.forward_abs_binop IT.ShiftRight operand zero_shift with
+       match Basis.forward_abs_binop ShiftRight operand zero_shift with
        | Some result -> Basis.equal result operand
        | None -> false)
 
@@ -1054,7 +1055,7 @@ let prop_shift_not_bottom =
         if is_bottom_wint operand then
           None
         else
-          Basis.forward_abs_binop IT.ShiftLeft operand shift
+          Basis.forward_abs_binop ShiftLeft operand shift
       in
       String.concat
         "\n"
@@ -1076,7 +1077,7 @@ let prop_shift_not_bottom =
        if is_bottom_wint operand then
          true
        else (
-         match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+         match Basis.forward_abs_binop ShiftLeft operand shift with
          | Some result -> not (is_bottom_wint result)
          | None -> false))
 
@@ -1093,7 +1094,7 @@ let prop_remainder_not_bottom =
        if is_bottom_wint dividend then
          true
        else (
-         match Basis.forward_abs_binop IT.Mod dividend divisor_int with
+         match Basis.forward_abs_binop Mod dividend divisor_int with
          | Some result -> not (is_bottom_wint result)
          | None -> false))
 
@@ -1108,7 +1109,7 @@ let prop_remainder_bounded_unsigned =
       try
         let dividend = make_wint test_bt_u8 dividend_start dividend_stop in
         let divisor = make_wint test_bt_u8 1 divisor_max in
-        let result_opt = Basis.forward_abs_binop IT.Mod dividend divisor in
+        let result_opt = Basis.forward_abs_binop Mod dividend divisor in
         let bound = make_wint test_bt_u8 0 (divisor_max - 1) in
         String.concat
           "\n"
@@ -1131,7 +1132,7 @@ let prop_remainder_bounded_unsigned =
        try
          let dividend = make_wint test_bt_u8 dividend_start dividend_stop in
          let divisor = make_wint test_bt_u8 1 divisor_max in
-         match Basis.forward_abs_binop IT.Mod dividend divisor with
+         match Basis.forward_abs_binop Mod dividend divisor with
          | Some result ->
            let bound = make_wint test_bt_u8 0 (divisor_max - 1) in
            Basis.leq result bound
@@ -1149,7 +1150,7 @@ let prop_remainder_zero_dividend =
     ~print:(fun divisor_val ->
       let zero_dividend = make_wint test_bt_u8 0 0 in
       let divisor = make_wint test_bt_u8 divisor_val divisor_val in
-      let result_opt = Basis.forward_abs_binop IT.Mod zero_dividend divisor in
+      let result_opt = Basis.forward_abs_binop Mod zero_dividend divisor in
       let expected_zero = make_wint test_bt_u8 0 0 in
       String.concat
         "\n"
@@ -1169,7 +1170,7 @@ let prop_remainder_zero_dividend =
     (fun divisor_val ->
        let zero_dividend = make_wint test_bt_u8 0 0 in
        let divisor = make_wint test_bt_u8 divisor_val divisor_val in
-       match Basis.forward_abs_binop IT.Mod zero_dividend divisor with
+       match Basis.forward_abs_binop Mod zero_dividend divisor with
        | Some result ->
          let expected_zero = make_wint test_bt_u8 0 0 in
          Basis.equal result expected_zero
@@ -1185,7 +1186,7 @@ let prop_remainder_zero_divisor_bottom =
     (fun (dividend_start, dividend_stop) ->
        let dividend = make_wint test_bt_u8 dividend_start dividend_stop in
        let zero_divisor = make_wint test_bt_u8 0 0 in
-       match Basis.forward_abs_binop IT.Mod dividend zero_divisor with
+       match Basis.forward_abs_binop Mod dividend zero_divisor with
        | Some result -> is_bottom_wint result
        | None -> false)
 
@@ -1200,7 +1201,7 @@ let prop_signed_remainder_sign_patterns =
        try
          let dividend = make_wint test_bt_s8 dividend_val dividend_val in
          let divisor = make_wint test_bt_s8 divisor_val divisor_val in
-         match Basis.forward_abs_binop IT.Mod dividend divisor with
+         match Basis.forward_abs_binop Mod dividend divisor with
          | Some result ->
            (* For positive dividend and divisor: result should be in [0, divisor-1] *)
            if dividend_val >= 0 && divisor_val > 0 then (
@@ -1222,7 +1223,7 @@ let prop_excessive_shift_produces_top =
     (fun (start, shift_amt) ->
        let operand = make_wint test_bt_u8 start start in
        let shift = make_wint test_bt_u8 shift_amt shift_amt in
-       match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+       match Basis.forward_abs_binop ShiftLeft operand shift with
        | Some result -> is_top_wint result
        | None -> false)
 
@@ -1237,7 +1238,7 @@ let prop_non_constant_shift_produces_top =
        let operand = make_wint test_bt_u8 start stop in
        let shift = make_wint test_bt_u8 0 max_shift in
        (* Non-constant shift *)
-       match Basis.forward_abs_binop IT.ShiftLeft operand shift with
+       match Basis.forward_abs_binop ShiftLeft operand shift with
        | Some result -> is_top_wint result
        | None -> false)
 

--- a/tests/ounit/bennet/stage1/destructProducts.ml
+++ b/tests/ounit/bennet/stage1/destructProducts.ml
@@ -128,7 +128,7 @@ let make_test_prog_with_struct () : unit Mucore.file =
 let make_test_generator
       (name : Sym.t)
       (iargs : (Sym.t * BT.t) list)
-      (assertions : (IT.t * IT.t) list)
+      (assertions : (Cn.Terms.Normal.t * Cn.Terms.Normal.t) list)
   : Def.t
   =
   let rec make_body assertions =

--- a/tests/ounit/bennet/stage2/disjunction.ml
+++ b/tests/ounit/bennet/stage2/disjunction.ml
@@ -3,6 +3,7 @@
 open OUnit2
 module BT = Cn.BaseTypes
 module IT = Cn.IndexTerms
+module T = Cn.Terms.Normal
 module LC = Cn.LogicalConstraints
 module Sym = Cn.Sym
 module Pp = Cn.Pp
@@ -113,8 +114,8 @@ let test_split_and_leftover _ =
      | [ Annot (`Assert (LC.T it_split, gt_body), (), _, _); _ ] ->
        assert_equal
          ~msg:"First branch should assert only the liftable disjunct"
-         ~cmp:IT.equal
-         ~printer:(fun it -> Pp.plain (IT.pp it))
+         ~cmp:T.equal
+         ~printer:(fun it -> Pp.plain (T.pp it))
          d_split
          it_split;
        assert_term_equal

--- a/tests/ounit/indexTerms.ml
+++ b/tests/ounit/indexTerms.ml
@@ -48,8 +48,8 @@ let debug_bounds name constraint_term (x, bt) =
   Printf.printf
     "%s: lower=%s, upper=%s\n"
     name
-    (match lower with Some l -> Cn.Pp.plain (Cn.IndexTerms.pp l) | None -> "None")
-    (match upper with Some u -> Cn.Pp.plain (Cn.IndexTerms.pp u) | None -> "None");
+    (match lower with Some l -> Cn.Pp.plain (Cn.Terms.pp l) | None -> "None")
+    (match upper with Some u -> Cn.Pp.plain (Cn.Terms.pp u) | None -> "None");
   (lower, upper)
 
 
@@ -71,7 +71,7 @@ let test_bounds_simple_le _ =
   assert_bool "LE constraint should not have lower bound" (Option.is_none lower);
   match upper with
   | Some u ->
-    (match is_bits_const u with
+    (match Cn.Terms.is_bits_const u with
      | Some (_, z) -> assert_equal ~msg:"Upper bound should be 10" z (Z.of_int 10)
      | _ -> assert_failure "Upper bound should be a constant")
   | None -> assert_failure "Upper bound should be present for LE"
@@ -85,7 +85,7 @@ let test_bounds_simple_ge _ =
   assert_bool "GE constraint should not have upper bound" (Option.is_none upper);
   match lower with
   | Some l ->
-    (match is_bits_const l with
+    (match Cn.Terms.is_bits_const l with
      | Some (_, z) -> assert_equal ~msg:"Lower bound should be 3" z (Z.of_int 3)
      | _ -> assert_failure "Lower bound should be a constant")
   | None -> assert_failure "Lower bound should be present for GE"
@@ -102,20 +102,20 @@ let test_bounds_conjunction _ =
     (Option.is_some lower && Option.is_some upper);
   match (lower, upper) with
   | Some l, Some u ->
-    (match is_bits_const l with
+    (match Cn.Terms.is_bits_const l with
      | Some (_, z) -> assert_equal ~msg:"Lower bound should be 3" z (Z.of_int 3)
      | _ ->
        assert_failure
          (Printf.sprintf
             "Lower bound should be a constant instead of %s"
-            (Cn.Pp.plain (Cn.IndexTerms.pp l))));
-    (match is_bits_const u with
+            (Cn.Pp.plain (Cn.Terms.pp l))));
+    (match Cn.Terms.is_bits_const u with
      | Some (_, z) -> assert_equal ~msg:"Upper bound should be 10" z (Z.of_int 10)
      | _ ->
        assert_failure
          (Printf.sprintf
             "Upper bound should be a constant instead of %s"
-            (Cn.Pp.plain (Cn.IndexTerms.pp u))))
+            (Cn.Pp.plain (Cn.Terms.pp u))))
   | _ -> assert_failure "Both bounds should be present for conjunction"
 
 
@@ -133,22 +133,22 @@ let test_bounds_conjunction_tighter _ =
     (* Should take max of lower bounds (5) and min of upper bounds (8) *)
     let l = Cn.Simplify.IndexTerms.simp (Cn.Simplify.default Cn.Global.empty) l in
     let u = Cn.Simplify.IndexTerms.simp (Cn.Simplify.default Cn.Global.empty) u in
-    (match is_bits_const l with
+    (match Cn.Terms.is_bits_const l with
      | Some (_, z) ->
        assert_equal ~msg:"Lower bound should be max(3,5) = 5" z (Z.of_int 5)
      | _ ->
        assert_failure
          (Printf.sprintf
             "Lower bound should be a constant instead of %s"
-            (Cn.Pp.plain (Cn.IndexTerms.pp l))));
-    (match is_bits_const u with
+            (Cn.Pp.plain (Cn.Terms.pp l))));
+    (match Cn.Terms.is_bits_const u with
      | Some (_, z) ->
        assert_equal ~msg:"Upper bound should be min(10,8) = 8" z (Z.of_int 8)
      | _ ->
        assert_failure
          (Printf.sprintf
             "Upper bound should be a constant instead of %s"
-            (Cn.Pp.plain (Cn.IndexTerms.pp u))))
+            (Cn.Pp.plain (Cn.Terms.pp u))))
   | _ -> assert_failure "Both bounds should be present for tighter conjunction"
 
 
@@ -188,7 +188,7 @@ let bounds_consistency_prop =
        let eq_bounds_correct =
          match (eq_lower, eq_upper) with
          | Some l, Some u ->
-           (match (is_bits_const l, is_bits_const u) with
+           (match (Cn.Terms.is_bits_const l, Cn.Terms.is_bits_const u) with
             | Some (_, lz), Some (_, uz) ->
               Z.equal lz (Z.of_int eq_val) && Z.equal uz (Z.of_int eq_val)
             | _ -> false)
@@ -204,7 +204,7 @@ let bounds_consistency_prop =
        let conj_bounds_correct =
          match (conj_lower, conj_upper) with
          | Some l, Some u ->
-           (match (is_bits_const l, is_bits_const u) with
+           (match (Cn.Terms.is_bits_const l, Cn.Terms.is_bits_const u) with
             | Some (_, lz), Some (_, uz) ->
               Z.equal lz (Z.of_int min_val) && Z.equal uz (Z.of_int max_val)
             | _ -> false)
@@ -225,7 +225,7 @@ let random_inequality_bounds_prop =
       &&
       match le_upper with
       | Some u ->
-        (match is_bits_const u with
+        (match Cn.Terms.is_bits_const u with
          | Some (_, z) -> Z.equal z (Z.of_int value)
          | _ -> false)
       | None -> false
@@ -238,7 +238,7 @@ let random_inequality_bounds_prop =
       &&
       match ge_lower with
       | Some l ->
-        (match is_bits_const l with
+        (match Cn.Terms.is_bits_const l with
          | Some (_, z) -> Z.equal z (Z.of_int value)
          | _ -> false)
       | None -> false
@@ -260,7 +260,7 @@ let random_conjunction_bounds_prop =
        let conj_lower, conj_upper = Bounds.get_bounds_opt (x, test_bt) conj_constraint in
        match (conj_lower, conj_upper) with
        | Some l, Some u ->
-         (match (is_bits_const l, is_bits_const u) with
+         (match (Cn.Terms.is_bits_const l, Cn.Terms.is_bits_const u) with
           | Some (_, lz), Some (_, uz) ->
             Z.equal lz (Z.of_int lower_val) && Z.equal uz (Z.of_int upper_val)
           | _ -> false)


### PR DESCRIPTION
- `Terms` has all the definitions except term constructors, which are in `IndexTerms` (which should maybe be renamed)
- `Terms` top-level has definitions polymorphic in the type annotation, `Terms.Normal` definitions specific to BT.t

This is for general cleanup, but also to hopefully parameterise IndexTerms in the choice of integer representation.