### PR TITLE
[CN-Rocq] Support recursive resource predicates properly

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.opam
-        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-${{ hashFiles('cn.opam') }}
+        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-heap-lang-4.4.0-${{ hashFiles('cn.opam') }}
   
     - name: Setup OPAM
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
@@ -52,14 +52,17 @@ jobs:
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
         opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
         opam install --deps-only --yes ./cn.opam
-        opam install --yes coq.8.20.1 coq-iris.4.4.0
+        # TODO(CN-Rocq): Fixpoint_Tests.v currently uses iris.heap_lang as a
+        # test fixture. Revisit this when the Rocq test dependencies are
+        # represented properly in the opam/Dune package metadata.
+        opam install --yes coq.8.20.1 coq-iris.4.4.0 coq-iris-heap-lang.4.4.0
       
     - name: Save OPAM cache
       uses: actions/cache/save@v5
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       with:
         path: ~/.opam
-        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-${{ hashFiles('cn.opam') }}
+        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-heap-lang-4.4.0-${{ hashFiles('cn.opam') }}
 
     - name: Install CN (with Coq)
       run: |

--- a/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
+++ b/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
@@ -1,0 +1,69 @@
+  From iris.proofmode Require Import proofmode.
+  From iris.bi.lib Require Import fixpoint_mono.
+
+  (** [solve_mono_go] proves goals of the form [body[Φ] -∗ body[Ψ]] (after
+    [iIntros "HF"], so: goal [body[Ψ]] with "HF" : [body[Φ]]) for bodies
+    generated from the grammar
+
+      P ::= ∃ x:A. P | l ↦ v | ⊤ | ⊥ | P ∗ Q | ⌜ϕ⌝ ∧ P | ⌜ϕ⌝
+          | if b then P else Q | match e with C₁ xs₁ => P₁ | … | Cₙ xsₙ => Pₙ end
+          | f(e)
+
+    where [match] is over any NON-INDEXED inductive (plain parameters are
+    fine; indexed families would need inversion rather than [destruct]) with
+    a constant return type. Any number of branches is fine, as are compound
+    patterns — nested (x :: y :: rest), or-patterns (C₁ | C₂ => P), and
+    wildcards — since Rocq elaborates them to trees of single-level matches,
+    which the destruct rule consumes one level at a time. The context must
+    contain
+      "Hmon" : □ (∀ y, Φ y -∗ Ψ y).
+
+    Invariant: goal and "HF" have identical shape, differing only at
+    recursive-call leaves (Ψ vs Φ). At each node:
+    - Φ-free subterm (↦, ⊤, ⊥, ⌜ϕ⌝, or any subtree without f): [iExact]
+    - recursive call f(e): apply "Hmon"
+    - ∃ / ∗ / ∧: mirror the structure and recurse
+    - match/if (incl. pattern-matching lambdas, which elaborate to matches):
+      destruct the shared scrutinee; both sides reduce in lockstep. *)
+Ltac solve_mono_go :=
+  cbv beta iota zeta;
+  first
+    [ iExact "HF"
+    | iApply "Hmon"; iExact "HF"
+    | lazymatch goal with
+      | |- environments.envs_entails _ (bi_exist _) =>
+          let x := fresh "x" in
+          iDestruct "HF" as (x) "HF"; iExists x; solve_mono_go
+      | |- environments.envs_entails _ (bi_sep _ _) =>
+          iDestruct "HF" as "[HF1 HF2]";
+          iSplitL "HF1";
+          [ iRename "HF1" into "HF" | iRename "HF2" into "HF" ];
+          solve_mono_go
+      | |- environments.envs_entails _ (bi_and _ _) =>
+          iSplit;
+          [ iDestruct "HF" as "[HF _]" | iDestruct "HF" as "[_ HF]" ];
+          solve_mono_go
+      | |- environments.envs_entails _ (match ?x with _ => _ end) =>
+          destruct x; solve_mono_go
+      | |- _ => fail "solve_mono_go: unsupported connective in body"
+      end ].
+
+(** Full [BiMonoPred] solver: [solve_bi_mono_pred F_pre] where [F_pre] is the
+    pre-fixpoint functional. The non-expansiveness obligation first tries the
+    discrete fast-path (valid whenever the domain is built from [leibnizO],
+    [valO], [prodO], ...): an [n]-distance on a discrete OFE is an equality,
+    so substitute and conclude by reflexivity. [solve_proper] can also handle
+    fully discrete domains (via the [SolveProperSubrelation (dist n) (=)]
+    instance, iris/algebra/ofe.v), but reaches the same conclusion only after
+    backtracking typeclass search through the body; the fast-path is
+    deterministic and independent of the body's shape. [solve_proper] remains
+    as a fallback for domains with non-discrete components. *)
+Ltac solve_bi_mono_pred F :=
+  split;
+  [ iIntros (Φ Ψ HΦ HΨ) "#Hmon %y HF"; unfold F; solve_mono_go
+  | intros ? ?;
+    first
+      [ intros ? x1 x2 Hx;
+        apply discrete in Hx; [ | apply _ ];
+        apply leibniz_equiv in Hx; subst; reflexivity
+      | solve_proper ] ].

--- a/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
+++ b/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
@@ -67,3 +67,43 @@ Ltac solve_bi_mono_pred F :=
         apply discrete in Hx; [ | apply _ ];
         apply leibniz_equiv in Hx; subst; reflexivity
       | solve_proper ] ].
+
+(** Proves the standard public induction principle for a generated resource
+    predicate group.  The generator supplies only the group-specific pieces:
+
+    - [F]: the combined pre-fixpoint;
+    - [motive]: the dispatch-type motive assembled from the public motives;
+    - [solve_step]: applies the appropriate public step hypothesis in each
+      dispatch-constructor branch;
+    - [unfold_wrappers]: unfolds the public predicate wrappers in the final
+      conclusions.
+
+    Everything involving the Iris least fixpoint remains in this library. *)
+Ltac solve_cn_predicate_induction F motive solve_step unfold_wrappers :=
+  set (CN_ind_motive := motive);
+  let motive_type := type of CN_ind_motive in
+  lazymatch motive_type with
+  | ?A → ?PROP =>
+    let induction_assertion :=
+      constr:((∀ call : A, bi_least_fixpoint F call -∗ CN_ind_motive call)%I) in
+    assert (NonExpansive CN_ind_motive) as HCN_ind_motive_ne;
+    [ intros n x1 x2 Hx;
+      apply discrete in Hx; [ | apply _ ];
+      apply leibniz_equiv in Hx; subst; reflexivity
+    | iAssert induction_assertion as "Hind";
+      [ iApply least_fixpoint_iter;
+        let call := fresh "call" in
+        iIntros "!>" (call) "Hbody";
+        destruct call;
+        iEval (rewrite /F /CN_ind_motive /=) in "Hbody";
+        rewrite /CN_ind_motive /=;
+        solve_step
+      | let rec solve_conclusions _ :=
+          first
+            [ iSplit; [ solve_conclusions () | solve_conclusions () ]
+            | repeat iIntros (?);
+              iIntros "Hfix";
+              unfold_wrappers;
+              iApply ("Hind" with "Hfix") ]
+        in solve_conclusions () ] ]
+  end.

