### PR TITLE
[CN-Rocq] Update Rocq and Iris dependencies to latest versions

### DIFF
--- a/.github/workflows/rocq.yml
+++ b/.github/workflows/rocq.yml
@@ -20,7 +20,7 @@ jobs:
   build:
 
     name: Rocq
-    
+
     strategy:
       matrix:
         version: [5.2.0]
@@ -41,8 +41,8 @@ jobs:
       uses: actions/cache/restore@v5
       with:
         path: ~/.opam
-        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-heap-lang-4.4.0-${{ hashFiles('cn.opam') }}
-  
+        key: ${{ matrix.version }}-with-coq-${{ hashFiles('cn.opam') }}
+
     - name: Setup OPAM
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       run: |
@@ -52,17 +52,13 @@ jobs:
         opam repo add --yes --this-switch coq-released https://coq.inria.fr/opam/released
         opam pin --yes -n coq-struct-tact https://github.com/uwplse/StructTact.git
         opam install --deps-only --yes ./cn.opam
-        # TODO(CN-Rocq): Fixpoint_Tests.v currently uses iris.heap_lang as a
-        # test fixture. Revisit this when the Rocq test dependencies are
-        # represented properly in the opam/Dune package metadata.
-        opam install --yes coq.8.20.1 coq-iris.4.4.0 coq-iris-heap-lang.4.4.0
-      
+
     - name: Save OPAM cache
       uses: actions/cache/save@v5
       if: steps.cache-opam-restore.outputs.cache-hit != 'true'
       with:
         path: ~/.opam
-        key: ${{ matrix.version }}-with-coq-8.20.1-iris-4.4.0-heap-lang-4.4.0-${{ hashFiles('cn.opam') }}
+        key: ${{ matrix.version }}-with-coq-${{ hashFiles('cn.opam') }}
 
     - name: Install CN (with Coq)
       run: |
@@ -78,8 +74,63 @@ jobs:
         eval $(opam env --switch=${{ matrix.version }}-with-coq )
         ./tests/diff-prog.py tests/run-cn-coq.sh tests/cn/coq.json --max-workers=2 2> diff.patch || (cat diff.patch; exit 1)
 
+  rocq-lemmas:
+
+    name: Rocq lemma export
+
+    strategy:
+      matrix:
+        version: [4.14.1]
+
+    runs-on: ubuntu-24.04
+
+    steps:
+
+    - name: Checkout CN
+      uses: actions/checkout@v6
+
+    - name: System dependencies (Ubuntu)
+      run: |
+        sudo apt-get install build-essential libgmp-dev z3 opam
+
+    - name: Restore OPAM cache
+      id: cache-opam-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.opam
+        key: ${{ matrix.version }}-rocq-lemma-9.2.0-iris-4.5.0-stdpp-1.13.0-heap-lang-4.5.0-${{ hashFiles('cn.opam') }}
+
+    - name: Setup OPAM
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
+        opam switch create ${{ matrix.version }}-rocq-lemma ${{ matrix.version }}
+        eval $(opam env --switch=${{ matrix.version }}-rocq-lemma)
+        opam repo add --yes --this-switch rocq-released https://rocq-prover.org/opam/released
+        opam install --deps-only --yes ./cn.opam
+        opam install --yes \
+          rocq-core.9.2.0 \
+          rocq-stdlib.9.2.0 \
+          rocq-iris.4.5.0 \
+          rocq-stdpp.1.13.0 \
+          rocq-iris-heap-lang.4.5.0
+
+    - name: Save OPAM cache
+      uses: actions/cache/save@v5
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      with:
+        path: ~/.opam
+        key: ${{ matrix.version }}-rocq-lemma-9.2.0-iris-4.5.0-stdpp-1.13.0-heap-lang-4.5.0-${{ hashFiles('cn.opam') }}
+
+    - name: Install CN
+      run: |
+        opam switch ${{ matrix.version }}-rocq-lemma
+        eval $(opam env --switch=${{ matrix.version }}-rocq-lemma)
+        opam pin --yes --no-action add cn .
+        opam install --yes cn
+
     - name: Run CN lemma export tests
       run: |
-        opam switch ${{ matrix.version }}-with-coq
-        eval $(opam env --switch=${{ matrix.version }}-with-coq )
+        opam switch ${{ matrix.version }}-rocq-lemma
+        eval $(opam env --switch=${{ matrix.version }}-rocq-lemma)
         ./tests/run-cn-lemmas.sh

--- a/coq/dune
+++ b/coq/dune
@@ -1,1 +1,1 @@
-(dirs Cerberus Cn Reasoning CN_Lemmas)
+(dirs Cerberus Cn Reasoning)

--- a/tests/run-cn-lemmas.sh
+++ b/tests/run-cn-lemmas.sh
@@ -17,6 +17,7 @@ run_proof_case() {
   mkdir -p "${theory_dir}"
   cp "${DIRNAME}/../coq/CN_Lemmas/CN_Lib.v" "${theory_dir}/"
   cp "${DIRNAME}/../coq/CN_Lemmas/CN_Lib_Iris.v" "${theory_dir}/"
+  cp "${DIRNAME}/../coq/CN_Lemmas/CN_Lib_Iris_Fixpoint.v" "${theory_dir}/"
   cp "${proof_dir}"/*.v "${theory_dir}/"
   cp "${proof_dir}/_CoqProject" "${case_dir}/"
 
@@ -28,7 +29,8 @@ run_proof_case() {
   fi
 
   (cd "${case_dir}" &&
-    coq_makefile -f _CoqProject -o Makefile.coq &&
+    rocq makefile -f _CoqProject \
+      theories/CN_Lib_Iris_Fixpoint.v -o Makefile.coq &&
     timeout 60 make -f Makefile.coq)
 }
 
@@ -43,7 +45,7 @@ run_fixpoint_test() {
   cp "${test_dir}/_CoqProject" "${case_dir}/"
 
   (cd "${case_dir}" &&
-    coq_makefile -f _CoqProject -o Makefile.coq &&
+    rocq makefile -f _CoqProject -o Makefile.coq &&
     timeout 60 make -f Makefile.coq)
 }
 


### PR DESCRIPTION
The Rocq lemma export machinery is independent of Vadim's Rocq machinery. We can therefore choose the Rocq and Iris versions independently. Since there is no reason to use older versions, I selected the latest version of each dependency.

Separately, this should resolve the CI issue in which downloading stdpp from mpi-sws fails with an HTTP 429 error, because newer package versions are hosted on GitHub.
