### PR TITLE
[CN-Testing] Export specs in AustenTest JSON

### DIFF
--- a/bin/test/shared.ml
+++ b/bin/test/shared.ml
@@ -58,6 +58,7 @@ let run
       no_replays
       no_replicas
       output_tyche
+      export_spec_json
       inline
       experimental_struct_asgn_destruction
       experimental_product_arg_destruction
@@ -144,6 +145,7 @@ let run
           no_replays;
           no_replicas;
           output_tyche;
+          export_spec_json;
           print_size_info;
           print_backtrack_info;
           print_satisfaction_info;
@@ -529,6 +531,18 @@ module Flags = struct
       & info ~docs:s_output [ "output-tyche" ] ~doc)
 
 
+  let export_spec_json =
+    let doc =
+      "Dump the specification IR as JSON in AustenTest's spec-module format. FILE names \
+       the output when the translation unit has one function under test, and a directory \
+       to write <function>.json into otherwise"
+    in
+    Arg.(
+      value
+      & opt (some string) TestGeneration.default_cfg.export_spec_json
+      & info ~docs:s_output [ "export-spec-json" ] ~docv:"FILE" ~doc)
+
+
   let inline =
     let doc =
       "Set inlining mode: 'nothing' (no inlining, default), 'nonrec' (non-recursive \
@@ -775,6 +789,7 @@ let mk_term
   $ Flags.no_replays
   $ Flags.no_replicas
   $ Flags.output_tyche
+  $ Flags.export_spec_json
   $ Flags.inline
   $ Flags.experimental_struct_asgn_destruction ~docs:(experimental_section s_generation)
   $ Flags.experimental_product_arg_destruction ~docs:(experimental_section s_generation)