--- a/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
+++ b/coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v
@@ -45,6 +45,10 @@ Ltac solve_mono_go :=
           solve_mono_go
       | |- environments.envs_entails _ (match ?x with _ => _ end) =>
           destruct x; solve_mono_go
+      | |- environments.envs_entails _ (bi_or _ _) =>
+          iDestruct "HF" as "[HF | HF]";
+          [ iLeft | iRight ];
+          solve_mono_go
       | |- _ => fail "solve_mono_go: unsupported connective in body"
       end ].
 
@@ -58,15 +62,18 @@ Ltac solve_mono_go :=
     backtracking typeclass search through the body; the fast-path is
     deterministic and independent of the body's shape. [solve_proper] remains
     as a fallback for domains with non-discrete components. *)
-Ltac solve_bi_mono_pred F :=
+Ltac solve_bi_mono_pred_with_prepare F prepare :=
   split;
-  [ iIntros (Φ Ψ HΦ HΨ) "#Hmon %y HF"; unfold F; solve_mono_go
+  [ iIntros (Φ Ψ HΦ HΨ) "#Hmon %y HF"; unfold F;  prepare; solve_mono_go
   | intros ? ?;
     first
       [ intros ? x1 x2 Hx;
         apply discrete in Hx; [ | apply _ ];
         apply leibniz_equiv in Hx; subst; reflexivity
       | solve_proper ] ].
+
+Ltac solve_bi_mono_pred F :=
+  solve_bi_mono_pred_with_prepare F ltac:(idtac).
 
 (** Proves the standard public induction principle for a generated resource
     predicate group.  The generator supplies only the group-specific pieces:

--- a/coq/CN_Lemmas/dune
+++ b/coq/CN_Lemmas/dune
@@ -4,4 +4,4 @@
  (synopsis "Rocq and Iris support for CN-exported lemmas")
  (mode vo)
  (theories iris stdpp Ltac2)
- (modules CN_Lib CN_Lib_Iris))
+ (modules CN_Lib CN_Lib_Iris CN_Lib_Iris_Fixpoint))

--- a/lib/cn_to_coq.ml
+++ b/lib/cn_to_coq.ml
@@ -553,22 +553,37 @@ let pred_to_coq_ir (gl : Global.t) (nm : Sym.t) =
   (* distinguishing between defined and uninterpreted predicates *)
   match pred.clauses with
   | Some clauses ->
-    CI.Coq_rpred
+    Either.Left
       ( CI.Coq_sym nm,
         CI.Coq_sym pred.pointer,
         args,
         bt_to_coq_ir gl (snd pred.oarg),
         List.map translate_one_clause clauses )
   | None ->
-    CI.Coq_rpred_uninterp
+    Either.Right
       (CI.Coq_sym nm, CI.Coq_sym pred.pointer, args, bt_to_coq_ir gl (snd pred.oarg))
 
 
 let resource_pred_to_coq_ir (gl : Global.t) (preds : Sym.t list list) =
   let rpred_clump_to_coq_ir (gl : Global.t) (nms : Sym.t list) =
-    List.map (pred_to_coq_ir gl) nms
+    let translated = List.map (pred_to_coq_ir gl) nms in
+    match translated with
+    | Either.Left _ :: _ ->
+      (* check if all clauses are left as well*)
+      let preds =
+        List.map
+          (function
+            | Either.Left (name, ptr, args, ret_bt, clauses) ->
+              CI.{ name; ptr; args; ret_bt; clauses }
+            | _ -> failwith "Unexpected predicate structure")
+          translated
+      in
+      Stdlib.Either.Left preds
+    | [ Either.Right (nm, ptr, args, ret_bt) ] ->
+      Stdlib.Either.Right (nm, ptr, args, ret_bt)
+    | _ -> failwith "Unexpected predicate structure"
   in
-  List.map (rpred_clump_to_coq_ir gl) preds
+  List.partition_map (rpred_clump_to_coq_ir gl) preds
 
 
 (* translate the whole global context to coq_ir *)
@@ -589,11 +604,11 @@ let cn_to_coq_ir (global : Global.t) (lemmata : (Sym.t * (Loc.t * AT.lemmat)) li
       ([], [])
   in
   (* 3. Translate the resource predicates (todo) *)
-  let translated_preds =
+  let translated_pred_groups, translated_uninterp_preds =
     if Option.is_some global.resource_predicate_order then
       resource_pred_to_coq_ir global (Option.get global.resource_predicate_order)
     else
-      []
+      ([], [])
   in
   (* 4. Translate the lemma statement *)
   let translate_lemmas ((sym : Sym.t), (_, lemmat)) =
@@ -604,5 +619,6 @@ let cn_to_coq_ir (global : Global.t) (lemmata : (Sym.t * (Loc.t * AT.lemmat)) li
   CI.Coq_gl
     ( translated_dtypes,
       translated_logical_funs,
-      translated_preds,
+      translated_pred_groups,
+      translated_uninterp_preds,
       List.map translate_lemmas lemmata )

--- a/lib/coq_ir.ml
+++ b/lib/coq_ir.ml
@@ -148,10 +148,17 @@ type coq_clause =
   | Coq_clause of coq_term list * coq_term
 
 type coq_resource_pred =
-  (* parameters: pred name, input pointer name, input arguments and types,
-               output type, clauses (None -> uninterpreted pred) *)
-  | Coq_rpred of coq_sym * coq_sym * (coq_sym * coq_bt) list * coq_bt * coq_clause list
-  | Coq_rpred_uninterp of coq_sym * coq_sym * (coq_sym * coq_bt) list * coq_bt
+  { name : coq_sym;
+    ptr : coq_sym;
+    args : (coq_sym * coq_bt) list;
+    ret_bt : coq_bt;
+    clauses : coq_clause list
+  }
+
+(* Group of mutually recursive resource predicates *)
+type coq_resource_pred_group = coq_resource_pred list
+
+type coq_uinterp_resource_pred = coq_sym * coq_sym * (coq_sym * coq_bt) list * coq_bt
 
 (* CN lemmas *)
 type coq_lemma =
@@ -164,5 +171,6 @@ type coq_gl =
       coq_dt list list
       (* uninterpreted functions and defined functions*)
       * (coq_fun list list * coq_fun list list)
-      * coq_resource_pred list list
+      * coq_resource_pred_group list
+      * coq_uinterp_resource_pred list
       * coq_lemma list

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -5,6 +5,8 @@ module StringSet = Set.Make (String)
 module CI = Coq_ir
 module CC = Cn_to_coq
 
+let ret_sym = "ν"
+
 (* Printing headers for each module in the Coq file *)
 
 let parse_directions directions = (directions, StringSet.singleton "all")
@@ -21,6 +23,12 @@ let header filename =
   ^^ !^"Require CN_Lemmas.CN_Lib."
   ^^ hardline
   ^^ !^"Require Import CN_Lemmas.CN_Lib_Iris."
+  ^^ hardline
+  ^^ !^"From iris.bi.lib Require Import fixpoint_mono."
+  ^^ hardline
+  ^^ !^"From iris.proofmode Require Import proofmode."
+  ^^ hardline
+  ^^ !^"Require Import CN_Lemmas.CN_Lib_Iris_Fixpoint."
   ^^ hardline
   ^^ hardline
 
@@ -141,7 +149,7 @@ let pred_spec preds =
   ^^ (if List.length preds == 0 then
         !^"  (* no resource predicates required *)" ^^ hardline
       else
-        !^"  Unset Guard Checking." ^^ hardline ^^ open_iris_mode preds "Iris_Pred_Defs")
+        open_iris_mode preds "Iris_Pred_Defs")
   ^^ hardline
   ^^ !^"End ResourcePredicates."
   ^^ hardline
@@ -460,7 +468,7 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
       else
         iris_pure !^"Is_true true"
     (* this is the return value of a resource predicate*)
-    | CI.Coq_LAT_I t -> iris_pure (!^"ret = " ^^ aux t)
+    | CI.Coq_LAT_I t -> iris_pure (!^(ret_sym ^ " = ") ^^ aux t)
     | CI.Coq_Owned_LAT (CI.Coq_sym s, bt, t, pointer, _) ->
       let forall_owned op_nm =
         pp_forall
@@ -620,8 +628,17 @@ let rec scanl (f : 'b -> 'a -> 'b) (q : 'b) (ls : 'a list) =
 
 let scanl1 f ls = match ls with x :: xs -> scanl f x xs | [] -> []
 
+(* Generates `Ptr -> arg_ty1 -> ... -> ret_ty -> iProp Σ` *)
+let make_pred_ty args ret_ty res_ty =
+  let open Pp in
+  (* add pointer arg *)
+  let arg_bts = CI.Coq_Loc :: List.map snd args in
+  let arg_types = List.map bt_to_coq arg_bts @ [ bt_to_coq ret_ty ] in
+  List.fold_right (fun arg result -> infix 2 1 !^"->" arg result) arg_types !^res_ty
+
+
 (* print resource predicate definitions *)
-let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred list list) =
+let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
   let open Pp in
   let unpack_clauses (clauses : CI.coq_clause list) =
     let clause_to_coq (clause : CI.coq_clause) =
@@ -652,40 +669,343 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred list list) =
     in
     List.map clause_to_coq (scanl1 clause_concat clauses)
   in
-  let make_args (args : (CI.coq_sym * CI.coq_bt) list) =
-    let make_one_arg arg =
-      match arg with CI.Coq_sym id, bt -> parens (typ (Sym.pp id) (bt_to_coq bt))
+  let make_one_arg = function
+    | CI.Coq_sym id, bt -> parens (typ (Sym.pp id) (bt_to_coq bt))
+  in
+  let unpack_sym (CI.Coq_sym sym) = sym in
+  let get_pred_name (pred : CI.coq_resource_pred) = unpack_sym pred.CI.name in
+  let make_formal_args (pred : CI.coq_resource_pred) =
+    let ptr = unpack_sym pred.CI.ptr in
+    let ptr_arg = parens (typ (Sym.pp ptr) (bt_to_coq CI.Coq_Loc)) in
+    let ret_arg = parens (typ !^ret_sym (bt_to_coq pred.CI.ret_bt)) in
+    (ptr_arg :: List.map make_one_arg pred.CI.args) @ [ ret_arg ]
+  in
+  let make_actual_args (pred : CI.coq_resource_pred) =
+    let ptr = unpack_sym pred.CI.ptr in
+    let args = List.map (fun (arg, _) -> Sym.pp (unpack_sym arg)) pred.CI.args in
+    (Sym.pp ptr :: args) @ [ !^ret_sym ]
+  in
+  let make_args (group : CI.coq_resource_pred_group) (pred : CI.coq_resource_pred) =
+    let make_rec_arg (arg : CI.coq_resource_pred) =
+      let ty = make_pred_ty arg.args arg.ret_bt "iProp Σ" in
+      parens (typ (Sym.pp (get_pred_name arg)) ty)
     in
-    List.map make_one_arg args
+    let rec_args = List.map make_rec_arg group in
+    rec_args @ make_formal_args pred
   in
-  let unpack_preds (pred : CI.coq_resource_pred) =
-    match pred with
-    | CI.Coq_rpred (CI.Coq_sym nm, CI.Coq_sym ptr, args, ret_ty, clauses) ->
-      !^"  Fixpoint "
-      ^^ !^(Sym.pp_string nm)
-      ^^ !^" "
-      ^^ parens (typ !^(Sym.pp_string ptr) !^"Ptr")
-      ^^ !^" "
-      ^^ intersperse " " "" (make_args args)
-      ^^ !^" "
-      ^^ parens (typ !^"ret" (bt_to_coq ret_ty))
-      ^^ !^" {struct ret} "
-      ^^ !^" : iProp Σ := "
+  let get_body_name (pred : CI.coq_resource_pred) =
+    Sym.pp_string (get_pred_name pred) ^ "_body"
+  in
+  let unpack_body (group : CI.coq_resource_pred_group) (pred : CI.coq_resource_pred) =
+    defn
+      (get_body_name pred)
+      (make_args group pred)
+      (Some (Pp.string "iProp Σ"))
+      (intersperse " ∨ " "" (unpack_clauses pred.CI.clauses))
+      false
+  in
+  let get_constr_name (pred : CI.coq_resource_pred) =
+    "CN_GROUP_" ^ Sym.pp_string (get_pred_name pred)
+  in
+  let get_group_type_name index = "cn_predicate_group_" ^ string_of_int index in
+  let make_constr type_name pred =
+    let constr_name = get_constr_name pred in
+    typ (Pp.string constr_name) (make_pred_ty pred.args pred.ret_bt type_name)
+  in
+  let make_group_type index (predicates : CI.coq_resource_pred_group) =
+    let type_name = get_group_type_name index in
+    let constrs = List.map (make_constr type_name) predicates in
+    let group_type =
+      !^("Inductive " ^ type_name ^ " : Type :=")
       ^^ hardline
-      ^^ intersperse " ∨ " "." (unpack_clauses clauses)
+      ^^ flow hardline (List.map (fun c -> !^"  | " ^^ c) constrs)
+      ^^ !^"."
       ^^ hardline
-    | CI.Coq_rpred_uninterp (CI.Coq_sym nm, _, args, ret_ty) ->
-      let coq_arg_typs = List.map (fun (_, bt) -> bt_to_coq bt) args in
-      let coq_rt = bt_to_coq ret_ty in
-      let ty = List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) coq_arg_typs coq_rt in
-      (!^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^" -> Prop." ^^ hardline) ^^ hardline
+    in
+    let ofe_type =
+      !^("Canonical Structure " ^ type_name ^ "O := leibnizO " ^ type_name ^ ".")
+      ^^ hardline
+    in
+    group_type ^^ ofe_type
   in
-  let is_uninterp (pred : CI.coq_resource_pred) =
-    match pred with CI.Coq_rpred_uninterp _ -> true | _ -> false
+  (* (λ p ν, rec (CN_GROUP_IsForest p ν)) *)
+  let make_closure (pred : CI.coq_resource_pred) =
+    let args = make_actual_args pred in
+    let call = parensM @@ build @@ (!^(get_constr_name pred) :: args) in
+    let binders = build args in
+    let body = parensM @@ build [ !^"rec"; call ] in
+    parensM @@ (!^"λ" ^^^ binders ^^ comma) ^//^ body
   in