@@ -868,6 +883,7 @@ let mk_release_term ~(engine : TestGeneration.engine) ~(preset : TestGeneration.
       no_replays = cfg.no_replays;
       no_replicas = cfg.no_replicas;
       output_tyche = cfg.output_tyche;
+      export_spec_json = cfg.export_spec_json;
       print_size_info = cfg.print_size_info;
       print_backtrack_info = cfg.print_backtrack_info;
       print_satisfaction_info = cfg.print_satisfaction_info;
@@ -926,6 +942,7 @@ let mk_release_term ~(engine : TestGeneration.engine) ~(preset : TestGeneration.
   $ Flags.no_replays
   $ Flags.no_replicas
   $ opt_or preset.output_tyche Flags.output_tyche
+  $ opt_or preset.export_spec_json Flags.export_spec_json
   $ const preset.inline
   $ const preset.experimental_struct_asgn_destruction
   $ const preset.experimental_product_arg_destruction

--- a/lib/testGeneration/releases.ml
+++ b/lib/testGeneration/releases.ml
@@ -78,6 +78,7 @@ let pldi26 : TestGenConfig.t =
     no_replays = false;
     no_replicas = false;
     output_tyche = None;
+    export_spec_json = None;
     print_size_info = false;
     print_backtrack_info = false;
     print_satisfaction_info = false;

--- a/lib/testGeneration/specExport.ml
+++ b/lib/testGeneration/specExport.ml
@@ -1,0 +1,766 @@
+(* Dump CN's specification IR as JSON in the shape AustenTest consumes.
+
+   AustenTest is a Rust reimplementation of Bennet and Darcy. Its
+   `austen-spec` crate ports CN's `ArgumentTypes` / `LogicalArgumentTypes` /
+   `Request` / `Definition` / `Terms` / `BaseTypes` / `Sctypes` type for type
+   and reads them as serde JSON. Until now those files were hand-written,
+   which capped its corpus at four toy fixtures; this exports the real thing,
+   so `tests/cn-test-gen/src/*.c` can be driven through that pipeline.
+
+   Why hand-written rather than [@@deriving yojson]: serde's encoding and the
+   ppx's do not agree. serde renders an externally-tagged enum as an object
+   ({"Loc": null}) where the ppx renders a positional array (["Loc", null]);
+   serde renders a record variant's payload as an object where the ppx
+   renders an array; `Sym.t` is an opaque Cerberus symbol that has to become
+   {"name", "num"}; and a number of constructors are simply spelled
+   differently on the two sides (BW_CLZ_NoSMT vs BwClzNoSmt). So the encoding
+   is spelled out here, and the far side's
+   `crates/austen-spec/tests/fixtures_round_trip.rs` re-parses everything
+   this produces.
+
+   Dropped throughout, all deliberately: `Locations.t` and the LAT/AT `info`
+   strings (AustenTest carries no source spans), `Definition.Predicate`'s
+   `recursive` (it recomputes recursion from the call graph) and `attrs`, and
+   `Definition.Function.emit_coq`. Return types and `ensures` go too — the
+   generator only ever produces *inputs*. *)
+
+module BT = BaseTypes
+module T = Terms.Normal
+module LC = LogicalConstraints
+module LAT = LogicalArgumentTypes
+module AT = ArgumentTypes
+module Req = Request
+
+type json = Yojson.Safe.t
+
+(* ------------------------------------------------------------ primitives *)
+
+let obj fields : json = `Assoc fields
+
+(* serde's externally-tagged encodings, named so the intent is visible at
+   every use site rather than inferred from the shape. *)
+let unit_variant (name : string) : json = `String name
+
+let newtype_variant (name : string) (payload : json) : json = obj [ (name, payload) ]
+
+let tuple_variant (name : string) (payloads : json list) : json =
+  obj [ (name, `List payloads) ]
+
+
+let record_variant (name : string) (fields : (string * json) list) : json =
+  obj [ (name, obj fields) ]
+
+
+let pair (a : json) (b : json) : json = `List [ a; b ]
+
+(* `austen_gen::Sym`. `name` is an `Option<String>`: an anonymous Cerberus
+   symbol has no description to render, and inventing one would make two
+   distinct symbols look alike in a diff. `num` is the load-bearing half —
+   AustenTest's `Sym` compares on it alone, and `Sym.json` here in CN throws
+   it away, which is why that function is no use for this.
+
+   `pp_string_no_nums`, not `pp_string`: `bin/test/shared.ml` sets
+   `Sym.executable_spec_enabled`, which changes what `pp_string` renders. *)
+let json_of_sym (s : Sym.t) : json =
+  let name =
+    match Sym.description s with
+    | Cerb_frontend.Symbol.SD_None -> `Null
+    | _ -> `String (Sym.pp_string_no_nums s)
+  in
+  obj [ ("name", name); ("num", `Int (Sym.num s)) ]
+
+
+(* `austen_gen::Id`, a newtype over String. *)
+let json_of_id (i : Id.t) : json = `String (Id.get_string i)
+
+(* `num_bigint::BigInt`'s serde encoding: [sign, [u32 limbs, little-endian]],
+   sign being -1/0/1 and the limbs those of the absolute value. Zero is
+   [0, []] — an empty limb list, not [0]. This is the one shape here that
+   cannot be read off the Rust type definition; it comes from num-bigint
+   0.4's own `bigint/serde.rs`, which documents the format as frozen. *)
+let json_of_z (z : Z.t) : json =
+  let base = Z.shift_left Z.one 32 in
+  let rec limbs a acc =
+    if Z.equal a Z.zero then
+      List.rev acc
+    else
+      limbs (Z.div a base) (`Int (Z.to_int (Z.rem a base)) :: acc)
+  in
+  `List [ `Int (Z.sign z); `List (limbs (Z.abs z) []) ]
+
+
+(* `num_rational::Ratio`: [numer, denom]. *)
+let json_of_q (q : Q.t) : json = pair (json_of_z (Q.num q)) (json_of_z (Q.den q))
+
+let json_of_sign : BT.sign -> json = function
+  | BT.Signed -> unit_variant "Signed"
+  | BT.Unsigned -> unit_variant "Unsigned"
+
+
+(* ---------------------------------------------------------------- Sctype *)
+
+let json_of_ibt : Sctypes.IntegerBaseTypes.t -> json =
+  let open Sctypes.IntegerBaseTypes in
+  function
+  | Ichar -> unit_variant "Ichar"
+  | Short -> unit_variant "Short"
+  | Int_ -> unit_variant "Int"
+  | Long -> unit_variant "Long"
+  | LongLong -> unit_variant "LongLong"
+  | IntN_t n -> newtype_variant "IntN" (`Int n)
+  | Int_leastN_t n -> newtype_variant "IntLeastN" (`Int n)
+  | Int_fastN_t n -> newtype_variant "IntFastN" (`Int n)
+  | Intmax_t -> unit_variant "Intmax"
+  | Intptr_t -> unit_variant "Intptr"
+
+
+let json_of_ity : Sctypes.IntegerTypes.t -> json =
+  let open Sctypes.IntegerTypes in
+  function
+  | Char -> unit_variant "Char"
+  | Bool -> unit_variant "Bool"
+  | Signed ibt -> newtype_variant "Signed" (json_of_ibt ibt)
+  | Unsigned ibt -> newtype_variant "Unsigned" (json_of_ibt ibt)
+  | Enum s -> newtype_variant "Enum" (json_of_sym s)
+  | Wchar_t -> unit_variant "WcharT"
+  | Wint_t -> unit_variant "WintT"
+  | Size_t -> unit_variant "SizeT"
+  | Ptrdiff_t -> unit_variant "PtrdiffT"
+  | Ptraddr_t -> unit_variant "PtraddrT"
+
+
+(* The Rust field is `const_`: `const` is a keyword there, and the escape is
+   part of the serialized name because nothing renames it. *)
+let json_of_quals (q : Sctypes.Qualifiers.t) : json =
+  obj
+    [ ("const_", `Bool q.const);
+      ("restrict", `Bool q.restrict);
+      ("volatile", `Bool q.volatile)
+    ]
+
+
+let rec json_of_sct (ct : Sctypes.t) : json =
+  match ct with
+  | Sctypes.Void -> unit_variant "Void"
+  | Sctypes.Integer ity -> newtype_variant "Integer" (json_of_ity ity)
+  | Sctypes.Array (ct', n) ->
+    tuple_variant
+      "Array"
+      [ json_of_sct ct'; (match n with None -> `Null | Some n -> `Int n) ]
+  | Sctypes.Pointer ct' -> newtype_variant "Pointer" (json_of_sct ct')
+  | Sctypes.Struct tag -> newtype_variant "Struct" (json_of_sym tag)
+  | Sctypes.Function ((quals, ret), args, variadic) ->
+    record_variant
+      "Function"
+      [ ("return_type", pair (json_of_quals quals) (json_of_sct ret));
+        ( "args",
+          `List (List.map (fun (a, is_reg) -> pair (json_of_sct a) (`Bool is_reg)) args)
+        );
+        ("variadic", `Bool variadic)
+      ]
+  | Sctypes.Byte -> unit_variant "Byte"
+
+
+(* -------------------------------------------------------------- BaseType *)
+
+(* CN's `ArgumentTypes` are over `BaseTypes.t = unit t_gen`, so every `Loc`
+   here carries `()` and serializes as {"Loc": null}. AustenTest's `Loc`
+   takes an optional pointee, which its own `annotate_pointees` pass fills
+   in from the definitions, so exporting them all bare loses nothing. *)
+let rec json_of_bt (bt : BT.t) : json =
+  match bt with
+  | BT.Unit -> unit_variant "Unit"
+  | BT.Bool -> unit_variant "Bool"
+  | BT.Integer -> unit_variant "Integer"
+  | BT.MemByte -> unit_variant "MemByte"
+  | BT.Bits (sign, n) -> tuple_variant "Bits" [ json_of_sign sign; `Int n ]
+  | BT.Real -> unit_variant "Real"
+  | BT.Alloc_id -> unit_variant "AllocId"
+  | BT.Loc () -> newtype_variant "Loc" `Null
+  | BT.CType -> unit_variant "CType"
+  | BT.Struct tag -> newtype_variant "Struct" (json_of_sym tag)
+  | BT.Datatype tag -> newtype_variant "Datatype" (json_of_sym tag)
+  | BT.Record members -> newtype_variant "Record" (json_of_members members)
+  | BT.Map (k, v) -> tuple_variant "Map" [ json_of_bt k; json_of_bt v ]
+  | BT.List bt' -> newtype_variant "List" (json_of_bt bt')
+  | BT.Tuple bts -> newtype_variant "Tuple" (`List (List.map json_of_bt bts))
+  | BT.Set bt' -> newtype_variant "Set" (json_of_bt bt')
+  | BT.Option bt' -> newtype_variant "Option" (json_of_bt bt')
+
+
+and json_of_members (ms : unit BT.member_types_gen) : json =
+  `List (List.map (fun (id, bt) -> pair (json_of_id id) (json_of_bt bt)) ms)
+
+
+(* ------------------------------------------------------------- IndexTerm *)
+
+let json_of_const : Terms.const -> json =
+  let open Terms in
+  function
+  | Z z -> newtype_variant "Z" (json_of_z z)
+  | Bits ((sign, n), z) ->
+    tuple_variant "Bits" [ pair (json_of_sign sign) (`Int n); json_of_z z ]
+  | Q q -> newtype_variant "Q" (json_of_q q)
+  | MemByte { alloc_id; value } ->
+    record_variant
+      "MemByte"
+      [ ("alloc_id", match alloc_id with None -> `Null | Some z -> json_of_z z);
+        ("value", json_of_z value)
+      ]
+  | Pointer { alloc_id; addr } ->
+    record_variant
+      "Pointer"
+      [ ("alloc_id", json_of_z alloc_id); ("addr", json_of_z addr) ]
+  | Alloc_id z -> newtype_variant "AllocId" (json_of_z z)
+  | Bool b -> newtype_variant "Bool" (`Bool b)
+  | Unit -> unit_variant "Unit"
+  | Null -> unit_variant "Null"
+  | CType_const ct -> newtype_variant "CTypeConst" (json_of_sct ct)
+  | Default bt -> newtype_variant "Default" (json_of_bt bt)
+
+
+(* CN spells these in SCREAMING style, AustenTest in CamelCase. Both matches
+   are exhaustive, so a new operator on either side is a compile error rather
+   than a silently mistranslated term. *)
+let json_of_unop : Terms.unop -> json =
+  let open Terms in
+  function
+  | Not -> unit_variant "Not"
+  | Negate -> unit_variant "Negate"
+  | BW_CLZ_NoSMT -> unit_variant "BwClzNoSmt"
+  | BW_CTZ_NoSMT -> unit_variant "BwCtzNoSmt"
+  | BW_FFS_NoSMT -> unit_variant "BwFfsNoSmt"
+  | BW_FLS_NoSMT -> unit_variant "BwFlsNoSmt"
+  | BW_Compl -> unit_variant "BwCompl"
+
+
+let json_of_binop : Terms.binop -> json =
+  let open Terms in
+  function
+  | And -> unit_variant "And"
+  | Or -> unit_variant "Or"
+  | Implies -> unit_variant "Implies"
+  | Add -> unit_variant "Add"
+  | Sub -> unit_variant "Sub"
+  | Mul -> unit_variant "Mul"
+  | MulNoSMT -> unit_variant "MulNoSmt"
+  | Div -> unit_variant "Div"
+  | DivNoSMT -> unit_variant "DivNoSmt"
+  | Exp -> unit_variant "Exp"
+  | ExpNoSMT -> unit_variant "ExpNoSmt"
+  | Rem -> unit_variant "Rem"
+  | RemNoSMT -> unit_variant "RemNoSmt"
+  | Mod -> unit_variant "Mod"
+  | ModNoSMT -> unit_variant "ModNoSmt"
+  | BW_Xor -> unit_variant "BwXor"
+  | BW_And -> unit_variant "BwAnd"
+  | BW_Or -> unit_variant "BwOr"
+  | ShiftLeft -> unit_variant "ShiftLeft"
+  | ShiftRight -> unit_variant "ShiftRight"
+  | LT -> unit_variant "Lt"
+  | LE -> unit_variant "Le"
+  | Min -> unit_variant "Min"
+  | Max -> unit_variant "Max"
+  | EQ -> unit_variant "Eq"
+  | LTPointer -> unit_variant "LtPointer"
+  | LEPointer -> unit_variant "LePointer"
+  | SetUnion -> unit_variant "SetUnion"
+  | SetIntersection -> unit_variant "SetIntersection"
+  | SetDifference -> unit_variant "SetDifference"
+  | SetMember -> unit_variant "SetMember"
+  | Subset -> unit_variant "Subset"
+
+
+let rec json_of_pattern (p : BT.t Terms.pattern) : json =
+  let (Terms.Pat (p_, bt, _loc)) = p in
+  let pattern =
+    match p_ with
+    | Terms.PSym s -> newtype_variant "Sym" (json_of_sym s)
+    | Terms.PWild -> unit_variant "Wild"
+    | Terms.PConstructor (s, args) ->
+      tuple_variant
+        "Constructor"
+        [ json_of_sym s;
+          `List
+            (List.map (fun (id, p') -> pair (json_of_id id) (json_of_pattern p')) args)
+        ]
+  in
+  obj [ ("pattern", pattern); ("bt", json_of_bt bt) ]
+
+
+(* `IT (term, bt, loc)` becomes {"term": …, "bt": …}; the location is dropped. *)
+let rec json_of_it (it : T.t) : json =
+  let (Terms.IT (t, bt, _loc)) = it in
+  obj [ ("term", json_of_term t); ("bt", json_of_bt bt) ]
+
+
+and json_of_named_terms (xs : (Id.t * T.t) list) : json =
+  `List (List.map (fun (id, it) -> pair (json_of_id id) (json_of_it it)) xs)
+
+
+and json_of_term (t : BT.t Terms.term) : json =
+  let open Terms in
+  match t with
+  | Const c -> newtype_variant "Const" (json_of_const c)
+  | Sym s -> newtype_variant "Sym" (json_of_sym s)
+  | Unop (op, a) -> tuple_variant "Unop" [ json_of_unop op; json_of_it a ]
+  | Binop (op, a, b) ->
+    tuple_variant "Binop" [ json_of_binop op; json_of_it a; json_of_it b ]
+  | ITE (c, a, b) -> tuple_variant "Ite" [ json_of_it c; json_of_it a; json_of_it b ]
+  | EachI ((start, (s, bt), stop), body) ->
+    record_variant
+      "EachI"
+      [ ("start", `Int start);
+        ("var", pair (json_of_sym s) (json_of_bt bt));
+        ("end", `Int stop);
+        ("body", json_of_it body)
+      ]
+  | Tuple xs -> newtype_variant "Tuple" (`List (List.map json_of_it xs))
+  | NthTuple (n, x) -> tuple_variant "NthTuple" [ `Int n; json_of_it x ]
+  | Struct (tag, members) ->
+    tuple_variant "Struct" [ json_of_sym tag; json_of_named_terms members ]
+  | StructMember (x, id) -> tuple_variant "StructMember" [ json_of_it x; json_of_id id ]
+  | StructUpdate ((target, member), value) ->
+    record_variant
+      "StructUpdate"
+      [ ("target", json_of_it target);
+        ("member", json_of_id member);
+        ("value", json_of_it value)
+      ]
+  | Record members -> newtype_variant "Record" (json_of_named_terms members)
+  | RecordMember (x, id) -> tuple_variant "RecordMember" [ json_of_it x; json_of_id id ]
+  | RecordUpdate ((target, member), value) ->
+    record_variant
+      "RecordUpdate"
+      [ ("target", json_of_it target);
+        ("member", json_of_id member);
+        ("value", json_of_it value)
+      ]
+  | Constructor (s, args) ->
+    tuple_variant "Constructor" [ json_of_sym s; json_of_named_terms args ]
+  | MemberShift (x, tag, id) ->
+    tuple_variant "MemberShift" [ json_of_it x; json_of_sym tag; json_of_id id ]
+  | ArrayShift { base; ct; index } ->
+    record_variant
+      "ArrayShift"
+      [ ("base", json_of_it base); ("ct", json_of_sct ct); ("index", json_of_it index) ]
+  | CopyAllocId { addr; loc } ->
+    record_variant "CopyAllocId" [ ("addr", json_of_it addr); ("loc", json_of_it loc) ]
+  | HasAllocId x -> newtype_variant "HasAllocId" (json_of_it x)
+  | SizeOf ct -> newtype_variant "SizeOf" (json_of_sct ct)
+  | OffsetOf (tag, id) -> tuple_variant "OffsetOf" [ json_of_sym tag; json_of_id id ]
+  | Nil bt -> newtype_variant "Nil" (json_of_bt bt)
+  | Cons (h, t') -> tuple_variant "Cons" [ json_of_it h; json_of_it t' ]
+  | Head x -> newtype_variant "Head" (json_of_it x)
+  | Tail x -> newtype_variant "Tail" (json_of_it x)
+  | Representable (ct, x) ->
+    tuple_variant "Representable" [ json_of_sct ct; json_of_it x ]
+  | Good (ct, x) -> tuple_variant "Good" [ json_of_sct ct; json_of_it x ]
+  | Aligned { t = x; align } ->
+    record_variant "Aligned" [ ("t", json_of_it x); ("align", json_of_it align) ]
+  | WrapI (ity, x) -> tuple_variant "WrapI" [ json_of_ity ity; json_of_it x ]
+  | MapConst (bt, x) -> tuple_variant "MapConst" [ json_of_bt bt; json_of_it x ]
+  | MapSet (m, k, v) ->
+    tuple_variant "MapSet" [ json_of_it m; json_of_it k; json_of_it v ]
+  | MapGet (m, k) -> tuple_variant "MapGet" [ json_of_it m; json_of_it k ]
+  | MapDef ((s, bt), x) ->
+    tuple_variant "MapDef" [ pair (json_of_sym s) (json_of_bt bt); json_of_it x ]
+  | Apply (f, args) ->
+    tuple_variant "Apply" [ json_of_sym f; `List (List.map json_of_it args) ]
+  | Let ((s, bound), body) ->
+    tuple_variant "Let" [ pair (json_of_sym s) (json_of_it bound); json_of_it body ]
+  | Match (scrutinee, arms) ->
+    tuple_variant
+      "Match"
+      [ json_of_it scrutinee;
+        `List (List.map (fun (p, x) -> pair (json_of_pattern p) (json_of_it x)) arms)
+      ]
+  | Cast (bt, x) -> tuple_variant "Cast" [ json_of_bt bt; json_of_it x ]
+  | CN_None bt -> newtype_variant "CnNone" (json_of_bt bt)
+  | CN_Some x -> newtype_variant "CnSome" (json_of_it x)
+  | IsSome x -> newtype_variant "IsSome" (json_of_it x)
+  | GetOpt x -> newtype_variant "GetOpt" (json_of_it x)
+
+
+(* ------------------------------------------------- constraints, requests *)
+
+let json_of_lc : LC.t -> json = function
+  | LC.T it -> newtype_variant "T" (json_of_it it)
+  | LC.Forall ((s, bt), body) ->
+    record_variant
+      "Forall"
+      [ ("var", pair (json_of_sym s) (json_of_bt bt)); ("body", json_of_it body) ]
+
+
+let json_of_init : Req.init -> json = function
+  | Req.Init -> unit_variant "Init"
+  | Req.Uninit -> unit_variant "Uninit"
+
+
+let json_of_req_name : Req.name -> json = function
+  | Req.Owned (ct, init) -> tuple_variant "Owned" [ json_of_sct ct; json_of_init init ]
+  | Req.PName s -> newtype_variant "PName" (json_of_sym s)
+
+
+(* `q_loc` goes with every other location. *)
+let json_of_req : Req.t -> json = function
+  | Req.P p ->
+    record_variant
+      "P"
+      [ ("name", json_of_req_name p.name);
+        ("pointer", json_of_it p.pointer);
+        ("iargs", `List (List.map json_of_it p.iargs))
+      ]
+  | Req.Q q ->
+    record_variant
+      "Q"
+      [ ("name", json_of_req_name q.name);
+        ("pointer", json_of_it q.pointer);
+        ("q", pair (json_of_sym (fst q.q)) (json_of_bt (snd q.q)));
+        ("step", json_of_sct q.step);
+        ("permission", json_of_it q.permission);
+        ("iargs", `List (List.map json_of_it q.iargs))
+      ]
+
+
+(* -------------------------------------------------------------- LAT, AT *)
+
+(* `info` is dropped from every binder. *)
+let rec json_of_lat : 'i. ('i -> json) -> 'i LAT.t -> json =
+  fun json_of_i lat ->
+  match lat with
+  | LAT.Define ((s, it), _info, rest) ->
+    tuple_variant
+      "Define"
+      [ pair (json_of_sym s) (json_of_it it); json_of_lat json_of_i rest ]
+  | LAT.Resource ((s, (req, bt)), _info, rest) ->
+    tuple_variant
+      "Resource"
+      [ pair (json_of_sym s) (pair (json_of_req req) (json_of_bt bt));
+        json_of_lat json_of_i rest
+      ]
+  | LAT.Constraint (lc, _info, rest) ->
+    tuple_variant "Constraint" [ json_of_lc lc; json_of_lat json_of_i rest ]
+  | LAT.I i -> newtype_variant "I" (json_of_i i)
+
+
+let rec json_of_at : 'i. ('i -> json) -> 'i AT.t -> json =
+  fun json_of_i at ->
+  match at with
+  | AT.Computational ((s, bt), _info, rest) ->
+    tuple_variant
+      "Computational"
+      [ pair (json_of_sym s) (json_of_bt bt); json_of_at json_of_i rest ]
+  | AT.Ghost ((s, bt), _info, rest) ->
+    tuple_variant
+      "Ghost"
+      [ pair (json_of_sym s) (json_of_bt bt); json_of_at json_of_i rest ]
+  | AT.L lat -> newtype_variant "L" (json_of_lat json_of_i lat)
+
+
+(* ---------------------------------------------------------- declarations *)
+
+let json_of_clause (c : Definition.Clause.t) : json =
+  obj
+    [ ("guard", json_of_it c.guard); ("packing_ft", json_of_lat json_of_it c.packing_ft) ]
+
+
+let json_of_predicate (name : Sym.t) (p : Definition.Predicate.t) : json =
+  (* AustenTest has no equivalent of `nounfold`, so it will unfold a
+     predicate CN would not. Worth saying out loud rather than exporting a
+     definition that behaves differently on the far side. *)
+  if Definition.Predicate.is_nounfold p then
+    Pp.warn_noloc
+      (Pp.string
+         ("predicate "
+          ^ Sym.pp_string_no_nums name
+          ^ " is [nounfold]; AustenTest has no equivalent and will unfold it"));
+  obj
+    [ ("name", json_of_sym name);
+      ("pointer", json_of_sym p.pointer);
+      ( "iargs",
+        `List (List.map (fun (s, bt) -> pair (json_of_sym s) (json_of_bt bt)) p.iargs) );
+      ("oarg", json_of_bt (snd p.oarg));
+      ( "clauses",
+        match p.clauses with
+        | None -> `Null
+        | Some cs -> `List (List.map json_of_clause cs) )
+    ]
+
+
+let json_of_logical_function (name : Sym.t) (f : Definition.Function.t) : json =
+  obj
+    [ ("name", json_of_sym name);
+      ( "args",
+        `List (List.map (fun (s, bt) -> pair (json_of_sym s) (json_of_bt bt)) f.args) );
+      ("return_bt", json_of_bt f.return_bt);
+      ( "body",
+        match f.body with
+        | Definition.Function.Uninterp -> `Null
+        | Definition.Function.Def it -> newtype_variant "Def" (json_of_it it)
+        | Definition.Function.Rec_Def it -> newtype_variant "RecDef" (json_of_it it) )
+    ]
+
+
+let json_of_datatype (name : Sym.t) (dt : Mucore.datatype) : json =
+  obj
+    [ ("name", json_of_sym name);
+      ( "constructors",
+        `List
+          (List.map
+             (fun (cname, params) ->
+                obj
+                  [ ("name", json_of_sym cname);
+                    ( "params",
+                      `List
+                        (List.map
+                           (fun (id, bt) -> pair (json_of_id id) (json_of_bt bt))
+                           params) )
+                  ])
+             dt.cases) )
+    ]
+
+
+(* ----------------------------------------------------------------- CType *)
+
+(* AustenTest's `CType` is its own type, distinct from `Sctype`: the C
+   signature as the shim needs it, and internally tagged
+   ({"kind": "int", "bits": 32, "signed": true}). Only void / bool / int /
+   pointer / named are expressible. *)
+exception Unrepresentable of string
+
+let rec json_of_ctype (ct : Sctypes.t) : json =
+  match ct with
+  | Sctypes.Void -> obj [ ("kind", `String "void") ]
+  | Sctypes.Integer Sctypes.IntegerTypes.Bool -> obj [ ("kind", `String "bool") ]
+  | Sctypes.Integer ity ->
+    (* An enum resolves to its width and signedness rather than being
+       exported as such: AustenTest fails closed on `Enum` in every sizing
+       position, so a resolved approximation beats an unusable exact type. *)
+    obj
+      [ ("kind", `String "int");
+        ("bits", `Int (8 * Memory.size_of_integer_type ity));
+        ("signed", `Bool (Memory.is_signed_integer_type ity))
+      ]
+  | Sctypes.Pointer ct' ->
+    obj [ ("kind", `String "pointer"); ("pointee", json_of_ctype ct') ]
+  | Sctypes.Array (ct', _) ->
+    (* Decay, which is what the C ABI does to an array parameter anyway. A
+       struct *field* of array type is rejected by the caller instead:
+       dropping it would corrupt the layout AustenTest sizes heap writes
+       with. *)
+    obj [ ("kind", `String "pointer"); ("pointee", json_of_ctype ct') ]
+  | Sctypes.Struct tag ->
+    obj [ ("kind", `String "named"); ("name", `String (Sym.pp_string_no_nums tag)) ]
+  | Sctypes.Function _ -> raise (Unrepresentable "a function type")
+  | Sctypes.Byte -> raise (Unrepresentable "the `byte` type")
+
+
+(* ------------------------------------------------------------ collectors *)
+
+(* `types`: the struct layouts, from which AustenTest computes member offsets
+   and hence the extent of a whole-node `asgn`. `Memory.member_types` drops
+   the padding pieces. *)
+let json_of_structs (prog5 : unit Mucore.file) : json list =
+  Pmap.fold
+    (fun tag (def : Mucore.tag_definition) acc ->
+       match def with
+       | Mucore.UnionDef ->
+         Pp.warn_noloc
+           (Pp.string
+              ("union "
+               ^ Sym.pp_string_no_nums tag
+               ^ " has no AustenTest counterpart and is not exported"));
+         acc
+       | Mucore.StructDef layout ->
+         let fields =
+           List.map
+             (fun (id, ct) ->
+                let ty =
+                  match ct with
+                  (* A field, not a parameter: nothing decays, and a dropped
+                   field would silently change every later member's offset. *)
+                  | Sctypes.Array _ ->
+                    raise (Unrepresentable ("an array field (" ^ Id.get_string id ^ ")"))
+                  | _ -> json_of_ctype ct
+                in
+                obj [ ("name", `String (Id.get_string id)); ("type", ty) ])
+             (Memory.member_types layout)
+         in
+         obj
+           [ ("name", `String (Sym.pp_string_no_nums tag));
+             ("tag", json_of_sym tag);
+             ("fields", `List fields)
+           ]
+         :: acc)
+    prog5.tagDefs
+    []
+
+
+(* The C signature of one function under test, recovered from the Ail sigma
+   exactly where `bennet/stage1/convert.ml` recovers its own `c_types`.
+
+   A declared-but-undefined function has no parameter names; positional ones
+   are used, since AustenTest matches `params` against the argument type's
+   computational binders by position, not by name. *)
+(* A C parameter's symbol is a Cerberus *object address* (`SD_ObjectAddress`),
+   which pretty-prints as `&x`. AustenTest splices this name straight into the
+   generated `extern "C"` declaration, so it has to be a plain identifier. *)
+let param_name (s : Sym.t) : string =
+  match Sym.description s with
+  | Cerb_frontend.Symbol.SD_ObjectAddress name -> name
+  | _ -> Sym.pp_string_no_nums s
+
+
+let c_signature sigma (fn : Sym.t) : (string * Sctypes.t) list * Sctypes.t =
+  let open Cerb_frontend in
+  let decl = List.assoc_opt Sym.equal fn sigma.AilSyntax.declarations in
+  match decl with
+  | Some (_, _, AilSyntax.Decl_function (_, (_, ret_ct), arg_cts, _, _, _)) ->
+    let names =
+      match List.assoc_opt Sym.equal fn sigma.AilSyntax.function_definitions with
+      | Some (_, _, _, param_names, _) -> List.map param_name param_names
+      | None -> List.mapi (fun i _ -> "arg" ^ string_of_int i) arg_cts
+    in
+    let sct_of ct =
+      match Sctypes.of_ctype ct with
+      | Some sct -> sct
+      | None ->
+        raise
+          (Unrepresentable
+             "a C type Sctypes cannot express (a float, an atomic, or a union)")
+    in
+    let args = List.map (fun (_quals, ct, _reg) -> sct_of ct) arg_cts in
+    let names =
+      if List.length names = List.length args then
+        names
+      else
+        List.mapi (fun i _ -> "arg" ^ string_of_int i) args
+    in
+    (List.combine names args, sct_of ret_ct)
+  | _ -> raise (Unrepresentable "no C declaration")
+
+
+let json_of_test filename sigma (test : Test.t) : json =
+  let name =
+    if test.is_static then
+      Fulminate.Utils.static_prefix filename ^ "_" ^ Sym.pp_string test.fn
+    else
+      Sym.pp_string test.fn
+  in
+  let params, ret = c_signature sigma test.fn in
+  obj
+    [ ("name", `String name);
+      ( "params",
+        `List
+          (List.map
+             (fun (pname, ct) ->
+                obj [ ("name", `String pname); ("type", json_of_ctype ct) ])
+             params) );
+      ("return", json_of_ctype ret);
+      (* AustenTest's ArgType terminal is `()`: it generates inputs, and the
+         return type and `ensures` are checked by the instrumented C, which
+         it does not run. *)
+      ("internal", json_of_at (fun _ -> `Null) test.internal)
+    ]
+
+
+(* The first symbol number not already used. AustenTest allocates fresh
+   symbols from here when it destructures draws and inserts scopes; left out,
+   it scans the module and starts above the largest number it finds.
+
+   Computed from the emitted JSON rather than taken from `Sym.fresh_int ()`
+   so the file is reproducible: the global counter depends on how much of the
+   pipeline has run, so exporting it would churn every file on every run. *)
+let rec max_sym_num (j : json) : int =
+  match j with
+  | `Assoc fields ->
+    let here =
+      match List.assoc_opt String.equal "num" fields with Some (`Int n) -> n | _ -> -1
+    in
+    List.fold_left (fun acc (_, v) -> max acc (max_sym_num v)) here fields
+  | `List xs -> List.fold_left (fun acc v -> max acc (max_sym_num v)) (-1) xs
+  | _ -> -1
+
+
+(* ----------------------------------------------------------------- entry *)
+
+(* One `SpecModule`, covering one translation unit and one function under
+   test.
+
+   One file per *function*, not per translation unit, even though the shape
+   would hold several: AustenTest's harness always dispatches specification
+   function index 0, so a module naming several functions would generate
+   arguments for one and call another. Putting each first in its own file
+   sidesteps that, and it matches how CN's own corpus is laid out
+   (`sorted_list.insert.pass.c` beside `sorted_list.cons.fail.c`). *)
+let json_of_module ~filename sigma (prog5 : unit Mucore.file) (test : Test.t) : json =
+  let fields =
+    [ ("filename", `String (Filename.basename filename));
+      ("types", `List (json_of_structs prog5));
+      ( "predicates",
+        `List
+          (List.map (fun (name, p) -> json_of_predicate name p) prog5.resource_predicates)
+      );
+      ( "datatypes",
+        `List (List.map (fun (name, dt) -> json_of_datatype name dt) prog5.datatypes) );
+      ( "logical_functions",
+        `List
+          (List.map
+             (fun (name, f) -> json_of_logical_function name f)
+             prog5.logical_predicates) );
+      ("functions", `List [ json_of_test filename sigma test ])
+    ]
+  in
+  obj (("next_sym", `Int (max_sym_num (obj fields) + 1)) :: fields)
+
+
+(* Write the specification module for the *first* function under test.
+
+   One function, not all of them, and never more than one file: AustenTest's
+   harness always dispatches specification function index 0, so a module
+   naming several functions would generate arguments for one and call
+   another. Exporting only the first keeps that impossible by construction,
+   and keeps one source file mapped to exactly one exported spec, which is
+   what the ladder registers.
+
+   The rest are named in a warning rather than dropped silently — they are
+   real coverage this export does not reach, and CN's corpus has several
+   files whose interesting entry point is not the first.
+
+   A function whose signature AustenTest cannot represent is skipped with a
+   warning rather than failing the run: the point of a corpus export is to
+   get as much across as possible and say plainly what did not make it. *)
+let save ~path ~filename sigma prog5 (tests : Test.t list) : unit =
+  match tests with
+  | [] -> ()
+  | test :: rest ->
+    (match rest with
+     | [] -> ()
+     | _ ->
+       Pp.warn_noloc
+         (Pp.string
+            ("exporting only "
+             ^ Sym.pp_string_no_nums test.fn
+             ^ " from "
+             ^ Filename.basename filename
+             ^ "; AustenTest dispatches one function per specification, so "
+             ^ String.concat
+                 ", "
+                 (List.map (fun (t : Test.t) -> Sym.pp_string_no_nums t.fn) rest)
+             ^ " are not exported")));
+    (match json_of_module ~filename sigma prog5 test with
+     | j ->
+       let oc = open_out path in
+       output_string oc (Yojson.Safe.pretty_to_string j);
+       output_char oc '\n';
+       close_out oc
+     | exception Unrepresentable what ->
+       Pp.warn_noloc
+         (Pp.string
+            ("not exporting "
+             ^ Sym.pp_string_no_nums test.fn
+             ^ " from "
+             ^ Filename.basename filename
+             ^ ": AustenTest cannot represent "
+             ^ what)))

--- a/lib/testGeneration/testGenConfig.ml
+++ b/lib/testGeneration/testGenConfig.ml
@@ -126,6 +126,7 @@ type t =
     no_replays : bool;
     no_replicas : bool;
     output_tyche : string option;
+    export_spec_json : string option;
     print_size_info : bool;
     print_backtrack_info : bool;
     print_satisfaction_info : bool;
@@ -196,6 +197,7 @@ let default =
     no_replays = false;
     no_replicas = false;
     output_tyche = Option.None;
+    export_spec_json = Option.None;
     print_size_info = false;
     print_backtrack_info = false;
     print_satisfaction_info = false;
@@ -402,6 +404,8 @@ let has_no_replays () = (Option.get !instance).no_replays
 let has_no_replicas () = (Option.get !instance).no_replicas
 
 let get_output_tyche () = (Option.get !instance).output_tyche
+
+let get_export_spec_json () = (Option.get !instance).export_spec_json
 
 let will_print_size_info () = (Option.get !instance).print_size_info
 

--- a/lib/testGeneration/testGenConfig.mli
+++ b/lib/testGeneration/testGenConfig.mli
@@ -107,6 +107,8 @@ type t =
     no_replays : bool;
     no_replicas : bool;
     output_tyche : string option;
+      (** Dump the specification IR as AustenTest spec-module JSON here. *)
+    export_spec_json : string option;
     print_size_info : bool;
     print_backtrack_info : bool;
     print_satisfaction_info : bool;
@@ -237,6 +239,8 @@ val has_no_replays : unit -> bool
 val has_no_replicas : unit -> bool
 
 val get_output_tyche : unit -> string option
+
+val get_export_spec_json : unit -> string option
 
 val will_print_size_info : unit -> bool
 

--- a/lib/testGeneration/testGeneration.ml
+++ b/lib/testGeneration/testGeneration.ml
@@ -503,6 +503,12 @@ let run
   =
   Cerb_debug.begin_csv_timing ();
   let insts = functions_under_test ~with_warning:false cabs_tunit sigma prog5 paused in
+  (* Before the generators, so `--export-spec-json` still produces a file for
+     a specification the generator pipeline itself chokes on — the export is
+     of the IR, not of anything downstream of it. *)
+  Option.iter
+    (fun path -> SpecExport.save ~path ~filename sigma prog5 insts)
+    (TestGenConfig.get_export_spec_json ());
   save_generators ~output_dir ~filename cabs_tunit sigma prog5 paused insts;
   save_tests
     ~output_dir


### PR DESCRIPTION
Last step in a full end-to-end testing setup of, `CN -> AustenTest (parameterized over generation engines) -> LibAFL (persistent fork server) -> Rust harness`

Note that the existing engines are not reimplemented yet (though a new heuristic baseline has been developed) nor is Fulminate integration done, though it is partially mocked (alongwith better ASan support).