-  ( List.map unpack_preds (List.filter (fun x -> is_uninterp x) (List.concat preds)),
-    List.map unpack_preds (List.filter (fun x -> not (is_uninterp x)) (List.concat preds))
-  )
+  (* CN_GROUP_IsForest p ν =>
+      IsForest_body
+        (λ p ν, (rec (CN_GROUP_IsForest p ν)))
+        (λ p ν, (rec (CN_GROUP_IsTree p ν)))
+        p ν *)
+  let make_case predicates (pred : CI.coq_resource_pred) =
+    let body_name = !^(get_body_name pred) in
+    let args = make_actual_args pred in
+    let closures = List.map make_closure predicates in
+    let body = build @@ (body_name :: closures) @ args in
+    let pattern = build @@ (!^(get_constr_name pred) :: args) in
+    infix 2 1 !^"=>" pattern body
+  in
+  let get_pre_fixpoint_name index = "cn_predicate_group_pre_" ^ string_of_int index in
+  let make_pre_fixpoint_body (predicates : CI.coq_resource_pred_group) =
+    let cases =
+      predicates
+      |> List.map (make_case predicates)
+      |> List.map (fun case -> !^"| " ^^ case)
+      |> flow hardline
+    in
+    align @@ !^"match call with" ^^ nest 2 (hardline ^^ cases) ^^ hardline ^^ !^"end"
+  in
+  let make_pre_fixpoint_definition index (predicates : CI.coq_resource_pred_group) =
+    let group_ofe_name = get_group_type_name index ^ "O" in
+    let rec_type = flow !^" -> " [ !^group_ofe_name; !^"iProp Σ" ] in
+    let rec_arg = parens @@ typ !^"rec" rec_type in
+    let call_arg = parens @@ typ !^"call" !^group_ofe_name in
+    defn
+      (get_pre_fixpoint_name index)
+      [ rec_arg; call_arg ]
+      (Some !^"iProp Σ")
+      (make_pre_fixpoint_body predicates)
+      false
+  in
+  let make_monotonicity_instance index (predicates : CI.coq_resource_pred_group) =
+    let pre_fixpoint = get_pre_fixpoint_name index in
+    let instance_name = get_group_type_name index ^ "_mono" in
+    let instance =
+      blank 2
+      ^^ align
+           (infix
+              2
+              1
+              colon
+              (!^"Local Instance" ^^^ !^instance_name)
+              (!^"BiMonoPred" ^^^ !^pre_fixpoint ^^ dot))
+    in
+    let prepare =
+      !^"ltac:"
+      ^^ parens
+           (build
+              [ !^"unfold";
+                intersperse "," "" @@ List.map (fun p -> !^(get_body_name p)) predicates
+              ])
+    in
+    let tactic =
+      prefix
+        2
+        1
+        (group (!^"solve_bi_mono_pred_with_prepare" ^/^ !^pre_fixpoint))
+        (prepare ^^ dot)
+    in
+    let proof =
+      blank 2 ^^ align (!^"Proof." ^^ nest 2 (hardline ^^ tactic) ^^ hardline ^^ !^"Qed.")
+    in
+    instance ^^ hardline ^^ proof ^^ hardline
+  in
+  let make_pre_fixpoint index (predicates : CI.coq_resource_pred_group) =
+    let definition = make_pre_fixpoint_definition index predicates in
+    let mono = make_monotonicity_instance index predicates in
+    definition ^^ mono
+  in
+  let make_fixpoint index (pred : CI.coq_resource_pred) =
+    let args = make_formal_args pred in
+    let app = !^(get_constr_name pred) :: make_actual_args pred in
+    let body =
+      build
+        [ !^"bi_least_fixpoint"; !^(get_pre_fixpoint_name index); parens @@ build app ]
+    in
+    defn (Sym.pp_string (get_pred_name pred)) args (Some !^"iProp Σ") body false
+  in
+  let make_fixpoints index (predicates : CI.coq_resource_pred_group) =
+    let pre_fixpoint = make_pre_fixpoint index predicates in
+    let fixpoints = List.map (make_fixpoint index) predicates in
+    pre_fixpoint ^^ hardline ^^ flow hardline fixpoints
+  in
+  (* induction lemma *)
+  let get_pred_prop_name (pred : CI.coq_resource_pred) =
+    "Φ_" ^ Sym.pp_string (get_pred_name pred)
+  in
+  let make_induction_lemma_arg (pred : CI.coq_resource_pred) =
+    let ty = make_pred_ty pred.args pred.ret_bt "iProp Σ" in
+    let name = get_pred_prop_name pred in
+    typ (Pp.string name) ty
+  in
+  let make_forall vars body =
+    let binders = List.map (fun (nm, bt) -> parens @@ typ nm (bt_to_coq bt)) vars in
+    group @@ !^"∀" ^^^ build binders ^^ comma ^^ nest 2 (break 1 ^^ body)
+  in
+  let get_pred_vars (pred : CI.coq_resource_pred) =
+    let vars =
+      List.map (fun (CI.Coq_sym sym, bt) -> (Sym.pp sym, bt)) pred.args
+      @ [ (!^ret_sym, pred.ret_bt) ]
+    in
+    (Sym.pp (unpack_sym pred.ptr), CI.Coq_Loc) :: vars
+  in
+  let make_lemma proof_name args statement proof =
+    let s =
+      !^"Lemma"
+      ^^^ proof_name
+      ^^ nest 4 (hardline ^^ flow hardline args)
+      ^^ space
+      ^^ colon
+      ^^ nest 2 (hardline ^^ statement)
+      ^^ dot
+      ^^ hardline
+    in
+    let proof =
+      blank 2
+      ^^ align
+           (!^"Proof" ^^ dot ^^ nest 2 (hardline ^^ proof) ^^ hardline ^^ !^"Qed" ^^ dot)
+    in
+    s ^^ proof
+  in
+  let make_induction_lemma index (predicates : CI.coq_resource_pred_group) =
+    let make_assumption predicates (pred : CI.coq_resource_pred) =
+      (* □ (∀ (p : Ptr) (ν : forest), IsForest_body Φ_IsForest Φ_IsTree p ν -∗ Φ_IsForest p ν) -∗ *)
+      let vars = get_pred_vars pred in
+      let extended_vars =
+        List.map (fun p -> !^(get_pred_prop_name p)) predicates @ List.map fst vars
+      in
+      let body1 = parensM @@ build @@ (!^(get_body_name pred) :: extended_vars) in
+      let body2 =
+        parensM @@ build @@ (!^(get_pred_prop_name pred) :: List.map fst vars)
+      in
+      let body = infix 2 1 !^"-∗" body1 body2 in
+      !^"□" ^^^ parens @@ make_forall vars body
+    in
+    let make_conc (pred : CI.coq_resource_pred) =
+      (* (∀ (p : Ptr) (ν : forest), IsForest p ν -∗ Φ_IsForest p ν) *)
+      let vars = get_pred_vars pred in
+      let body1 =
+        parensM @@ build @@ (Sym.pp (get_pred_name pred) :: List.map fst vars)
+      in
+      let body2 =
+        parensM @@ build @@ (!^(get_pred_prop_name pred) :: List.map fst vars)
+      in
+      let body = infix 2 1 !^"-∗" body1 body2 in
+      make_forall vars body
+    in
+    let make_induction_lemma_statement predicates =
+      let assumptions = List.map (make_assumption predicates) predicates in
+      let concs = List.map make_conc predicates in
+      let and_sep = space ^^ !^"∧" ^^ break 1 in
+      let conclusion = flow and_sep (List.map parens concs) in
+      separate (space ^^ !^"-∗" ^^ hardline) @@ assumptions @ [ conclusion ]
+    in
+    let make_induction_lemma_proof index (predicates : CI.coq_resource_pred_group) =
+      let name = !^(get_pre_fixpoint_name index) in
+      let cases =
+        List.map
+          (fun p ->
+             let vars = List.map fst (get_pred_vars p) in
+             let body = build @@ (!^(get_constr_name p) :: vars) in
+             let head = build @@ (!^(get_pred_prop_name p) :: vars) in
+             infix 2 1 !^"=>" body head)
+          predicates
+      in
+      let body = cases |> List.map (fun case -> bar ^^^ case) |> flow hardline in
+      let arg1 =
+        parens
+        @@ align
+        @@ !^"fun call =>"
+        ^^ nest
+             2
+             (hardline
+              ^^ !^"match call with"
+              ^^ nest 2 (hardline ^^ body)
+              ^^ hardline
+              ^^ !^"end")
+      in
+      let cases =
+        List.map
+          (fun p ->
+             !^"iApply"
+             ^^^ parens
+                   (!^"\"" ^^ !^"H_" ^^ Sym.pp (get_pred_name p) ^^ !^"\" with \"Hbody\""))
+          predicates
+      in
+      let body = flow (hardline ^^ bar ^^ space) cases in
+      let arg2 =
+        !^"ltac" ^^ colon ^^ parens (!^"first" ^^^ brackets (nest 2 (hardline ^^ body)))
+      in
+      let arg3 =
+        !^"ltac"
+        ^^ colon
+        ^^ parens
+             (!^"unfold"
+              ^^^ separate
+                    (comma ^^ space)
+                    (List.map (fun p -> Sym.pp (get_pred_name p)) predicates))
+        ^^ dot
+      in
+      !^"iIntros \""
+      ^^ build (List.map (fun p -> !^"#H_" ^^ Sym.pp (get_pred_name p)) predicates)
+      ^^ !^"\""
+      ^^ dot
+      ^^^ hardline
+      ^^^ !^"solve_cn_predicate_induction"
+      ^^^ nest 2 (hardline ^^ flow hardline [ name; arg1; arg2; arg3 ])
+    in
+    let args = List.map (fun p -> p |> make_induction_lemma_arg |> parens) predicates in
+    let statement = make_induction_lemma_statement predicates in
+    let proof = make_induction_lemma_proof index predicates in
+    let names = List.map (fun p -> Sym.pp (get_pred_name p)) predicates in
+    let proof_name = separate underscore names ^^ underscore ^^ !^"induction" in
+    make_lemma proof_name args statement proof
+  in
+  let make_unfold_lemma
+        index
+        (predicates : CI.coq_resource_pred_group)
+        (pred : CI.coq_resource_pred)
+    =
+    let proof_name = Sym.pp (get_pred_name pred) ^^ underscore ^^ !^"unfold" in
+    let args = get_pred_vars pred in
+    (* IsForest p ν ⊣⊢ IsForest_body IsForest IsTree p ν. *)
+    let statement =
+      let body1 =
+        parensM @@ build @@ (Sym.pp (get_pred_name pred) :: List.map fst args)
+      in
+      let body2 =
+        parensM
+        @@ build
+        @@ (!^(get_body_name pred)
+            :: List.map (fun p -> Sym.pp (get_pred_name p)) predicates)
+        @ List.map fst args
+      in
+      infix 2 1 !^"⊣⊢" body1 body2
+    in
+    let proof =
+      let rewrites = List.map (fun p -> !^"/" ^^ Sym.pp (get_pred_name p)) predicates in
+      let rem =
+        [ "least_fixpoint_unfold"; "/" ^ get_pre_fixpoint_name index; "/="; "//" ]
+      in
+      (build @@ (!^"rewrite" :: rewrites) @ List.map ( !^ ) rem) ^^ dot
+    in
+    make_lemma
+      proof_name
+      (List.map (fun (nm, bt) -> parens (typ nm (bt_to_coq bt))) args)
+      statement
+      proof
+  in
+  let unpack_group index (predicates : CI.coq_resource_pred_group) =
+    let group_type = make_group_type index predicates in
+    let pred_defs = List.map (unpack_body predicates) predicates in
+    let fixpoint = make_fixpoints index predicates in
+    let induction_lemma = make_induction_lemma index predicates in
+    let unfold_lemmata = List.map (make_unfold_lemma index predicates) predicates in
+    (group_type, pred_defs @ (fixpoint :: induction_lemma :: unfold_lemmata))
+  in
+  let groups = List.mapi unpack_group preds in
+  (List.map fst groups, List.concat_map snd groups)
+
+
+let translate_uninterp_pred =
+  let open Pp in
+  List.map (fun (CI.Coq_sym nm, _, args, ret_ty) ->
+    let ty = make_pred_ty args ret_ty "iProp Σ" in
+    (!^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline) ^^ hardline)
 
 
 (* translate functions to Coq *)
@@ -815,7 +1135,9 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
     let channel = open_out filename in
     Pp.print channel (header filename);
     (* translate everything to coq AST*)
-    let (CI.Coq_gl (dtys, funs, preds, lemmas)) = CC.cn_to_coq_ir global lemmata in
+    let (CI.Coq_gl (dtys, funs, preds, uninterp_preds, lemmas)) =
+      CC.cn_to_coq_ir global lemmata
+    in
     (* print datatypes *)
     let dtypes = translate_datatypes dtys in
     let structs =
@@ -825,15 +1147,19 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
         translate_structs global.struct_decls
     in
     let translated_funs = translate_fun global funs in
-    let translated_preds = translate_pred global preds in
+    let translated_uninterp_preds = translate_uninterp_pred uninterp_preds in
+    let pred_group_tys, translated_preds = translate_pred global preds in
     (* print datatypes *)
-    Pp.print channel (types_spec dtypes);
+    Pp.print channel (types_spec (dtypes @ pred_group_tys));
     (* print uninterpreted logical functions and resource predicates as parameters *)
-    Pp.print channel (param_spec (fst translated_funs @ fst translated_preds));
+    Pp.print channel (param_spec (fst translated_funs));
     (* print structs and function definitions *)
-    Pp.print channel (defs_module (structs @ snd translated_funs));
+    Pp.print
+      channel
+      (defs_module (structs @ translated_uninterp_preds @ snd translated_funs));
     (* print resource predicates *)
-    Pp.print channel (pred_spec (snd translated_preds));
+    Pp.print channel (pred_spec translated_preds);
+    (* print function definitions *)
     (* print lemmas *)
     let translated_lemmas = convert_lemma_defs global lemmas in
     Pp.print channel (lemmas_module [] translated_lemmas);

--- a/tests/rocq_lemmas/unit/fixpoint/Fixpoint_Tests.v
+++ b/tests/rocq_lemmas/unit/fixpoint/Fixpoint_Tests.v
@@ -1,0 +1,291 @@
+From iris.heap_lang Require Import proofmode notation.
+From iris.bi.lib Require Import fixpoint_mono.
+Require Import CN_Lemmas.CN_Lib_Iris_Fixpoint.
+
+(** * Tests *)
+
+Module FixpointTests.
+
+  (** A custom datatype, as generated from a DSL datatype declaration. *)
+  Inductive shape :=
+    | SLeaf
+    | SNum (n : Z)
+    | SFlag (b : bool).
+  Canonical Structure shapeO := leibnizO shape.
+
+  Inductive tri := TA | TB | TC.
+  Canonical Structure triO := leibnizO tri.
+
+  (** For the mutual-recursion test: mutually recursive datatypes, and a
+      custom argument type for the combined fixpoint whose constructor names
+      match the predicate names. Each constructor carries that predicate's
+      arguments directly, so no [prodO] uncurrying is needed. *)
+  Inductive tree := TNode (n : Z) (ts : forest)
+  with forest := FNil | FCons (t : tree) (ts : forest).
+  Canonical Structure treeO := leibnizO tree.
+  Canonical Structure forestO := leibnizO forest.
+
+  Inductive tf :=
+    | IsTree (v : val) (t : tree)
+    | IsForest (v : val) (ts : forest).
+  Canonical Structure tfO := leibnizO tf.
+
+  Section tests.
+    Context `{!heapGS Σ}.
+
+    (** Test 1: linked list (if / ∃ / ⌜ϕ⌝ / ∗ / ↦ / f(e)). *)
+    Definition is_list_pre (rec : prodO valO (leibnizO (list Z)) → iProp Σ)
+        : prodO valO (leibnizO (list Z)) → iProp Σ := λ vl,
+      (if bool_decide (vl.1 = NONEV) then ⌜vl.2 = []⌝
+       else ∃ (p : loc) (x : Z) (l' : list Z) (w : val),
+         ⌜vl.2 = x :: l'⌝ ∗ ⌜vl.1 = SOMEV #p⌝ ∗ p ↦ (#x, w)%V ∗ rec (w, l'))%I.
+
+    Local Instance is_list_pre_mono : BiMonoPred is_list_pre.
+    Proof. solve_bi_mono_pred is_list_pre. Qed.
+
+    (** Test 2: ⊤, ⊥, plain bool if, nested ifs, ∧ with a pure proposition,
+        multiple recursive calls. *)
+    Definition gnarly_pre
+        (rec : prodO (leibnizO bool) (prodO valO (leibnizO (list Z))) → iProp Σ)
+        : prodO (leibnizO bool) (prodO valO (leibnizO (list Z))) → iProp Σ := λ a,
+      (if a.1
+       then ⌜a.2.2 = []⌝ ∗ True
+       else if bool_decide (a.2.1 = NONEV)
+            then False
+            else ∃ (p : loc) (w : val) (x : Z) (l' : list Z),
+              ⌜a.2.2 = x :: l'⌝ ∗ p ↦ w ∗
+              (⌜x = 0%Z⌝ ∧ rec (true, (w, l'))) ∗
+              rec (false, (w, l')))%I.
+
+    Local Instance gnarly_pre_mono : BiMonoPred gnarly_pre.
+    Proof. solve_bi_mono_pred gnarly_pre. Qed.
+
+    (** Test 3: pattern-matching lambdas, including a nested pattern
+        (these elaborate to matches on pairs). *)
+    Definition plist_pre
+        (rec : prodO valO (prodO (leibnizO (list Z)) (leibnizO bool)) → iProp Σ)
+        : prodO valO (prodO (leibnizO (list Z)) (leibnizO bool)) → iProp Σ :=
+      λ '(v, (l, strict)),
+      (if bool_decide (v = NONEV) then (if strict then ⌜l = []⌝ else True)
+       else ∃ (p : loc) (x : Z) (l' : list Z) (w : val),
+         ⌜l = x :: l'⌝ ∗ ⌜v = SOMEV #p⌝ ∗ p ↦ (#x, w)%V ∗ rec (w, (l', strict)))%I.
+
+    Local Instance plist_pre_mono : BiMonoPred plist_pre.
+    Proof. solve_bi_mono_pred plist_pre. Qed.
+
+    (** Test 4: match over a custom datatype, with a projection as scrutinee
+        (a shape [f_equiv]'s match rules cannot decompose structurally — the
+        non-expansiveness proof goes through only because the domain is
+        discrete), recursive calls in some branches only, and a nested if
+        inside a branch. *)
+    Definition shape_pre (rec : prodO valO shapeO → iProp Σ)
+        : prodO valO shapeO → iProp Σ := λ a,
+      (match a.2 with
+       | SLeaf => ⌜a.1 = NONEV⌝
+       | SNum n => ∃ (p : loc) (w : val),
+           ⌜a.1 = SOMEV #p⌝ ∗ p ↦ (#n, w)%V ∗ rec (w, SLeaf)
+       | SFlag b => if b then True else rec (a.1, SLeaf) ∗ False
+       end)%I.
+
+    Local Instance shape_pre_mono : BiMonoPred shape_pre.
+    Proof. solve_bi_mono_pred shape_pre. Qed.
+
+    (** Test 5: compound patterns — deep patterns ([x], x :: y :: rest),
+        an or-pattern (TA | TB), and a wildcard default. These elaborate to
+        nested single-level matches, handled by repeated destructs. *)
+    Definition deep_pre
+        (rec : prodO valO (prodO (leibnizO (list Z)) triO) → iProp Σ)
+        : prodO valO (prodO (leibnizO (list Z)) triO) → iProp Σ := λ a,
+      (match a.2.1 with
+       | [] => ⌜a.1 = NONEV⌝
+       | [x] => ∃ (p : loc), ⌜a.1 = SOMEV #p⌝ ∗ p ↦ #x
+       | x :: y :: rest =>
+           (match a.2.2 with
+            | TA | TB => ⌜x = y⌝ ∗ rec (a.1, (rest, TC))
+            | _ => rec (a.1, (y :: rest, TA))
+            end)
+       end)%I.
+
+    Local Instance deep_pre_mono : BiMonoPred deep_pre.
+    Proof. solve_bi_mono_pred deep_pre. Qed.
+
+    (** Test 6: mutual recursion via a single fixpoint over a custom
+        dispatch type.
+
+          is_tree v (TNode n ts) = ∃ p w, ⌜v = #p⌝ ∗ p ↦ (#n, w) ∗ is_forest w ts
+          is_forest v FNil       = ⌜v = NONE⌝
+          is_forest v (FCons t ts) = ∃ p w1 w2, ⌜v = SOME #p⌝ ∗ p ↦ (w1, w2) ∗
+                                     is_tree w1 t ∗ is_forest w2 ts
+
+        (This particular pair is structurally decreasing on tree/forest, so a
+        mutual [Fixpoint] would also work; it is used here to demonstrate the
+        general encoding, which applies even when recursion is not
+        structural.) *)
+    Definition tf_pre (rec : tfO → iProp Σ) : tfO → iProp Σ := λ a,
+      (match a with
+       | IsTree v t =>
+           match t with
+           | TNode n ts => ∃ (p : loc) (w : val),
+               ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ rec (IsForest w ts)
+           end
+       | IsForest v ts =>
+           match ts with
+           | FNil => ⌜v = NONEV⌝
+           | FCons t ts' => ∃ (p : loc) (w1 w2 : val),
+               ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗
+               rec (IsTree w1 t) ∗ rec (IsForest w2 ts')
+           end
+       end)%I.
+
+    Local Instance tf_pre_mono : BiMonoPred tf_pre.
+    Proof. solve_bi_mono_pred tf_pre. Qed.
+
+    (** Wrapper layer: per-predicate definitions and unfold lemmas that hide
+        the dispatch type from users. *)
+    Definition is_tree (v : val) (t : tree) : iProp Σ :=
+      bi_least_fixpoint tf_pre (IsTree v t).
+    Definition is_forest (v : val) (ts : forest) : iProp Σ :=
+      bi_least_fixpoint tf_pre (IsForest v ts).
+
+    Lemma is_tree_unfold v n ts :
+      is_tree v (TNode n ts) ⊣⊢
+        ∃ (p : loc) (w : val), ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ is_forest w ts.
+    Proof. rewrite /is_tree least_fixpoint_unfold //. Qed.
+
+    Lemma is_forest_unfold v ts :
+      is_forest v ts ⊣⊢
+        match ts with
+        | FNil => ⌜v = NONEV⌝
+        | FCons t ts' => ∃ (p : loc) (w1 w2 : val),
+            ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗ is_tree w1 t ∗ is_forest w2 ts'
+        end.
+    Proof. rewrite /is_forest least_fixpoint_unfold //. Qed.
+
+    (** Derived mutual induction principle, from [least_fixpoint_iter] at the
+        combined motive [match a with IsTree v t => Φt v t | ... end]. *)
+    Lemma is_tree_forest_ind (Φt : val → tree → iProp Σ)
+        (Φf : val → forest → iProp Σ) :
+      □ (∀ v (n : Z) ts, (∃ (p : loc) (w : val),
+           ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ Φf w ts) -∗ Φt v (TNode n ts)) -∗
+      □ (∀ v, ⌜v = NONEV⌝ -∗ Φf v FNil) -∗
+      □ (∀ v t ts, (∃ (p : loc) (w1 w2 : val),
+           ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗ Φt w1 t ∗ Φf w2 ts) -∗
+         Φf v (FCons t ts)) -∗
+      (∀ v t, is_tree v t -∗ Φt v t) ∧ (∀ v ts, is_forest v ts -∗ Φf v ts).
+    Proof.
+      iIntros "#Ht #Hfnil #Hfcons".
+      set (Φ := (λ a, match a with
+                      | IsTree v t => Φt v t
+                      | IsForest v ts => Φf v ts
+                      end)%I : tfO → iProp Σ).
+      assert (NonExpansive Φ) as HΦne.
+      { intros n x1 x2 Hx.
+        apply discrete in Hx; [ | apply _ ].
+        apply leibniz_equiv in Hx; subst; reflexivity. }
+      iAssert (∀ a, bi_least_fixpoint tf_pre a -∗ Φ a)%I as "H".
+      { iApply least_fixpoint_iter.
+        iIntros "!>" (a) "Hpre".
+        destruct a as [v t|v ts]; [destruct t as [n ts]|destruct ts as [|t ts']];
+          simpl.
+        - iApply "Ht". done.
+        - by iApply "Hfnil".
+        - by iApply "Hfcons". }
+      iSplit.
+      - iIntros (v t) "HP". iApply ("H" $! (IsTree v t) with "HP").
+      - iIntros (v ts) "HP". iApply ("H" $! (IsForest v ts) with "HP").
+    Qed.
+
+    (** Test 7: the non-structural variant of Test 6. [is_forest'] tests
+        whether the value is null: if so the forest is asserted to be [FNil];
+        otherwise its components are existentially quantified and pinned by a
+        pure equation ([∃ t' ts', ⌜ts = FCons t' ts'⌝ ∗ …]). The recursive
+        calls are on the existentially bound [t'], [ts'] — related to [ts]
+        only through the pure equation — so no structural-decrease guard can
+        accept this system as a mutual [Fixpoint]; it genuinely needs the
+        least fixpoint. (The [IsTree] branch is unchanged from Test 6,
+        demonstrating that the two styles mix freely.) *)
+    Definition tf_pre' (rec : tfO → iProp Σ) : tfO → iProp Σ := λ a,
+      (match a with
+       | IsTree v t =>
+           match t with
+           | TNode n ts => ∃ (p : loc) (w : val),
+               ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ rec (IsForest w ts)
+           end
+       | IsForest v ts =>
+           if bool_decide (v = NONEV) then ⌜ts = FNil⌝
+           else ∃ (t' : tree) (ts' : forest), ⌜ts = FCons t' ts'⌝ ∗
+             ∃ (p : loc) (w1 w2 : val),
+               ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗
+               rec (IsTree w1 t') ∗ rec (IsForest w2 ts')
+       end)%I.
+
+    Local Instance tf_pre'_mono : BiMonoPred tf_pre'.
+    Proof. solve_bi_mono_pred tf_pre'. Qed.
+
+    Definition is_tree' (v : val) (t : tree) : iProp Σ :=
+      bi_least_fixpoint tf_pre' (IsTree v t).
+    Definition is_forest' (v : val) (ts : forest) : iProp Σ :=
+      bi_least_fixpoint tf_pre' (IsForest v ts).
+
+    Lemma is_tree'_unfold v n ts :
+      is_tree' v (TNode n ts) ⊣⊢
+        ∃ (p : loc) (w : val), ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ is_forest' w ts.
+    Proof. rewrite /is_tree' least_fixpoint_unfold //. Qed.
+
+    Lemma is_forest'_unfold v ts :
+      is_forest' v ts ⊣⊢
+        if bool_decide (v = NONEV) then ⌜ts = FNil⌝
+        else ∃ (t' : tree) (ts' : forest), ⌜ts = FCons t' ts'⌝ ∗
+          ∃ (p : loc) (w1 w2 : val),
+            ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗
+            is_tree' w1 t' ∗ is_forest' w2 ts'.
+    Proof. rewrite /is_forest' least_fixpoint_unfold //. Qed.
+
+    Lemma is_tree_forest'_ind (Φt : val → tree → iProp Σ)
+        (Φf : val → forest → iProp Σ) :
+      □ (∀ v (n : Z) ts, (∃ (p : loc) (w : val),
+           ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ Φf w ts) -∗ Φt v (TNode n ts)) -∗
+      □ (∀ v ts,
+           (if bool_decide (v = NONEV) then ⌜ts = FNil⌝
+            else ∃ (t' : tree) (ts' : forest), ⌜ts = FCons t' ts'⌝ ∗
+              ∃ (p : loc) (w1 w2 : val),
+                ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗ Φt w1 t' ∗ Φf w2 ts') -∗
+           Φf v ts) -∗
+      (∀ v t, is_tree' v t -∗ Φt v t) ∧ (∀ v ts, is_forest' v ts -∗ Φf v ts).
+    Proof.
+      iIntros "#Ht #Hf".
+      set (Φ := (λ a, match a with
+                      | IsTree v t => Φt v t
+                      | IsForest v ts => Φf v ts
+                      end)%I : tfO → iProp Σ).
+      assert (NonExpansive Φ) as HΦne.
+      { intros n x1 x2 Hx.
+        apply discrete in Hx; [ | apply _ ].
+        apply leibniz_equiv in Hx; subst; reflexivity. }
+      iAssert (∀ a, bi_least_fixpoint tf_pre' a -∗ Φ a)%I as "H".
+      { iApply least_fixpoint_iter.
+        iIntros "!>" (a) "Hpre".
+        destruct a as [v t|v ts]; [destruct t as [n ts]|]; simpl.
+        - iApply "Ht". done.
+        - by iApply "Hf". }
+      iSplit.
+      - iIntros (v t) "HP". iApply ("H" $! (IsTree v t) with "HP").
+      - iIntros (v ts) "HP". iApply ("H" $! (IsForest v ts) with "HP").
+    Qed.
+
+    (** The fixpoints and their unfolding lemmas now come for free. *)
+    Definition is_list (v : val) (l : list Z) : iProp Σ :=
+      bi_least_fixpoint is_list_pre (v, l).
+
+    Lemma is_list_unfold v l :
+      is_list v l ⊣⊢ is_list_pre (λ vl, is_list vl.1 vl.2) (v, l).
+    Proof. rewrite /is_list least_fixpoint_unfold //. Qed.
+
+    Definition is_shape (v : val) (s : shape) : iProp Σ :=
+      bi_least_fixpoint shape_pre (v, s).
+
+    Lemma is_shape_unfold v s :
+      is_shape v s ⊣⊢ shape_pre (λ a, is_shape a.1 a.2) (v, s).
+    Proof. rewrite /is_shape least_fixpoint_unfold //. Qed.
+  End tests.
+End FixpointTests.

--- a/tests/rocq_lemmas/unit/fixpoint/Fixpoint_Tests.v
+++ b/tests/rocq_lemmas/unit/fixpoint/Fixpoint_Tests.v
@@ -195,6 +195,38 @@ Module FixpointTests.
       - iIntros (v ts) "HP". iApply ("H" $! (IsForest v ts) with "HP").
     Qed.
 
+    (** The same public mutual induction principle, proved by the solver used
+        by generated resource-predicate groups. *)
+    Lemma is_tree_forest_ind_solver (Φt : val → tree → iProp Σ)
+        (Φf : val → forest → iProp Σ) :
+      □ (∀ v t,
+          (match t with
+           | TNode n ts => ∃ (p : loc) (w : val),
+               ⌜v = #p⌝ ∗ p ↦ (#n, w)%V ∗ Φf w ts
+           end) -∗ Φt v t) -∗
+      □ (∀ v ts,
+          (match ts with
+           | FNil => ⌜v = NONEV⌝
+           | FCons t ts' => ∃ (p : loc) (w1 w2 : val),
+               ⌜v = SOMEV #p⌝ ∗ p ↦ (w1, w2)%V ∗
+               Φt w1 t ∗ Φf w2 ts'
+           end) -∗ Φf v ts) -∗
+      (∀ v t, is_tree v t -∗ Φt v t) ∧
+      (∀ v ts, is_forest v ts -∗ Φf v ts).
+    Proof.
+      iIntros "#Ht #Hf".
+      solve_cn_predicate_induction
+        tf_pre
+        ((λ a, match a with
+               | IsTree v t => Φt v t
+               | IsForest v ts => Φf v ts
+               end)%I : tfO → iProp Σ)
+        ltac:(first
+          [ iApply ("Ht" with "Hbody")
+          | iApply ("Hf" with "Hbody") ])
+        ltac:(unfold is_tree, is_forest).
+    Qed.
+
     (** Test 7: the non-structural variant of Test 6. [is_forest'] tests
         whether the value is null: if so the forest is asserted to be [FNil];
         otherwise its components are existentially quantified and pinned by a
@@ -276,6 +308,21 @@ Module FixpointTests.
     (** The fixpoints and their unfolding lemmas now come for free. *)
     Definition is_list (v : val) (l : list Z) : iProp Σ :=
       bi_least_fixpoint is_list_pre (v, l).
+
+    (** Singleton-group variant of the generated induction principle. *)
+    Lemma is_list_ind_solver (Φ : val → list Z → iProp Σ) :
+      □ (∀ v l,
+          is_list_pre (λ vl, Φ vl.1 vl.2) (v, l) -∗ Φ v l) -∗
+      ∀ v l, is_list v l -∗ Φ v l.
+    Proof.
+      iIntros "#Hstep".
+      solve_cn_predicate_induction
+        is_list_pre
+        ((λ vl, Φ vl.1 vl.2)%I :
+          prodO valO (leibnizO (list Z)) → iProp Σ)
+        ltac:(iApply ("Hstep" with "Hbody"))
+        ltac:(unfold is_list).
+    Qed.
 
     Lemma is_list_unfold v l :
       is_list v l ⊣⊢ is_list_pre (λ vl, is_list vl.1 vl.2) (v, l).

--- a/tests/rocq_lemmas/unit/fixpoint/_CoqProject
+++ b/tests/rocq_lemmas/unit/fixpoint/_CoqProject
@@ -1,0 +1,4 @@
+-Q theories CN_Lemmas
+
+theories/CN_Lib_Iris_Fixpoint.v
+theories/Fixpoint_Tests.v

--- a/tests/run-cn-lemmas.sh
+++ b/tests/run-cn-lemmas.sh
@@ -32,6 +32,21 @@ run_proof_case() {
     timeout 60 make -f Makefile.coq)
 }
 
+run_fixpoint_test() {
+  local case_dir="${WORK_DIR}/fixpoint"
+  local theory_dir="${case_dir}/theories"
+  local test_dir="${LEMMA_DIR}/unit/fixpoint"
+
+  mkdir -p "${theory_dir}"
+  cp "${DIRNAME}/../coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v" "${theory_dir}/"
+  cp "${test_dir}/Fixpoint_Tests.v" "${theory_dir}/"
+  cp "${test_dir}/_CoqProject" "${case_dir}/"
+
+  (cd "${case_dir}" &&
+    coq_makefile -f _CoqProject -o Makefile.coq &&
+    timeout 60 make -f Makefile.coq)
+}
+
 run_and_report() {
   local case_name=$1
   shift
@@ -62,6 +77,10 @@ arrays_testing|arrays/testing|array_lemma.c
 pop_queue|queue|pop.c
 struct_test|struct_test|test.c
 EOF
+
+if ! run_and_report fixpoint run_fixpoint_test; then
+  FAILED+=(fixpoint)
+fi
 
 if [ "${#FAILED[@]}" -eq 0 ]; then
   exit 0


### PR DESCRIPTION
This PR enables CN to generate Rocq/Iris definitions for user-defined recursive resource predicates without relying on `Unset Guard Checking`. Our approach uses the Knaster-Tarski theorem in Iris [\[Krebbers et al. ITP 2025\]](https://robbertkrebbers.nl/research/articles/iris_inductive.pdf) so that users don't have to be worried about step-indexing. More precisely, this PR:
- generates a pre-fixpoint of each recursive resource predicate
- provides a tactic that automatically proves the corresponding `BiMonoPred` instance, including monotonicity and non-expansiveness, along with the CN predicate syntax
- does plumbing between the tactic and the generated definition, and obtains the fixpoint by applying Iris's existing `bi_least_fixpoint`.

CN also supports mutually recursive predicates. We handle them by utilising the strongly connected components of the resource-predicate dependency graph and defining the predicates in each component simultaneously. We also automatically generate auxiliary lemmata ( induction lemma and unfold lemma) for each predicate so that users can reason about generated predicates without understanding their implementation details.

Note that I have already divided the entire changes into three commits, which are expected to be merged to `main` without squashing.