### PR TITLE
Refactors to lemma printing machinery

### DIFF
--- a/lib/cn_to_coq.ml
+++ b/lib/cn_to_coq.ml
@@ -13,19 +13,19 @@ module StringSet = Set.Make (String)
 module StringMap = Map.Make (String)
 module CI = Coq_ir
 
-let rec pat_to_coq_ir pat =
+let rec pat_to_itp_ir pat =
   match pat with
-  | Terms.Pat (Terms.PSym sym, _, _) -> CI.Coq_pSym (CI.Coq_sym sym)
-  | Terms.Pat (Terms.PWild, _, _) -> CI.Coq_pWild
+  | Terms.Pat (Terms.PSym sym, _, _) -> CI.ITP_pSym (CI.ITP_sym sym)
+  | Terms.Pat (Terms.PWild, _, _) -> CI.ITP_pWild
   | Terms.Pat (Terms.PConstructor (c_nm, id_ps), _, _) ->
-    CI.Coq_pConstructor (CI.Coq_sym c_nm, List.map (fun x -> pat_to_coq_ir (snd x)) id_ps)
+    CI.ITP_pConstructor (CI.ITP_sym c_nm, List.map (fun x -> pat_to_itp_ir (snd x)) id_ps)
 
 
 (* assuming here that the id's are in canonical order *)
 
 (* set of functions with boolean return type that we want to use
    as toplevel propositions, i.e. return Prop rather than bool
-   (computational) in Coq. *)
+   (computational) in ITP. *)
 let prop_funs = StringSet.of_list [ "page_group_ok" ]
 
 let fun_prop_ret (global : Global.t) nm =
@@ -55,67 +55,67 @@ let get_struct_xs struct_decls tag =
   | None -> ([], [])
 
 
-(* CN basetypes to Coq_IR *)
-let rec bt_to_coq_ir (gl : Global.t) (bt : BT.t) =
+(* CN basetypes to ITP_IR *)
+let rec bt_to_itp_ir (gl : Global.t) (bt : BT.t) =
   match bt with
-  | BaseTypes.Bool -> CI.Coq_Bool
-  | BaseTypes.Integer -> CI.Coq_Integer
+  | BaseTypes.Bool -> CI.ITP_Bool
+  | BaseTypes.Integer -> CI.ITP_Integer
   | BaseTypes.Bits (sign, i) ->
     (match sign with
-     | BT.Signed -> CI.Coq_Bits (CI.Coq_Signed, i)
-     | BT.Unsigned -> CI.Coq_Bits (CI.Coq_Unsigned, i))
+     | BT.Signed -> CI.ITP_Bits (CI.ITP_Signed, i)
+     | BT.Unsigned -> CI.ITP_Bits (CI.ITP_Unsigned, i))
   | BaseTypes.Map (x, y) ->
-    let enc_x = bt_to_coq_ir gl x in
-    let enc_y = bt_to_coq_ir gl y in
-    CI.Coq_Map (enc_x, enc_y)
+    let enc_x = bt_to_itp_ir gl x in
+    let enc_y = bt_to_itp_ir gl y in
+    CI.ITP_Map (enc_x, enc_y)
   | BaseTypes.Struct tag ->
     let _, fld_bts = get_struct_xs gl.struct_decls tag in
-    let enc_fld_bts = List.map (bt_to_coq_ir gl) fld_bts in
-    CI.Coq_Struct (CI.Coq_sym tag, enc_fld_bts)
+    let enc_fld_bts = List.map (bt_to_itp_ir gl) fld_bts in
+    CI.ITP_Struct (CI.ITP_sym tag, enc_fld_bts)
   | BaseTypes.Record mems ->
-    let enc_mem_bts = List.map (bt_to_coq_ir gl) (List.map snd mems) in
-    CI.Coq_Record enc_mem_bts
-  | BaseTypes.Loc () -> CI.Coq_Loc
+    let enc_mem_bts = List.map (bt_to_itp_ir gl) (List.map snd mems) in
+    CI.ITP_Record enc_mem_bts
+  | BaseTypes.Loc () -> CI.ITP_Loc
   (* todo: probably not right *)
-  | BaseTypes.Datatype tag -> CI.Coq_Datatype (CI.Coq_sym tag)
-  | BaseTypes.List _bt2 -> CI.Coq_List (bt_to_coq_ir gl bt)
-  | BaseTypes.Unit -> CI.Coq_Unit
-  | BaseTypes.MemByte -> CI.Coq_Membyte
-  | BaseTypes.Real -> CI.Coq_Real
-  | BaseTypes.Alloc_id -> CI.Coq_Alloc_id
-  | BaseTypes.CType -> CI.Coq_CType
-  | BaseTypes.Tuple bts -> CI.Coq_Tuple (List.map (bt_to_coq_ir gl) bts)
-  | BaseTypes.Set _ -> CI.Coq_Set (bt_to_coq_ir gl bt)
+  | BaseTypes.Datatype tag -> CI.ITP_Datatype (CI.ITP_sym tag)
+  | BaseTypes.List _bt2 -> CI.ITP_List (bt_to_itp_ir gl bt)
+  | BaseTypes.Unit -> CI.ITP_Unit
+  | BaseTypes.MemByte -> CI.ITP_Membyte
+  | BaseTypes.Real -> CI.ITP_Real
+  | BaseTypes.Alloc_id -> CI.ITP_Alloc_id
+  | BaseTypes.CType -> CI.ITP_CType
+  | BaseTypes.Tuple bts -> CI.ITP_Tuple (List.map (bt_to_itp_ir gl) bts)
+  | BaseTypes.Set _ -> CI.ITP_Set (bt_to_itp_ir gl bt)
   | BaseTypes.Option _ -> failwith "unsupported" (* TODO(HK): added just for plumbing *)
 
 
-(* map each mutually recursive list of datatypes to mutually recursive lists of coq_ir *)
-let dt_to_coq_ir (gl : Global.t) nm =
+(* map each mutually recursive list of datatypes to mutually recursive lists of itp_ir *)
+let dt_to_itp_ir (gl : Global.t) nm =
   (* find the info of a datatype *)
   let dt_info = Sym.Map.find nm gl.datatypes in
   (* get its params and translate them*)
-  let dt_args = List.map (fun (_, bt) -> bt_to_coq_ir gl bt) dt_info.all_params in
+  let dt_args = List.map (fun (_, bt) -> bt_to_itp_ir gl bt) dt_info.all_params in
   (* find the info of a constructor, given its name*)
   let constr_info constr = Sym.Map.find constr gl.datatype_constrs in
   (* get the argument types of the constructor *)
   let constr_argTs constrs_nms =
-    List.map (fun (_, bt) -> bt_to_coq_ir gl bt) constrs_nms
+    List.map (fun (_, bt) -> bt_to_itp_ir gl bt) constrs_nms
   in
   let constrs =
     List.map
-      (fun c -> CI.Coq_constr (CI.Coq_sym c, constr_argTs (constr_info c).params))
+      (fun c -> CI.ITP_constr (CI.ITP_sym c, constr_argTs (constr_info c).params))
       dt_info.constrs
   in
-  CI.Coq_dt (CI.Coq_sym nm, dt_args, constrs)
+  CI.ITP_dt (CI.ITP_sym nm, dt_args, constrs)
 
 
-let dtypes_to_coq_ir (gl : Global.t) (dtyps : Sym.t list list) =
+let dtypes_to_itp_ir (gl : Global.t) (dtyps : Sym.t list list) =
   (* translate one particular clump of mutually recursive definitoins *)
-  let dtype_clump_to_coq_ir (gl : Global.t) (nms : Sym.t list) =
-    List.map (dt_to_coq_ir gl) nms
+  let dtype_clump_to_itp_ir (gl : Global.t) (nms : Sym.t list) =
+    List.map (dt_to_itp_ir gl) nms
   in
   (* wrap them all together into a big list of lists *)
-  List.map (dtype_clump_to_coq_ir gl) dtyps
+  List.map (dtype_clump_to_itp_ir gl) dtyps
 
 
 let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (ys : 'a list) =
@@ -125,214 +125,214 @@ let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (ys : 'a list) =
   | Some (i, _) -> (i, List.length ys)
 
 
-(* translate index terms to coq_ir *)
-let it_to_coq_ir global it b =
+(* translate index terms to itp_ir *)
+let it_to_itp_ir global it b =
   let rec f comp_bool it =
     let aux t = f comp_bool t in
     let enc_prop = Option.is_none comp_bool in
     let with_is_true =
       enc_prop && BaseTypes.equal (Terms.Normal.get_bt it) BaseTypes.Bool
     in
-    let bt = bt_to_coq_ir global (Terms.Normal.get_bt it) in
+    let bt = bt_to_itp_ir global (Terms.Normal.get_bt it) in
     match Terms.Normal.get_term it with
-    | Terms.Sym s -> CI.Coq_sym_term (CI.Coq_sym s)
+    | Terms.Sym s -> CI.ITP_sym_term (CI.ITP_sym s)
     | Terms.Const l ->
       (match l with
        | Terms.Bool b ->
          if with_is_true then
-           CI.Coq_const (CI.Coq_bool_prop b)
+           CI.ITP_const (CI.ITP_bool_prop b)
          else
-           CI.Coq_const (CI.Coq_bool b)
-       | Terms.Z z -> CI.Coq_const (CI.Coq_Z z)
-       | Terms.Bits (info, z) -> CI.Coq_const (CI.Coq_bits (BT.normalise_to_range info z))
-       | Terms.Q _ -> CI.Coq_unsupported "Unsupported const Q"
-       | Terms.MemByte _ -> CI.Coq_unsupported "Unsupported const membyte"
-       | Terms.Pointer _ -> CI.Coq_unsupported "Unsupported const pointer"
-       | Terms.Alloc_id _ -> CI.Coq_unsupported "Unsupported const alloc_id"
-       | Terms.Unit -> CI.Coq_unsupported "Unsupported const unit"
-       | Terms.Null -> CI.Coq_const (CI.Coq_Z Z.zero)
-       | Terms.CType_const _ -> CI.Coq_unsupported "Unsupported const ctype"
-       | Terms.Default _ -> CI.Coq_unsupported "Unsupported const default")
+           CI.ITP_const (CI.ITP_bool b)
+       | Terms.Z z -> CI.ITP_const (CI.ITP_Z z)
+       | Terms.Bits (info, z) -> CI.ITP_const (CI.ITP_bits (BT.normalise_to_range info z))
+       | Terms.Q _ -> CI.ITP_unsupported "Unsupported const Q"
+       | Terms.MemByte _ -> CI.ITP_unsupported "Unsupported const membyte"
+       | Terms.Pointer _ -> CI.ITP_unsupported "Unsupported const pointer"
+       | Terms.Alloc_id _ -> CI.ITP_unsupported "Unsupported const alloc_id"
+       | Terms.Unit -> CI.ITP_unsupported "Unsupported const unit"
+       | Terms.Null -> CI.ITP_const (CI.ITP_Z Z.zero)
+       | Terms.CType_const _ -> CI.ITP_unsupported "Unsupported const ctype"
+       | Terms.Default _ -> CI.ITP_unsupported "Unsupported const default")
     | Terms.Unop (op, a) ->
       let x = aux a in
       (match op with
        | Terms.Not ->
          if enc_prop then
-           CI.Coq_unop (CI.Coq_neg_prop, x, bt)
+           CI.ITP_unop (CI.ITP_neg_prop, x, bt)
          else
-           CI.Coq_unop (CI.Coq_neg, x, bt)
-       | Terms.BW_FFS_NoSMT -> CI.Coq_unop (CI.Coq_BW_FFS_NoSMT, x, bt)
-       | Terms.BW_CTZ_NoSMT -> CI.Coq_unop (CI.Coq_BW_CTZ_NoSMT, x, bt)
-       | _ -> CI.Coq_unsupported "Unsupported unop")
+           CI.ITP_unop (CI.ITP_neg, x, bt)
+       | Terms.BW_FFS_NoSMT -> CI.ITP_unop (CI.ITP_BW_FFS_NoSMT, x, bt)
+       | Terms.BW_CTZ_NoSMT -> CI.ITP_unop (CI.ITP_BW_CTZ_NoSMT, x, bt)
+       | _ -> CI.ITP_unsupported "Unsupported unop")
     | Terms.Binop (op, a, b) ->
       let x = aux a in
       let y = aux b in
       (match op with
-       | Add -> CI.Coq_binop (CI.Coq_add, x, y, bt)
-       | Sub -> CI.Coq_binop (CI.Coq_sub, x, y, bt)
-       | Mul -> CI.Coq_binop (CI.Coq_mul, x, y, bt)
-       | MulNoSMT -> CI.Coq_binop (CI.Coq_mul, x, y, bt)
-       | Div -> CI.Coq_binop (CI.Coq_div, x, y, bt)
-       | DivNoSMT -> CI.Coq_binop (CI.Coq_div, x, y, bt)
-       | Mod -> CI.Coq_binop (CI.Coq_mod, x, y, bt)
-       | ModNoSMT -> CI.Coq_binop (CI.Coq_mod, x, y, bt)
+       | Add -> CI.ITP_binop (CI.ITP_add, x, y, bt)
+       | Sub -> CI.ITP_binop (CI.ITP_sub, x, y, bt)
+       | Mul -> CI.ITP_binop (CI.ITP_mul, x, y, bt)
+       | MulNoSMT -> CI.ITP_binop (CI.ITP_mul, x, y, bt)
+       | Div -> CI.ITP_binop (CI.ITP_div, x, y, bt)
+       | DivNoSMT -> CI.ITP_binop (CI.ITP_div, x, y, bt)
+       | Mod -> CI.ITP_binop (CI.ITP_mod, x, y, bt)
+       | ModNoSMT -> CI.ITP_binop (CI.ITP_mod, x, y, bt)
        (* TODO: this can't be right: mod and rem aren't the same
-      - maybe they have the same semantics as Coq Z.modulo/Z.rem *)
-       | Rem -> CI.Coq_binop (CI.Coq_rem, x, y, bt)
-       | RemNoSMT -> CI.Coq_binop (CI.Coq_mod, x, y, bt)
+      - maybe they have the same semantics as ITP Z.modulo/Z.rem *)
+       | Rem -> CI.ITP_binop (CI.ITP_rem, x, y, bt)
+       | RemNoSMT -> CI.ITP_binop (CI.ITP_mod, x, y, bt)
        | LT ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_lt_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_lt, x, y, bt)
+           CI.ITP_binop (CI.ITP_lt, x, y, bt)
        | LE ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_le_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_le, x, y, bt)
-       | Exp -> CI.Coq_binop (CI.Coq_exp, x, y, bt)
-       | ExpNoSMT -> CI.Coq_binop (CI.Coq_exp, x, y, bt)
-       | BW_Xor -> CI.Coq_binop (CI.Coq_bwxor, x, y, bt)
-       | BW_And -> CI.Coq_binop (CI.Coq_bwand, x, y, bt)
-       | BW_Or -> CI.Coq_binop (CI.Coq_bwor, x, y, bt)
+           CI.ITP_binop (CI.ITP_le, x, y, bt)
+       | Exp -> CI.ITP_binop (CI.ITP_exp, x, y, bt)
+       | ExpNoSMT -> CI.ITP_binop (CI.ITP_exp, x, y, bt)
+       | BW_Xor -> CI.ITP_binop (CI.ITP_bwxor, x, y, bt)
+       | BW_And -> CI.ITP_binop (CI.ITP_bwand, x, y, bt)
+       | BW_Or -> CI.ITP_binop (CI.ITP_bwor, x, y, bt)
        | EQ ->
          let comp = Some (it, "argument of equality") in
          if enc_prop then
-           CI.Coq_binop (CI.Coq_eq_prop, f comp a, f comp b, bt)
+           CI.ITP_binop (CI.ITP_eq_prop, f comp a, f comp b, bt)
          else
-           CI.Coq_binop (CI.Coq_eq, f comp a, f comp b, bt)
+           CI.ITP_binop (CI.ITP_eq, f comp a, f comp b, bt)
        | LEPointer ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_le_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_le, x, y, bt)
+           CI.ITP_binop (CI.ITP_le, x, y, bt)
        | LTPointer ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_lt_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_lt, x, y, bt)
+           CI.ITP_binop (CI.ITP_lt, x, y, bt)
        | And ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_and_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_and_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_and, x, y, bt)
+           CI.ITP_binop (CI.ITP_and, x, y, bt)
        | Or ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_or_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_or_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_or, x, y, bt)
+           CI.ITP_binop (CI.ITP_or, x, y, bt)
        | Implies ->
          if enc_prop then
-           CI.Coq_binop (CI.Coq_impl_prop, x, y, bt)
+           CI.ITP_binop (CI.ITP_impl_prop, x, y, bt)
          else
-           CI.Coq_binop (CI.Coq_impl, x, y, bt)
-       | _ -> CI.Coq_unsupported "Unsupported binop")
+           CI.ITP_binop (CI.ITP_impl, x, y, bt)
+       | _ -> CI.ITP_unsupported "Unsupported binop")
     | Terms.Match (x, cases) ->
       let comp = Some (it, "case-discriminant") in
-      let br (pat, rhs) = (pat_to_coq_ir pat, aux rhs) in
-      CI.Coq_match (f comp x, List.map br cases)
+      let br (pat, rhs) = (pat_to_itp_ir pat, aux rhs) in
+      CI.ITP_match (f comp x, List.map br cases)
     | Terms.ITE (sw, x, y) ->
       let comp = Some (it, "if-condition") in
-      CI.Coq_ite (f comp sw, aux x, aux y)
+      CI.ITP_ite (f comp sw, aux x, aux y)
     | Terms.EachI ((i1, (s, t), i2), x) ->
-      CI.Coq_eachI ((i1, (CI.Coq_sym s, bt_to_coq_ir global t), i2), aux x)
-    | Terms.MapSet (m, x, y) -> CI.Coq_mapset (aux m, aux x, aux y)
-    | Terms.MapGet (m, x) -> CI.Coq_mapget (aux m, aux x)
+      CI.ITP_eachI ((i1, (CI.ITP_sym s, bt_to_itp_ir global t), i2), aux x)
+    | Terms.MapSet (m, x, y) -> CI.ITP_mapset (aux m, aux x, aux y)
+    | Terms.MapGet (m, x) -> CI.ITP_mapget (aux m, aux x)
     | Terms.RecordMember (t, m) ->
       let flds = BT.record_bt (Terms.Normal.get_bt t) in
       let ix = find_tuple_element Id.equal m (List.map fst flds) in
-      CI.Coq_recordmember (aux t, CI.Coq_id m, ix)
+      CI.ITP_recordmember (aux t, CI.ITP_id m, ix)
     | Terms.RecordUpdate ((t, m), x) ->
       let flds = BT.record_bt (Terms.Normal.get_bt t) in
       let ix = find_tuple_element Id.equal m (List.map fst flds) in
-      CI.Coq_recordupdate ((aux t, CI.Coq_id m), aux x, ix)
-    | Terms.Record mems -> CI.Coq_record (List.map aux (List.map snd mems))
+      CI.ITP_recordupdate ((aux t, CI.ITP_id m), aux x, ix)
+    | Terms.Record mems -> CI.ITP_record (List.map aux (List.map snd mems))
     | Terms.StructMember (t, m) ->
       let tag = BaseTypes.struct_bt (Terms.Normal.get_bt t) in
       let mems, _bts = get_struct_xs global.struct_decls tag in
       let ix = find_tuple_element Id.equal m mems in
-      CI.Coq_structmember (aux t, CI.Coq_id m, ix)
+      CI.ITP_structmember (aux t, CI.ITP_id m, ix)
     | Terms.StructUpdate ((t, m), x) ->
       let tag = BaseTypes.struct_bt (Terms.Normal.get_bt t) in
       let mems, _bts = get_struct_xs global.struct_decls tag in
       let ix = find_tuple_element Id.equal m mems in
-      CI.Coq_structupdate ((aux t, CI.Coq_id m), aux x, ix)
-    | Terms.Cast (cbt, t) -> CI.Coq_cast (bt_to_coq_ir global cbt, aux t)
+      CI.ITP_structupdate ((aux t, CI.ITP_id m), aux x, ix)
+    | Terms.Cast (cbt, t) -> CI.ITP_cast (bt_to_itp_ir global cbt, aux t)
     | Terms.Apply (name, args) ->
       let prop_ret = fun_prop_ret global name in
       let body_aux = f (if prop_ret then None else Some (it, "fun-arg")) in
       if prop_ret then
-        CI.Coq_apply_prop (CI.Coq_sym name, List.map body_aux args)
+        CI.ITP_apply_prop (CI.ITP_sym name, List.map body_aux args)
       else
-        CI.Coq_apply (CI.Coq_sym name, List.map body_aux args)
-    | Terms.Good (_, t) -> CI.Coq_good (aux t)
+        CI.ITP_apply (CI.ITP_sym name, List.map body_aux args)
+    | Terms.Good (_, t) -> CI.ITP_good (aux t)
     | Terms.Representable (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
       (match Sctypes.is_struct_ctype ct with
        | Some s ->
-         CI.Coq_representable (CI.Coq_sym s, CI.Coq_Struct (CI.Coq_sym s, []), aux t2)
+         CI.ITP_representable (CI.ITP_sym s, CI.ITP_Struct (CI.ITP_sym s, []), aux t2)
        | None ->
-         CI.Coq_unsupported "Unsupported representable (why are we in the None case?)")
+         CI.ITP_unsupported "Unsupported representable (why are we in the None case?)")
     | Terms.Constructor (nm, id_args) ->
       let comp = Some (it, "datatype contents") in
       (* assuming here that the id's are in canonical order *)
-      CI.Coq_constructor (CI.Coq_sym nm, List.map (fun x -> f comp (snd x)) id_args)
+      CI.ITP_constructor (CI.ITP_sym nm, List.map (fun x -> f comp (snd x)) id_args)
     | Terms.WrapI (ity, arg) ->
       let maxInt = Memory.max_integer_type ity in
       let minInt = Memory.min_integer_type ity in
-      CI.Coq_wrapI (maxInt, minInt, aux arg)
-    | Terms.Let ((nm, x), y) -> CI.Coq_let (CI.Coq_sym nm, aux x, aux y)
+      CI.ITP_wrapI (maxInt, minInt, aux arg)
+    | Terms.Let ((nm, x), y) -> CI.ITP_let (CI.ITP_sym nm, aux x, aux y)
     | Terms.ArrayShift { base; ct; index } ->
       let size_of_ct = Z.of_int @@ Memory.size_of_ctype ct in
       (* do a + b * c*)
-      CI.Coq_arrayshift (aux base, size_of_ct, aux index)
-    | Terms.Tuple _ -> CI.Coq_unsupported "Unsupported tuple"
-    | Terms.NthTuple (_, _) -> CI.Coq_unsupported "Unsupported nth tuple"
-    | Terms.Struct (_, _) -> CI.Coq_unsupported "Unsupported struct"
-    | Terms.MemberShift _ -> CI.Coq_unsupported "Unsupported member shift"
-    | Terms.CopyAllocId _ -> CI.Coq_unsupported "Unsupported copy alloc id"
-    | Terms.HasAllocId _ -> CI.Coq_unsupported "Unsupported has alloc id"
-    | Terms.SizeOf _ -> CI.Coq_unsupported "Unsupported size of"
-    | Terms.OffsetOf (_, _) -> CI.Coq_unsupported "Unsupported offset of"
-    | Terms.Nil _ -> CI.Coq_unsupported "Unsupported nil"
-    | Terms.Cons (_, _) -> CI.Coq_unsupported "Unsupported cons"
-    | Terms.Head _ -> CI.Coq_unsupported "Unsupported head"
-    | Terms.Tail _ -> CI.Coq_unsupported "Unsupported tail"
-    | Terms.Representable (_, _) -> CI.Coq_unsupported "Unsupported representable"
-    | Terms.Aligned _ -> CI.Coq_unsupported "Unsupported aligned"
-    | Terms.MapConst (_, _) -> CI.Coq_unsupported "Unsupported map const"
-    | Terms.MapDef (_, _) -> CI.Coq_unsupported "Unsupported map def"
+      CI.ITP_arrayshift (aux base, size_of_ct, aux index)
+    | Terms.Tuple _ -> CI.ITP_unsupported "Unsupported tuple"
+    | Terms.NthTuple (_, _) -> CI.ITP_unsupported "Unsupported nth tuple"
+    | Terms.Struct (_, _) -> CI.ITP_unsupported "Unsupported struct"
+    | Terms.MemberShift _ -> CI.ITP_unsupported "Unsupported member shift"
+    | Terms.CopyAllocId _ -> CI.ITP_unsupported "Unsupported copy alloc id"
+    | Terms.HasAllocId _ -> CI.ITP_unsupported "Unsupported has alloc id"
+    | Terms.SizeOf _ -> CI.ITP_unsupported "Unsupported size of"
+    | Terms.OffsetOf (_, _) -> CI.ITP_unsupported "Unsupported offset of"
+    | Terms.Nil _ -> CI.ITP_unsupported "Unsupported nil"
+    | Terms.Cons (_, _) -> CI.ITP_unsupported "Unsupported cons"
+    | Terms.Head _ -> CI.ITP_unsupported "Unsupported head"
+    | Terms.Tail _ -> CI.ITP_unsupported "Unsupported tail"
+    | Terms.Representable (_, _) -> CI.ITP_unsupported "Unsupported representable"
+    | Terms.Aligned _ -> CI.ITP_unsupported "Unsupported aligned"
+    | Terms.MapConst (_, _) -> CI.ITP_unsupported "Unsupported map const"
+    | Terms.MapDef (_, _) -> CI.ITP_unsupported "Unsupported map def"
     | Terms.CN_None _ | Terms.CN_Some _ | Terms.IsSome _ | Terms.GetOpt _ ->
-      CI.Coq_unsupported "Unsupported map def" (* TODO(HK): added for plumbing *)
+      CI.ITP_unsupported "Unsupported map def" (* TODO(HK): added for plumbing *)
   in
   f b it
 
 
 (* unpacking LogicalConstraints *)
-let lc_to_coq_ir (gl : Global.t) (t : LC.t) =
+let lc_to_itp_ir (gl : Global.t) (t : LC.t) =
   match t with
-  | LC.T t -> CI.Coq_pure (it_to_coq_ir gl t None)
+  | LC.T t -> CI.ITP_pure (it_to_itp_ir gl t None)
   | LC.Forall ((sym, bt), it) ->
-    CI.Coq_forall
-      (CI.Coq_sym sym, bt_to_coq_ir gl bt, CI.Coq_pure (it_to_coq_ir gl it None))
+    CI.ITP_forall
+      (CI.ITP_sym sym, bt_to_itp_ir gl bt, CI.ITP_pure (it_to_itp_ir gl it None))
 
 
 (* TODO(HK): added this auxiliary function for plumbing *)
-let q_step_to_coq_ir (step : Sctypes.t) : CI.coq_term =
-  CI.Coq_const (CI.Coq_Z (Z.of_int (Memory.size_of_ctype step)))
+let q_step_to_itp_ir (step : Sctypes.t) : CI.itp_term =
+  CI.ITP_const (CI.ITP_Z (Z.of_int (Memory.size_of_ctype step)))
 
 
 (* Unpacking LogicalReturnTypes *)
-let rec lrt_to_coq_ir (gl : Global.t) (t : LRT.t) =
+let rec lrt_to_itp_ir (gl : Global.t) (t : LRT.t) =
   match t with
   | LRT.Constraint (lc, _, t) ->
-    let d = lrt_to_coq_ir gl t in
-    let c = lc_to_coq_ir gl lc in
-    CI.Coq_Constraint_LRT (c, d)
+    let d = lrt_to_itp_ir gl t in
+    let c = lc_to_itp_ir gl lc in
+    CI.ITP_Constraint_LRT (c, d)
   | LRT.Define ((sym, it), _, t) ->
-    let d = lrt_to_coq_ir gl t in
-    let l = it_to_coq_ir gl it None in
-    CI.Coq_let (CI.Coq_sym sym, l, d)
-  | LRT.I -> CI.Coq_LRT_I
+    let d = lrt_to_itp_ir gl t in
+    let l = it_to_itp_ir gl it None in
+    CI.ITP_let (CI.ITP_sym sym, l, d)
+  | LRT.I -> CI.ITP_LRT_I
   | LRT.Resource ((nm, (req, bt)), _, t) ->
     (match req with
      | P p ->
@@ -340,57 +340,57 @@ let rec lrt_to_coq_ir (gl : Global.t) (t : LRT.t) =
         | Owned (_, init) ->
           (match init with
            | Init ->
-             Coq_Owned_LRT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (lrt_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None,
-                 List.map (fun x -> it_to_coq_ir gl x None) p.iargs )
+             ITP_Owned_LRT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (lrt_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None,
+                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
            | Uninit ->
-             Coq_Block_LRT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (lrt_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None ))
+             ITP_Block_LRT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (lrt_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None ))
         | PName p_nm ->
-          Coq_PName_LRT
-            ( CI.Coq_sym nm,
-              CI.Coq_sym p_nm,
-              bt_to_coq_ir gl bt,
-              lrt_to_coq_ir gl t,
-              List.map (fun x -> it_to_coq_ir gl x None) p.iargs,
-              it_to_coq_ir gl p.pointer None ))
+          ITP_PName_LRT
+            ( CI.ITP_sym nm,
+              CI.ITP_sym p_nm,
+              bt_to_itp_ir gl bt,
+              lrt_to_itp_ir gl t,
+              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
+              it_to_itp_ir gl p.pointer None ))
      | Q q ->
        (match q.name with
         | Owned _ ->
-          CI.Coq_Each_LRT
-            ( CI.Coq_sym nm,
-              CI.Coq_sym (fst q.q),
+          CI.ITP_Each_LRT
+            ( CI.ITP_sym nm,
+              CI.ITP_sym (fst q.q),
               (* q name *)
-              bt_to_coq_ir gl (snd q.q),
+              bt_to_itp_ir gl (snd q.q),
               (* q value type *)
-              it_to_coq_ir gl q.pointer None,
+              it_to_itp_ir gl q.pointer None,
               (* pointer *)
-              q_step_to_coq_ir q.step,
+              q_step_to_itp_ir q.step,
               (* step *)
-              it_to_coq_ir gl q.permission None,
+              it_to_itp_ir gl q.permission None,
               (* permission *)
-              lrt_to_coq_ir gl t )
-        | PName _ -> CI.Coq_unsupported "unsupported Qpred PName in LRT"))
+              lrt_to_itp_ir gl t )
+        | PName _ -> CI.ITP_unsupported "unsupported Qpred PName in LRT"))
 
 
 (* Unpacking LogicalArgumentTypes that wrap IndexTerms (i.e. in resource predicates) *)
-let rec it_lat_to_coq_ir (gl : Global.t) (t : Terms.Normal.t LAT.t) =
+let rec it_lat_to_itp_ir (gl : Global.t) (t : Terms.Normal.t LAT.t) =
   match t with
   | LAT.Define ((sym, it), _, t) ->
-    let d = it_lat_to_coq_ir gl t in
-    let l = it_to_coq_ir gl it None in
-    CI.Coq_Define (CI.Coq_sym sym, l, d)
+    let d = it_lat_to_itp_ir gl t in
+    let l = it_to_itp_ir gl it None in
+    CI.ITP_Define (CI.ITP_sym sym, l, d)
   | LAT.Constraint (lc, _, t) ->
-    let c = lc_to_coq_ir gl lc in
-    let d = it_lat_to_coq_ir gl t in
-    CI.Coq_Constraint_LAT (c, d)
-  | LAT.I t -> CI.Coq_LAT_I (it_to_coq_ir gl t None)
+    let c = lc_to_itp_ir gl lc in
+    let d = it_lat_to_itp_ir gl t in
+    CI.ITP_Constraint_LAT (c, d)
+  | LAT.I t -> CI.ITP_LAT_I (it_to_itp_ir gl t None)
   | LAT.Resource ((nm, (req, bt)), _, t) ->
     (match req with
      | P p ->
@@ -398,45 +398,45 @@ let rec it_lat_to_coq_ir (gl : Global.t) (t : Terms.Normal.t LAT.t) =
         | Owned (_, init) ->
           (match init with
            | Init ->
-             Coq_Owned_LAT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (it_lat_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None,
-                 List.map (fun x -> it_to_coq_ir gl x None) p.iargs )
+             ITP_Owned_LAT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (it_lat_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None,
+                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
            | Uninit ->
-             Coq_Block_LAT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (it_lat_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None ))
+             ITP_Block_LAT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (it_lat_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None ))
         | PName p_nm ->
-          Coq_PName_LAT
-            ( CI.Coq_sym nm,
-              CI.Coq_sym p_nm,
-              bt_to_coq_ir gl bt,
-              it_lat_to_coq_ir gl t,
-              List.map (fun x -> it_to_coq_ir gl x None) p.iargs,
-              it_to_coq_ir gl p.pointer None ))
+          ITP_PName_LAT
+            ( CI.ITP_sym nm,
+              CI.ITP_sym p_nm,
+              bt_to_itp_ir gl bt,
+              it_lat_to_itp_ir gl t,
+              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
+              it_to_itp_ir gl p.pointer None ))
      (* Can iterated resources even appear here? *)
      | Q q ->
        (match q.name with
-        | Owned _ -> CI.Coq_unsupported "unsupported Qpred Owned in LRT"
-        | PName _ -> CI.Coq_unsupported "unsupported Qpred PName in LRT"))
+        | Owned _ -> CI.ITP_unsupported "unsupported Qpred Owned in LRT"
+        | PName _ -> CI.ITP_unsupported "unsupported Qpred PName in LRT"))
 
 
 (* Unpacking LogicalArgumentTypes that wrap LogicalReturnTypes *)
-let rec lrtlat_to_coq_ir (gl : Global.t) t =
+let rec lrtlat_to_itp_ir (gl : Global.t) t =
   match t with
   | LAT.Define ((sym, it), _, t) ->
-    let d = lrtlat_to_coq_ir gl t in
-    let l = it_to_coq_ir gl it None in
-    CI.Coq_Define (CI.Coq_sym sym, l, d)
+    let d = lrtlat_to_itp_ir gl t in
+    let l = it_to_itp_ir gl it None in
+    CI.ITP_Define (CI.ITP_sym sym, l, d)
   | LAT.Constraint (lc, _, t) ->
-    let c = lc_to_coq_ir gl lc in
-    let d = lrtlat_to_coq_ir gl t in
-    CI.Coq_Constraint_LAT (c, d)
-  | LAT.I t -> lrt_to_coq_ir gl t
+    let c = lc_to_itp_ir gl lc in
+    let d = lrtlat_to_itp_ir gl t in
+    CI.ITP_Constraint_LAT (c, d)
+  | LAT.I t -> lrt_to_itp_ir gl t
   | LAT.Resource ((nm, (req, bt)), _, t) ->
     (match req with
      | P p ->
@@ -444,129 +444,129 @@ let rec lrtlat_to_coq_ir (gl : Global.t) t =
         | Owned (_, init) ->
           (match init with
            | Init ->
-             Coq_Owned_LAT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (lrtlat_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None,
-                 List.map (fun x -> it_to_coq_ir gl x None) p.iargs )
+             ITP_Owned_LAT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (lrtlat_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None,
+                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
            | Uninit ->
-             Coq_Block_LAT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (lrtlat_to_coq_ir gl t),
-                 it_to_coq_ir gl p.pointer None ))
+             ITP_Block_LAT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (lrtlat_to_itp_ir gl t),
+                 it_to_itp_ir gl p.pointer None ))
         | PName p_nm ->
-          Coq_PName_LAT
-            ( CI.Coq_sym nm,
-              CI.Coq_sym p_nm,
-              bt_to_coq_ir gl bt,
-              lrtlat_to_coq_ir gl t,
-              List.map (fun x -> it_to_coq_ir gl x None) p.iargs,
-              it_to_coq_ir gl p.pointer None ))
+          ITP_PName_LAT
+            ( CI.ITP_sym nm,
+              CI.ITP_sym p_nm,
+              bt_to_itp_ir gl bt,
+              lrtlat_to_itp_ir gl t,
+              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
+              it_to_itp_ir gl p.pointer None ))
      | Q q ->
        (match q.name with
         | Owned (_, init) ->
           (match init with
            | Init ->
-             CI.Coq_Each_LAT
-               ( CI.Coq_sym nm,
-                 CI.Coq_sym (fst q.q),
+             CI.ITP_Each_LAT
+               ( CI.ITP_sym nm,
+                 CI.ITP_sym (fst q.q),
                  (* q name *)
-                 bt_to_coq_ir gl (snd q.q),
+                 bt_to_itp_ir gl (snd q.q),
                  (* q value type *)
-                 it_to_coq_ir gl q.pointer None,
+                 it_to_itp_ir gl q.pointer None,
                  (* pointer *)
-                 q_step_to_coq_ir q.step,
+                 q_step_to_itp_ir q.step,
                  (* step *)
-                 it_to_coq_ir gl q.permission None,
+                 it_to_itp_ir gl q.permission None,
                  (* permission *)
-                 lrtlat_to_coq_ir gl t )
+                 lrtlat_to_itp_ir gl t )
            | Uninit ->
-             Coq_Block_LAT
-               ( CI.Coq_sym nm,
-                 bt_to_coq_ir gl bt,
-                 CI.Iris_term (lrtlat_to_coq_ir gl t),
-                 it_to_coq_ir gl q.pointer None ))
+             ITP_Block_LAT
+               ( CI.ITP_sym nm,
+                 bt_to_itp_ir gl bt,
+                 CI.Iris_term (lrtlat_to_itp_ir gl t),
+                 it_to_itp_ir gl q.pointer None ))
           (* todo: Each stuff*)
-        | PName _ -> Coq_unsupported "unsupported Qpred PName in LRT"))
+        | PName _ -> ITP_unsupported "unsupported Qpred PName in LRT"))
 
 
 (* Main translation function for lemmas *)
-let rec lemmat_to_coq_ir (gl : Global.t) (ftyp : AT.lemmat) =
+let rec lemmat_to_itp_ir (gl : Global.t) (ftyp : AT.lemmat) =
   match ftyp with
   | AT.Computational ((sym, bt), _, t) | AT.Ghost ((sym, bt), _, t) ->
-    let d = lemmat_to_coq_ir gl t in
-    CI.Coq_forall (CI.Coq_sym sym, bt_to_coq_ir gl bt, d)
-  | AT.L t -> lrtlat_to_coq_ir gl t
+    let d = lemmat_to_itp_ir gl t in
+    CI.ITP_forall (CI.ITP_sym sym, bt_to_itp_ir gl bt, d)
+  | AT.L t -> lrtlat_to_itp_ir gl t
 
 
 (* Translating all functions for the global typing context *)
-let fun_to_coq_ir (gl : Global.t) nm =
+let fun_to_itp_ir (gl : Global.t) nm =
   let open Definition.Function in
   let def = Sym.Map.find nm gl.logical_functions in
-  let arg_tys = List.map (fun (nm, bt) -> (CI.Coq_sym nm, bt_to_coq_ir gl bt)) def.args in
+  let arg_tys = List.map (fun (nm, bt) -> (CI.ITP_sym nm, bt_to_itp_ir gl bt)) def.args in
   match def.body with
   | Uninterp ->
     if fun_prop_ret gl nm then
-      CI.Coq_fun_uninterp
-        (CI.Coq_sym nm, CI.Coq_uninterp_prop, arg_tys, bt_to_coq_ir gl def.return_bt)
+      CI.ITP_fun_uninterp
+        (CI.ITP_sym nm, CI.ITP_uninterp_prop, arg_tys, bt_to_itp_ir gl def.return_bt)
     else
-      CI.Coq_fun_uninterp
-        (CI.Coq_sym nm, CI.Coq_uninterp, arg_tys, bt_to_coq_ir gl def.return_bt)
+      CI.ITP_fun_uninterp
+        (CI.ITP_sym nm, CI.ITP_uninterp, arg_tys, bt_to_itp_ir gl def.return_bt)
   | Def body ->
-    CI.Coq_fun_def
-      ( CI.Coq_sym nm,
-        CI.Coq_def (it_to_coq_ir gl body (Some (body, "logical fun def"))),
+    CI.ITP_fun_def
+      ( CI.ITP_sym nm,
+        CI.ITP_def (it_to_itp_ir gl body (Some (body, "logical fun def"))),
         arg_tys,
-        bt_to_coq_ir gl def.return_bt )
+        bt_to_itp_ir gl def.return_bt )
   | Rec_Def body ->
-    CI.Coq_fun_def
-      ( CI.Coq_sym nm,
-        CI.Coq_recdef (it_to_coq_ir gl body (Some (body, "logical fun recdef"))),
+    CI.ITP_fun_def
+      ( CI.ITP_sym nm,
+        CI.ITP_recdef (it_to_itp_ir gl body (Some (body, "logical fun recdef"))),
         arg_tys,
-        bt_to_coq_ir gl def.return_bt )
+        bt_to_itp_ir gl def.return_bt )
 
 
-let logical_funs_to_coq_ir (gl : Global.t) (funs : Sym.t list list) =
-  let logicalfun_clump_to_coq_ir (gl : Global.t) (nms : Sym.t list) =
-    List.map (fun_to_coq_ir gl) nms
+let logical_funs_to_itp_ir (gl : Global.t) (funs : Sym.t list list) =
+  let logicalfun_clump_to_itp_ir (gl : Global.t) (nms : Sym.t list) =
+    List.map (fun_to_itp_ir gl) nms
   in
   let is_uninterp a =
-    match a with CI.Coq_fun_uninterp _ -> true | CI.Coq_fun_def _ -> false
+    match a with CI.ITP_fun_uninterp _ -> true | CI.ITP_fun_def _ -> false
   in
-  let translated_funs = List.map (logicalfun_clump_to_coq_ir gl) funs in
+  let translated_funs = List.map (logicalfun_clump_to_itp_ir gl) funs in
   ( List.filter (fun x -> is_uninterp (List.hd x)) translated_funs,
     List.filter (fun x -> not (is_uninterp (List.hd x))) translated_funs )
 
 
 (* Translating all resource predicates for the global typing context *)
 
-let pred_to_coq_ir (gl : Global.t) (nm : Sym.t) =
+let pred_to_itp_ir (gl : Global.t) (nm : Sym.t) =
   let open Definition.Predicate in
   let pred = Sym.Map.find nm gl.resource_predicates in
   let translate_one_clause (clause : Definition.Clause.t) =
-    CI.Coq_clause
-      ([ it_to_coq_ir gl clause.guard None ], it_lat_to_coq_ir gl clause.packing_ft)
+    CI.ITP_clause
+      ([ it_to_itp_ir gl clause.guard None ], it_lat_to_itp_ir gl clause.packing_ft)
   in
-  let args = List.map (fun (nm, bt) -> (CI.Coq_sym nm, bt_to_coq_ir gl bt)) pred.iargs in
+  let args = List.map (fun (nm, bt) -> (CI.ITP_sym nm, bt_to_itp_ir gl bt)) pred.iargs in
   (* distinguishing between defined and uninterpreted predicates *)
   match pred.clauses with
   | Some clauses ->
     Either.Left
-      ( CI.Coq_sym nm,
-        CI.Coq_sym pred.pointer,
+      ( CI.ITP_sym nm,
+        CI.ITP_sym pred.pointer,
         args,
-        bt_to_coq_ir gl (snd pred.oarg),
+        bt_to_itp_ir gl (snd pred.oarg),
         List.map translate_one_clause clauses )
   | None ->
     Either.Right
-      (CI.Coq_sym nm, CI.Coq_sym pred.pointer, args, bt_to_coq_ir gl (snd pred.oarg))
+      (CI.ITP_sym nm, CI.ITP_sym pred.pointer, args, bt_to_itp_ir gl (snd pred.oarg))
 
 
-let resource_pred_to_coq_ir (gl : Global.t) (preds : Sym.t list list) =
-  let rpred_clump_to_coq_ir (gl : Global.t) (nms : Sym.t list) =
-    let translated = List.map (pred_to_coq_ir gl) nms in
+let resource_pred_to_itp_ir (gl : Global.t) (preds : Sym.t list list) =
+  let rpred_clump_to_itp_ir (gl : Global.t) (nms : Sym.t list) =
+    let translated = List.map (pred_to_itp_ir gl) nms in
     match translated with
     | Either.Left _ :: _ ->
       (* check if all clauses are left as well*)
@@ -583,40 +583,40 @@ let resource_pred_to_coq_ir (gl : Global.t) (preds : Sym.t list list) =
       Stdlib.Either.Right (nm, ptr, args, ret_bt)
     | _ -> failwith "Unexpected predicate structure"
   in
-  List.partition_map (rpred_clump_to_coq_ir gl) preds
+  List.partition_map (rpred_clump_to_itp_ir gl) preds
 
 
-(* translate the whole global context to coq_ir *)
+(* translate the whole global context to itp_ir *)
 
-let cn_to_coq_ir (global : Global.t) (lemmata : (Sym.t * (Loc.t * AT.lemmat)) list) =
+let cn_to_itp_ir (global : Global.t) (lemmata : (Sym.t * (Loc.t * AT.lemmat)) list) =
   (* 1. Translate the datatypes *)
   let translated_dtypes =
     if Option.is_some global.datatype_order then
-      dtypes_to_coq_ir global (Option.get global.datatype_order)
+      dtypes_to_itp_ir global (Option.get global.datatype_order)
     else
       []
   in
   (* 2. Translate the logical functions *)
   let translated_logical_funs =
     if Option.is_some global.logical_function_order then
-      logical_funs_to_coq_ir global (Option.get global.logical_function_order)
+      logical_funs_to_itp_ir global (Option.get global.logical_function_order)
     else
       ([], [])
   in
   (* 3. Translate the resource predicates (todo) *)
   let translated_pred_groups, translated_uninterp_preds =
     if Option.is_some global.resource_predicate_order then
-      resource_pred_to_coq_ir global (Option.get global.resource_predicate_order)
+      resource_pred_to_itp_ir global (Option.get global.resource_predicate_order)
     else
       ([], [])
   in
   (* 4. Translate the lemma statement *)
   let translate_lemmas ((sym : Sym.t), (_, lemmat)) =
-    let d = lemmat_to_coq_ir global lemmat in
-    CI.Coq_lemma (CI.Coq_sym sym, d)
+    let d = lemmat_to_itp_ir global lemmat in
+    CI.ITP_lemma (CI.ITP_sym sym, d)
   in
   (* gives a list of pairs: (lemma name, translated lemma)*)
-  CI.Coq_gl
+  CI.ITP_gl
     ( translated_dtypes,
       translated_logical_funs,
       translated_pred_groups,

--- a/lib/cn_to_coq.ml
+++ b/lib/cn_to_coq.ml
@@ -108,23 +108,15 @@ let find_tuple_element (eq : 'a -> 'a -> bool) (x : 'a) (ys : 'a list) =
 
 
 (* translate index terms to itp_ir *)
-let it_to_itp_ir global it b =
-  let rec f comp_bool it =
-    let aux t = f comp_bool t in
-    let enc_prop = Option.is_none comp_bool in
-    let with_is_true =
-      enc_prop && BaseTypes.equal (Terms.Normal.get_bt it) BaseTypes.Bool
-    in
+let it_to_itp_ir global it =
+  let rec f it =
+    let aux t = f t in
     let bt = bt_to_itp_ir global (Terms.Normal.get_bt it) in
     match Terms.Normal.get_term it with
     | Terms.Sym s -> CI.ITP_sym_term (CI.ITP_sym s)
     | Terms.Const l ->
       (match l with
-       | Terms.Bool b ->
-         if with_is_true then
-           CI.ITP_const (CI.ITP_bool_prop b)
-         else
-           CI.ITP_const (CI.ITP_bool b)
+       | Terms.Bool b -> CI.ITP_const (CI.ITP_bool_prop b)
        | Terms.Z z -> CI.ITP_const (CI.ITP_Z z)
        | Terms.Bits (info, z) -> CI.ITP_const (CI.ITP_bits (BT.normalise_to_range info z))
        | Terms.Q _ -> CI.ITP_unsupported "Unsupported const Q"
@@ -138,11 +130,7 @@ let it_to_itp_ir global it b =
     | Terms.Unop (op, a) ->
       let x = aux a in
       (match op with
-       | Terms.Not ->
-         if enc_prop then
-           CI.ITP_unop (CI.ITP_neg_prop, x, bt)
-         else
-           CI.ITP_unop (CI.ITP_neg, x, bt)
+       | Terms.Not -> CI.ITP_unop (CI.ITP_neg_prop, x, bt)
        | Terms.BW_FFS_NoSMT -> CI.ITP_unop (CI.ITP_BW_FFS_NoSMT, x, bt)
        | Terms.BW_CTZ_NoSMT -> CI.ITP_unop (CI.ITP_BW_CTZ_NoSMT, x, bt)
        | _ -> CI.ITP_unsupported "Unsupported unop")
@@ -162,60 +150,24 @@ let it_to_itp_ir global it b =
       - maybe they have the same semantics as ITP Z.modulo/Z.rem *)
        | Rem -> CI.ITP_binop (CI.ITP_rem, x, y, bt)
        | RemNoSMT -> CI.ITP_binop (CI.ITP_mod, x, y, bt)
-       | LT ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_lt, x, y, bt)
-       | LE ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_le, x, y, bt)
+       | LT -> CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
+       | LE -> CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
        | Exp -> CI.ITP_binop (CI.ITP_exp, x, y, bt)
        | ExpNoSMT -> CI.ITP_binop (CI.ITP_exp, x, y, bt)
        | BW_Xor -> CI.ITP_binop (CI.ITP_bwxor, x, y, bt)
        | BW_And -> CI.ITP_binop (CI.ITP_bwand, x, y, bt)
        | BW_Or -> CI.ITP_binop (CI.ITP_bwor, x, y, bt)
-       | EQ ->
-         let comp = Some (it, "argument of equality") in
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_eq_prop, f comp a, f comp b, bt)
-         else
-           CI.ITP_binop (CI.ITP_eq, f comp a, f comp b, bt)
-       | LEPointer ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_le, x, y, bt)
-       | LTPointer ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_lt, x, y, bt)
-       | And ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_and_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_and, x, y, bt)
-       | Or ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_or_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_or, x, y, bt)
-       | Implies ->
-         if enc_prop then
-           CI.ITP_binop (CI.ITP_impl_prop, x, y, bt)
-         else
-           CI.ITP_binop (CI.ITP_impl, x, y, bt)
+       | EQ -> CI.ITP_binop (CI.ITP_eq_prop, f a, f b, bt)
+       | LEPointer -> CI.ITP_binop (CI.ITP_le_prop, x, y, bt)
+       | LTPointer -> CI.ITP_binop (CI.ITP_lt_prop, x, y, bt)
+       | And -> CI.ITP_binop (CI.ITP_and_prop, x, y, bt)
+       | Or -> CI.ITP_binop (CI.ITP_or_prop, x, y, bt)
+       | Implies -> CI.ITP_binop (CI.ITP_impl_prop, x, y, bt)
        | _ -> CI.ITP_unsupported "Unsupported binop")
     | Terms.Match (x, cases) ->
-      let comp = Some (it, "case-discriminant") in
       let br (pat, rhs) = (pat_to_itp_ir pat, aux rhs) in
-      CI.ITP_match (f comp x, List.map br cases)
-    | Terms.ITE (sw, x, y) ->
-      let comp = Some (it, "if-condition") in
-      CI.ITP_ite (f comp sw, aux x, aux y)
+      CI.ITP_match (f x, List.map br cases)
+    | Terms.ITE (sw, x, y) -> CI.ITP_ite (f sw, aux x, aux y)
     | Terms.EachI ((i1, (s, t), i2), x) ->
       CI.ITP_eachI ((i1, (CI.ITP_sym s, bt_to_itp_ir global t), i2), aux x)
     | Terms.MapSet (m, x, y) -> CI.ITP_mapset (aux m, aux x, aux y)
@@ -240,7 +192,7 @@ let it_to_itp_ir global it b =
       let ix = find_tuple_element Id.equal m mems in
       CI.ITP_structupdate ((aux t, CI.ITP_id m), aux x, ix)
     | Terms.Cast (cbt, t) -> CI.ITP_cast (bt_to_itp_ir global cbt, aux t)
-    | Terms.Apply (name, args) -> CI.ITP_apply (CI.ITP_sym name, List.map aux args)
+    | Terms.Apply (name, args) -> CI.ITP_apply_prop (CI.ITP_sym name, List.map aux args)
     | Terms.Good (_, t) -> CI.ITP_good (aux t)
     | Terms.Representable (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
       (match Sctypes.is_struct_ctype ct with
@@ -249,9 +201,8 @@ let it_to_itp_ir global it b =
        | None ->
          CI.ITP_unsupported "Unsupported representable (why are we in the None case?)")
     | Terms.Constructor (nm, id_args) ->
-      let comp = Some (it, "datatype contents") in
       (* assuming here that the id's are in canonical order *)
-      CI.ITP_constructor (CI.ITP_sym nm, List.map (fun x -> f comp (snd x)) id_args)
+      CI.ITP_constructor (CI.ITP_sym nm, List.map (fun x -> f (snd x)) id_args)
     | Terms.WrapI (ity, arg) ->
       let maxInt = Memory.max_integer_type ity in
       let minInt = Memory.min_integer_type ity in
@@ -280,16 +231,16 @@ let it_to_itp_ir global it b =
     | Terms.CN_None _ | Terms.CN_Some _ | Terms.IsSome _ | Terms.GetOpt _ ->
       CI.ITP_unsupported "Unsupported map def" (* TODO(HK): added for plumbing *)
   in
-  f b it
+  f it
 
 
 (* unpacking LogicalConstraints *)
 let lc_to_itp_ir (gl : Global.t) (t : LC.t) =
   match t with
-  | LC.T t -> CI.ITP_pure (it_to_itp_ir gl t None)
+  | LC.T t -> CI.ITP_pure (it_to_itp_ir gl t)
   | LC.Forall ((sym, bt), it) ->
     CI.ITP_forall
-      (CI.ITP_sym sym, bt_to_itp_ir gl bt, CI.ITP_pure (it_to_itp_ir gl it None))
+      (CI.ITP_sym sym, bt_to_itp_ir gl bt, CI.ITP_pure (it_to_itp_ir gl it))
 
 
 (* TODO(HK): added this auxiliary function for plumbing *)
@@ -306,7 +257,7 @@ let rec lrt_to_itp_ir (gl : Global.t) (t : LRT.t) =
     CI.ITP_Constraint_LRT (c, d)
   | LRT.Define ((sym, it), _, t) ->
     let d = lrt_to_itp_ir gl t in
-    let l = it_to_itp_ir gl it None in
+    let l = it_to_itp_ir gl it in
     CI.ITP_let (CI.ITP_sym sym, l, d)
   | LRT.I -> CI.ITP_LRT_I
   | LRT.Resource ((nm, (req, bt)), _, t) ->
@@ -320,22 +271,22 @@ let rec lrt_to_itp_ir (gl : Global.t) (t : LRT.t) =
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (lrt_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None,
-                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
+                 it_to_itp_ir gl p.pointer,
+                 List.map (fun x -> it_to_itp_ir gl x) p.iargs )
            | Uninit ->
              ITP_Block_LRT
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (lrt_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None ))
+                 it_to_itp_ir gl p.pointer))
         | PName p_nm ->
           ITP_PName_LRT
             ( CI.ITP_sym nm,
               CI.ITP_sym p_nm,
               bt_to_itp_ir gl bt,
               lrt_to_itp_ir gl t,
-              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
-              it_to_itp_ir gl p.pointer None ))
+              List.map (fun x -> it_to_itp_ir gl x) p.iargs,
+              it_to_itp_ir gl p.pointer))
      | Q q ->
        (match q.name with
         | Owned _ ->
@@ -345,11 +296,11 @@ let rec lrt_to_itp_ir (gl : Global.t) (t : LRT.t) =
               (* q name *)
               bt_to_itp_ir gl (snd q.q),
               (* q value type *)
-              it_to_itp_ir gl q.pointer None,
+              it_to_itp_ir gl q.pointer,
               (* pointer *)
               q_step_to_itp_ir q.step,
               (* step *)
-              it_to_itp_ir gl q.permission None,
+              it_to_itp_ir gl q.permission,
               (* permission *)
               lrt_to_itp_ir gl t )
         | PName _ -> CI.ITP_unsupported "unsupported Qpred PName in LRT"))
@@ -360,13 +311,13 @@ let rec it_lat_to_itp_ir (gl : Global.t) (t : Terms.Normal.t LAT.t) =
   match t with
   | LAT.Define ((sym, it), _, t) ->
     let d = it_lat_to_itp_ir gl t in
-    let l = it_to_itp_ir gl it None in
+    let l = it_to_itp_ir gl it in
     CI.ITP_Define (CI.ITP_sym sym, l, d)
   | LAT.Constraint (lc, _, t) ->
     let c = lc_to_itp_ir gl lc in
     let d = it_lat_to_itp_ir gl t in
     CI.ITP_Constraint_LAT (c, d)
-  | LAT.I t -> CI.ITP_LAT_I (it_to_itp_ir gl t None)
+  | LAT.I t -> CI.ITP_LAT_I (it_to_itp_ir gl t)
   | LAT.Resource ((nm, (req, bt)), _, t) ->
     (match req with
      | P p ->
@@ -378,22 +329,22 @@ let rec it_lat_to_itp_ir (gl : Global.t) (t : Terms.Normal.t LAT.t) =
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (it_lat_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None,
-                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
+                 it_to_itp_ir gl p.pointer,
+                 List.map (fun x -> it_to_itp_ir gl x) p.iargs )
            | Uninit ->
              ITP_Block_LAT
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (it_lat_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None ))
+                 it_to_itp_ir gl p.pointer))
         | PName p_nm ->
           ITP_PName_LAT
             ( CI.ITP_sym nm,
               CI.ITP_sym p_nm,
               bt_to_itp_ir gl bt,
               it_lat_to_itp_ir gl t,
-              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
-              it_to_itp_ir gl p.pointer None ))
+              List.map (fun x -> it_to_itp_ir gl x) p.iargs,
+              it_to_itp_ir gl p.pointer))
      (* Can iterated resources even appear here? *)
      | Q q ->
        (match q.name with
@@ -406,7 +357,7 @@ let rec lrtlat_to_itp_ir (gl : Global.t) t =
   match t with
   | LAT.Define ((sym, it), _, t) ->
     let d = lrtlat_to_itp_ir gl t in
-    let l = it_to_itp_ir gl it None in
+    let l = it_to_itp_ir gl it in
     CI.ITP_Define (CI.ITP_sym sym, l, d)
   | LAT.Constraint (lc, _, t) ->
     let c = lc_to_itp_ir gl lc in
@@ -424,22 +375,22 @@ let rec lrtlat_to_itp_ir (gl : Global.t) t =
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (lrtlat_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None,
-                 List.map (fun x -> it_to_itp_ir gl x None) p.iargs )
+                 it_to_itp_ir gl p.pointer,
+                 List.map (fun x -> it_to_itp_ir gl x) p.iargs )
            | Uninit ->
              ITP_Block_LAT
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (lrtlat_to_itp_ir gl t),
-                 it_to_itp_ir gl p.pointer None ))
+                 it_to_itp_ir gl p.pointer))
         | PName p_nm ->
           ITP_PName_LAT
             ( CI.ITP_sym nm,
               CI.ITP_sym p_nm,
               bt_to_itp_ir gl bt,
               lrtlat_to_itp_ir gl t,
-              List.map (fun x -> it_to_itp_ir gl x None) p.iargs,
-              it_to_itp_ir gl p.pointer None ))
+              List.map (fun x -> it_to_itp_ir gl x) p.iargs,
+              it_to_itp_ir gl p.pointer))
      | Q q ->
        (match q.name with
         | Owned (_, init) ->
@@ -451,11 +402,11 @@ let rec lrtlat_to_itp_ir (gl : Global.t) t =
                  (* q name *)
                  bt_to_itp_ir gl (snd q.q),
                  (* q value type *)
-                 it_to_itp_ir gl q.pointer None,
+                 it_to_itp_ir gl q.pointer,
                  (* pointer *)
                  q_step_to_itp_ir q.step,
                  (* step *)
-                 it_to_itp_ir gl q.permission None,
+                 it_to_itp_ir gl q.permission,
                  (* permission *)
                  lrtlat_to_itp_ir gl t )
            | Uninit ->
@@ -463,7 +414,7 @@ let rec lrtlat_to_itp_ir (gl : Global.t) t =
                ( CI.ITP_sym nm,
                  bt_to_itp_ir gl bt,
                  CI.Iris_term (lrtlat_to_itp_ir gl t),
-                 it_to_itp_ir gl q.pointer None ))
+                 it_to_itp_ir gl q.pointer))
           (* todo: Each stuff*)
         | PName _ -> ITP_unsupported "unsupported Qpred PName in LRT"))
 
@@ -485,17 +436,17 @@ let fun_to_itp_ir (gl : Global.t) nm =
   match def.body with
   | Uninterp ->
     CI.ITP_fun_uninterp
-      ( CI.ITP_sym nm, CI.ITP_uninterp, arg_tys, bt_to_itp_ir gl def.return_bt)
+      ( CI.ITP_sym nm, CI.ITP_uninterp_prop, arg_tys, bt_to_itp_ir gl def.return_bt)
   | Def body ->
     CI.ITP_fun_def
       ( CI.ITP_sym nm,
-        CI.ITP_def (it_to_itp_ir gl body (Some (body, "logical fun def"))),
+        CI.ITP_def (it_to_itp_ir gl body),
         arg_tys,
         bt_to_itp_ir gl def.return_bt )
   | Rec_Def body ->
     CI.ITP_fun_def
       ( CI.ITP_sym nm,
-        CI.ITP_recdef (it_to_itp_ir gl body (Some (body, "logical fun recdef"))),
+        CI.ITP_recdef (it_to_itp_ir gl body),
         arg_tys,
         bt_to_itp_ir gl def.return_bt )
 
@@ -519,7 +470,7 @@ let pred_to_itp_ir (gl : Global.t) (nm : Sym.t) =
   let pred = Sym.Map.find nm gl.resource_predicates in
   let translate_one_clause (clause : Definition.Clause.t) =
     CI.ITP_clause
-      ([ it_to_itp_ir gl clause.guard None ], it_lat_to_itp_ir gl clause.packing_ft)
+      ([ it_to_itp_ir gl clause.guard], it_lat_to_itp_ir gl clause.packing_ft)
   in
   let args = List.map (fun (nm, bt) -> (CI.ITP_sym nm, bt_to_itp_ir gl bt)) pred.iargs in
   (* distinguishing between defined and uninterpreted predicates *)

--- a/lib/cn_to_coq.ml
+++ b/lib/cn_to_coq.ml
@@ -20,24 +20,6 @@ let rec pat_to_itp_ir pat =
   | Terms.Pat (Terms.PConstructor (c_nm, id_ps), _, _) ->
     CI.ITP_pConstructor (CI.ITP_sym c_nm, List.map (fun x -> pat_to_itp_ir (snd x)) id_ps)
 
-
-(* assuming here that the id's are in canonical order *)
-
-(* set of functions with boolean return type that we want to use
-   as toplevel propositions, i.e. return Prop rather than bool
-   (computational) in ITP. *)
-let prop_funs = StringSet.of_list [ "page_group_ok" ]
-
-let fun_prop_ret (global : Global.t) nm =
-  match Sym.Map.find_opt nm global.logical_functions with
-  (* todo: the None case shouldn't be possible since the CN code must be well-formed *)
-  | None -> true
-  | Some def ->
-    let open Definition.Function in
-    BaseTypes.equal BaseTypes.Bool def.return_bt
-    && StringSet.mem (Sym.pp_string nm) prop_funs
-
-
 let struct_layout_field_bts xs =
   let open Memory in
   let xs2 =
@@ -258,13 +240,7 @@ let it_to_itp_ir global it b =
       let ix = find_tuple_element Id.equal m mems in
       CI.ITP_structupdate ((aux t, CI.ITP_id m), aux x, ix)
     | Terms.Cast (cbt, t) -> CI.ITP_cast (bt_to_itp_ir global cbt, aux t)
-    | Terms.Apply (name, args) ->
-      let prop_ret = fun_prop_ret global name in
-      let body_aux = f (if prop_ret then None else Some (it, "fun-arg")) in
-      if prop_ret then
-        CI.ITP_apply_prop (CI.ITP_sym name, List.map body_aux args)
-      else
-        CI.ITP_apply (CI.ITP_sym name, List.map body_aux args)
+    | Terms.Apply (name, args) -> CI.ITP_apply (CI.ITP_sym name, List.map aux args)
     | Terms.Good (_, t) -> CI.ITP_good (aux t)
     | Terms.Representable (ct, t2) when Option.is_some (Sctypes.is_struct_ctype ct) ->
       (match Sctypes.is_struct_ctype ct with
@@ -508,12 +484,8 @@ let fun_to_itp_ir (gl : Global.t) nm =
   let arg_tys = List.map (fun (nm, bt) -> (CI.ITP_sym nm, bt_to_itp_ir gl bt)) def.args in
   match def.body with
   | Uninterp ->
-    if fun_prop_ret gl nm then
-      CI.ITP_fun_uninterp
-        (CI.ITP_sym nm, CI.ITP_uninterp_prop, arg_tys, bt_to_itp_ir gl def.return_bt)
-    else
-      CI.ITP_fun_uninterp
-        (CI.ITP_sym nm, CI.ITP_uninterp, arg_tys, bt_to_itp_ir gl def.return_bt)
+    CI.ITP_fun_uninterp
+      ( CI.ITP_sym nm, CI.ITP_uninterp, arg_tys, bt_to_itp_ir gl def.return_bt)
   | Def body ->
     CI.ITP_fun_def
       ( CI.ITP_sym nm,

--- a/lib/cn_to_coq.ml
+++ b/lib/cn_to_coq.ml
@@ -436,7 +436,7 @@ let fun_to_itp_ir (gl : Global.t) nm =
   match def.body with
   | Uninterp ->
     CI.ITP_fun_uninterp
-      ( CI.ITP_sym nm, CI.ITP_uninterp_prop, arg_tys, bt_to_itp_ir gl def.return_bt)
+      ( CI.ITP_sym nm, arg_tys, bt_to_itp_ir gl def.return_bt)
   | Def body ->
     CI.ITP_fun_def
       ( CI.ITP_sym nm,

--- a/lib/coq_ir.ml
+++ b/lib/coq_ir.ml
@@ -3,174 +3,174 @@ module AT = ArgumentTypes
 
 (* CN primitives *)
 
-type coq_sym = Coq_sym of Sym.t
+type itp_sym = ITP_sym of Sym.t
 
-type coq_id = Coq_id of Id.t
+type itp_id = ITP_id of Id.t
 
-type coq_sign =
-  | Coq_Signed
-  | Coq_Unsigned
+type itp_sign =
+  | ITP_Signed
+  | ITP_Unsigned
 
 (* CN BaseTypes*)
 
-type coq_bt =
-  | Coq_Bool
-  | Coq_Integer
-  | Coq_Bits of coq_sign * int
-  | Coq_Map of coq_bt * coq_bt
-  | Coq_Struct of coq_sym * coq_bt list
-  | Coq_Record of coq_bt list
-  | Coq_Loc
-  | Coq_Datatype of coq_sym
-  | Coq_List of coq_bt
-  | Coq_Unit
-  | Coq_Membyte
-  | Coq_Real
-  | Coq_Alloc_id
-  | Coq_CType
-  | Coq_Tuple of coq_bt list
-  | Coq_Set of coq_bt
+type itp_bt =
+  | ITP_Bool
+  | ITP_Integer
+  | ITP_Bits of itp_sign * int
+  | ITP_Map of itp_bt * itp_bt
+  | ITP_Struct of itp_sym * itp_bt list
+  | ITP_Record of itp_bt list
+  | ITP_Loc
+  | ITP_Datatype of itp_sym
+  | ITP_List of itp_bt
+  | ITP_Unit
+  | ITP_Membyte
+  | ITP_Real
+  | ITP_Alloc_id
+  | ITP_CType
+  | ITP_Tuple of itp_bt list
+  | ITP_Set of itp_bt
 
 (* CN IndexTerms *)
 
-type coq_pat =
-  | Coq_pSym of coq_sym
-  | Coq_pWild
-  | Coq_pConstructor of coq_sym * coq_pat list
+type itp_pat =
+  | ITP_pSym of itp_sym
+  | ITP_pWild
+  | ITP_pConstructor of itp_sym * itp_pat list
 
-type coq_const =
-  | Coq_bool of bool
-  | Coq_bool_prop of bool
-  | Coq_Z of Z.t
-  | Coq_bits of Z.t
+type itp_const =
+  | ITP_bool of bool
+  | ITP_bool_prop of bool
+  | ITP_Z of Z.t
+  | ITP_bits of Z.t
 
-type coq_unop =
-  | Coq_neg
-  | Coq_neg_prop
-  | Coq_BW_FFS_NoSMT
-  | Coq_BW_CTZ_NoSMT
+type itp_unop =
+  | ITP_neg
+  | ITP_neg_prop
+  | ITP_BW_FFS_NoSMT
+  | ITP_BW_CTZ_NoSMT
 
-type coq_binop =
-  | Coq_add
-  | Coq_sub
-  | Coq_mul
-  | Coq_div
-  | Coq_mod
-  | Coq_rem
-  | Coq_lt
-  | Coq_lt_prop
-  | Coq_le
-  | Coq_le_prop
-  | Coq_exp
-  | Coq_bwxor
-  | Coq_bwand
-  | Coq_bwor
-  | Coq_eq
-  | Coq_eq_prop
-  | Coq_and
-  | Coq_and_prop
-  | Coq_or
-  | Coq_or_prop
-  | Coq_impl
-  | Coq_impl_prop
+type itp_binop =
+  | ITP_add
+  | ITP_sub
+  | ITP_mul
+  | ITP_div
+  | ITP_mod
+  | ITP_rem
+  | ITP_lt
+  | ITP_lt_prop
+  | ITP_le
+  | ITP_le_prop
+  | ITP_exp
+  | ITP_bwxor
+  | ITP_bwand
+  | ITP_bwor
+  | ITP_eq
+  | ITP_eq_prop
+  | ITP_and
+  | ITP_and_prop
+  | ITP_or
+  | ITP_or_prop
+  | ITP_impl
+  | ITP_impl_prop
 
-type coq_term =
-  | Coq_sym_term of coq_sym
-  | Coq_const of coq_const
-  | Coq_unop of coq_unop * coq_term * coq_bt
-  | Coq_binop of coq_binop * coq_term * coq_term * coq_bt
-  | Coq_match of coq_term * (coq_pat * coq_term) list
-  | Coq_ite of coq_term * coq_term * coq_term
-  | Coq_eachI of (int * (coq_sym * coq_bt) * int) * coq_term
-  | Coq_mapset of coq_term * coq_term * coq_term
-  | Coq_mapget of coq_term * coq_term
+type itp_term =
+  | ITP_sym_term of itp_sym
+  | ITP_const of itp_const
+  | ITP_unop of itp_unop * itp_term * itp_bt
+  | ITP_binop of itp_binop * itp_term * itp_term * itp_bt
+  | ITP_match of itp_term * (itp_pat * itp_term) list
+  | ITP_ite of itp_term * itp_term * itp_term
+  | ITP_eachI of (int * (itp_sym * itp_bt) * int) * itp_term
+  | ITP_mapset of itp_term * itp_term * itp_term
+  | ITP_mapget of itp_term * itp_term
     (* the (int * int) gives the position of an element *)
-  | Coq_recordmember of coq_term * coq_id * (int * int)
-  | Coq_recordupdate of (coq_term * coq_id) * coq_term * (int * int)
-  | Coq_record of coq_term list
-  | Coq_structmember of coq_term * coq_id * (int * int)
-  | Coq_structupdate of (coq_term * coq_id) * coq_term * (int * int)
-  | Coq_cast of coq_bt * coq_term
-  | Coq_apply of coq_sym * coq_term list
-  | Coq_apply_prop of coq_sym * coq_term list
-  | Coq_good of coq_term (*| Coq_good of coq_sym * coq_bt * coq_term*)
-  | Coq_representable of coq_sym * coq_bt * coq_term
-  | Coq_constructor of coq_sym * coq_term list
-  | Coq_nthlist of coq_term * coq_term * coq_term
-  | Coq_arraytolist of coq_term * coq_term * coq_term
-  | Coq_let of coq_sym * coq_term * coq_term
-  | Coq_wrapI of Z.t * Z.t * coq_term
-  | Coq_arrayshift of coq_term * Z.t * coq_term
-  | Coq_unsupported of string
-  | Coq_forall of coq_sym * coq_bt * coq_term
-  | Coq_Define of coq_sym * coq_term * coq_term
-  | Coq_Constraint_LRT of coq_term * coq_term
-  | Coq_Constraint_LAT of coq_term * coq_term
-  | Coq_LAT_I of coq_term
-  | Coq_LRT_I
-  | Coq_Owned_LRT of coq_sym * coq_bt * iris_term * coq_term * coq_term list
-  | Coq_Block_LRT of coq_sym * coq_bt * iris_term * coq_term
-  | Coq_Owned_LAT of coq_sym * coq_bt * iris_term * coq_term * coq_term list
-  | Coq_Block_LAT of coq_sym * coq_bt * iris_term * coq_term
-  | Coq_PName_LAT of coq_sym * coq_sym * coq_bt * coq_term * coq_term list * coq_term
-  | Coq_PName_LRT of coq_sym * coq_sym * coq_bt * coq_term * coq_term list * coq_term
-  | Coq_Each_LAT of coq_sym * coq_sym * coq_bt * coq_term * coq_term * coq_term * coq_term
-  | Coq_Each_LRT of coq_sym * coq_sym * coq_bt * coq_term * coq_term * coq_term * coq_term
-  | Coq_pure of coq_term
+  | ITP_recordmember of itp_term * itp_id * (int * int)
+  | ITP_recordupdate of (itp_term * itp_id) * itp_term * (int * int)
+  | ITP_record of itp_term list
+  | ITP_structmember of itp_term * itp_id * (int * int)
+  | ITP_structupdate of (itp_term * itp_id) * itp_term * (int * int)
+  | ITP_cast of itp_bt * itp_term
+  | ITP_apply of itp_sym * itp_term list
+  | ITP_apply_prop of itp_sym * itp_term list
+  | ITP_good of itp_term (*| ITP_good of itp_sym * itp_bt * itp_term*)
+  | ITP_representable of itp_sym * itp_bt * itp_term
+  | ITP_constructor of itp_sym * itp_term list
+  | ITP_nthlist of itp_term * itp_term * itp_term
+  | ITP_arraytolist of itp_term * itp_term * itp_term
+  | ITP_let of itp_sym * itp_term * itp_term
+  | ITP_wrapI of Z.t * Z.t * itp_term
+  | ITP_arrayshift of itp_term * Z.t * itp_term
+  | ITP_unsupported of string
+  | ITP_forall of itp_sym * itp_bt * itp_term
+  | ITP_Define of itp_sym * itp_term * itp_term
+  | ITP_Constraint_LRT of itp_term * itp_term
+  | ITP_Constraint_LAT of itp_term * itp_term
+  | ITP_LAT_I of itp_term
+  | ITP_LRT_I
+  | ITP_Owned_LRT of itp_sym * itp_bt * iris_term * itp_term * itp_term list
+  | ITP_Block_LRT of itp_sym * itp_bt * iris_term * itp_term
+  | ITP_Owned_LAT of itp_sym * itp_bt * iris_term * itp_term * itp_term list
+  | ITP_Block_LAT of itp_sym * itp_bt * iris_term * itp_term
+  | ITP_PName_LAT of itp_sym * itp_sym * itp_bt * itp_term * itp_term list * itp_term
+  | ITP_PName_LRT of itp_sym * itp_sym * itp_bt * itp_term * itp_term list * itp_term
+  | ITP_Each_LAT of itp_sym * itp_sym * itp_bt * itp_term * itp_term * itp_term * itp_term
+  | ITP_Each_LRT of itp_sym * itp_sym * itp_bt * itp_term * itp_term * itp_term * itp_term
+  | ITP_pure of itp_term
 
-and iris_term = Iris_term of coq_term
+and iris_term = Iris_term of itp_term
 
 (* CN datatypes *)
-(* note: this is different from Coq_Datatype in coq_term *)
-type coq_constr = Coq_constr of coq_sym * coq_bt list
+(* note: this is different from ITP_Datatype in itp_term *)
+type itp_constr = ITP_constr of itp_sym * itp_bt list
 
-type coq_dt =
+type itp_dt =
   (* parameters: name, list of argument types, list of constructors *)
-  | Coq_dt of coq_sym * coq_bt list * coq_constr list
+  | ITP_dt of itp_sym * itp_bt list * itp_constr list
 
 (* CN logical functions *)
-type coq_uninterp =
-  | Coq_uninterp
-  | Coq_uninterp_prop
+type itp_uninterp =
+  | ITP_uninterp
+  | ITP_uninterp_prop
 
-type coq_def =
-  | Coq_def of coq_term
-  | Coq_recdef of coq_term
+type itp_def =
+  | ITP_def of itp_term
+  | ITP_recdef of itp_term
 
-type coq_fun =
+type itp_fun =
   (* parameters: function name, function body, argument typess, return type*)
-  | Coq_fun_uninterp of coq_sym * coq_uninterp * (coq_sym * coq_bt) list * coq_bt
-  | Coq_fun_def of coq_sym * coq_def * (coq_sym * coq_bt) list * coq_bt
+  | ITP_fun_uninterp of itp_sym * itp_uninterp * (itp_sym * itp_bt) list * itp_bt
+  | ITP_fun_def of itp_sym * itp_def * (itp_sym * itp_bt) list * itp_bt
 
 (* CN resource predicates *)
-type coq_clause =
+type itp_clause =
   (* parameters : guard, clause body *)
-  | Coq_clause of coq_term list * coq_term
+  | ITP_clause of itp_term list * itp_term
 
-type coq_resource_pred =
-  { name : coq_sym;
-    ptr : coq_sym;
-    args : (coq_sym * coq_bt) list;
-    ret_bt : coq_bt;
-    clauses : coq_clause list
+type itp_resource_pred =
+  { name : itp_sym;
+    ptr : itp_sym;
+    args : (itp_sym * itp_bt) list;
+    ret_bt : itp_bt;
+    clauses : itp_clause list
   }
 
 (* Group of mutually recursive resource predicates *)
-type coq_resource_pred_group = coq_resource_pred list
+type itp_resource_pred_group = itp_resource_pred list
 
-type coq_uinterp_resource_pred = coq_sym * coq_sym * (coq_sym * coq_bt) list * coq_bt
+type itp_uinterp_resource_pred = itp_sym * itp_sym * (itp_sym * itp_bt) list * itp_bt
 
 (* CN lemmas *)
-type coq_lemma =
+type itp_lemma =
   (* parameters: lemma name, lemma body *)
-  | Coq_lemma of coq_sym * coq_term
+  | ITP_lemma of itp_sym * itp_term
 
 (* The entire CN global typing context, plus lemma statements *)
-type coq_gl =
-  | Coq_gl of
-      coq_dt list list
+type itp_gl =
+  | ITP_gl of
+      itp_dt list list
       (* uninterpreted functions and defined functions*)
-      * (coq_fun list list * coq_fun list list)
-      * coq_resource_pred_group list
-      * coq_uinterp_resource_pred list
-      * coq_lemma list
+      * (itp_fun list list * itp_fun list list)
+      * itp_resource_pred_group list
+      * itp_uinterp_resource_pred list
+      * itp_lemma list

--- a/lib/coq_ir.ml
+++ b/lib/coq_ir.ml
@@ -39,13 +39,11 @@ type itp_pat =
   | ITP_pConstructor of itp_sym * itp_pat list
 
 type itp_const =
-  | ITP_bool of bool
   | ITP_bool_prop of bool
   | ITP_Z of Z.t
   | ITP_bits of Z.t
 
 type itp_unop =
-  | ITP_neg
   | ITP_neg_prop
   | ITP_BW_FFS_NoSMT
   | ITP_BW_CTZ_NoSMT
@@ -57,21 +55,15 @@ type itp_binop =
   | ITP_div
   | ITP_mod
   | ITP_rem
-  | ITP_lt
   | ITP_lt_prop
-  | ITP_le
   | ITP_le_prop
   | ITP_exp
   | ITP_bwxor
   | ITP_bwand
   | ITP_bwor
-  | ITP_eq
   | ITP_eq_prop
-  | ITP_and
   | ITP_and_prop
-  | ITP_or
   | ITP_or_prop
-  | ITP_impl
   | ITP_impl_prop
 
 type itp_term =
@@ -91,7 +83,6 @@ type itp_term =
   | ITP_structmember of itp_term * itp_id * (int * int)
   | ITP_structupdate of (itp_term * itp_id) * itp_term * (int * int)
   | ITP_cast of itp_bt * itp_term
-  | ITP_apply of itp_sym * itp_term list
   | ITP_apply_prop of itp_sym * itp_term list
   | ITP_good of itp_term (*| ITP_good of itp_sym * itp_bt * itp_term*)
   | ITP_representable of itp_sym * itp_bt * itp_term
@@ -130,7 +121,6 @@ type itp_dt =
 
 (* CN logical functions *)
 type itp_uninterp =
-  | ITP_uninterp
   | ITP_uninterp_prop
 
 type itp_def =

--- a/lib/coq_ir.ml
+++ b/lib/coq_ir.ml
@@ -119,17 +119,13 @@ type itp_dt =
   (* parameters: name, list of argument types, list of constructors *)
   | ITP_dt of itp_sym * itp_bt list * itp_constr list
 
-(* CN logical functions *)
-type itp_uninterp =
-  | ITP_uninterp_prop
-
 type itp_def =
   | ITP_def of itp_term
   | ITP_recdef of itp_term
 
 type itp_fun =
   (* parameters: function name, function body, argument typess, return type*)
-  | ITP_fun_uninterp of itp_sym * itp_uninterp * (itp_sym * itp_bt) list * itp_bt
+  | ITP_fun_uninterp of itp_sym * (itp_sym * itp_bt) list * itp_bt
   | ITP_fun_def of itp_sym * itp_def * (itp_sym * itp_bt) list * itp_bt
 
 (* CN resource predicates *)

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -7,7 +7,7 @@ module CC = Cn_to_coq
 
 let ret_sym = "ν"
 
-(* Printing headers for each module in the Coq file *)
+(* Printing headers for each module in the ITP file *)
 
 let parse_directions directions = (directions, StringSet.singleton "all")
 
@@ -240,10 +240,10 @@ let binop s x y =
   parens (flow (break 1) [ x; !^s; y ])
 
 
-let tuple_coq_ty doc fld_tys =
+let tuple_itp_ty doc fld_tys =
   let open Pp in
   let rec stars = function
-    | [] -> fail "tuple_coq_ty: empty" doc
+    | [] -> fail "tuple_itp_ty: empty" doc
     | [ x ] -> [ x ]
     | x :: xs -> x :: star :: stars xs
   in
@@ -262,33 +262,33 @@ let gen_get_upd ((i, list_len) : int * int) (tm : PPrint.document) =
     pp_snd (foldi (list_len - 1 - i) pp_fst tm)
 
 
-(* CN BaseTypes to Coq *)
-let rec bt_to_coq (bt : CI.coq_bt) =
+(* CN BaseTypes to ITP *)
+let rec bt_to_itp (bt : CI.itp_bt) =
   let open Pp in
   match bt with
-  | CI.Coq_Bool -> !^"bool"
-  | CI.Coq_Integer -> !^"Z"
-  | CI.Coq_Bits _ -> !^"Z"
-  | CI.Coq_Map (x, y) ->
-    let enc_x = bt_to_coq x in
-    let enc_y = bt_to_coq y in
+  | CI.ITP_Bool -> !^"bool"
+  | CI.ITP_Integer -> !^"Z"
+  | CI.ITP_Bits _ -> !^"Z"
+  | CI.ITP_Map (x, y) ->
+    let enc_x = bt_to_itp x in
+    let enc_y = bt_to_itp y in
     parens (binop "->" enc_x enc_y)
-  | CI.Coq_Struct (CI.Coq_sym tag, _) -> Sym.pp tag
-  | CI.Coq_Record mems ->
-    let enc_mem_bts = List.map bt_to_coq mems in
-    tuple_coq_ty !^"record" enc_mem_bts
-  | CI.Coq_Loc -> !^"Ptr"
-  | CI.Coq_Datatype (CI.Coq_sym tag) -> Sym.pp tag
-  | CI.Coq_List _bt2 -> !^"list " ^^ bt_to_coq _bt2
-  | CI.Coq_Unit -> !^"unsupported BT unit"
-  | CI.Coq_Membyte -> !^"unsupported BT membyte"
-  | CI.Coq_Real -> !^"unsupported BT real"
-  | CI.Coq_Alloc_id -> !^"unsupported BT alloc_id"
-  | CI.Coq_CType -> !^"unsupported BT ctype"
-  | CI.Coq_Tuple fld_bts ->
-    let enc_fld_bts = List.map bt_to_coq fld_bts in
-    tuple_coq_ty !^"" enc_fld_bts
-  | CI.Coq_Set _bt2 -> rets "unsupported BT set"
+  | CI.ITP_Struct (CI.ITP_sym tag, _) -> Sym.pp tag
+  | CI.ITP_Record mems ->
+    let enc_mem_bts = List.map bt_to_itp mems in
+    tuple_itp_ty !^"record" enc_mem_bts
+  | CI.ITP_Loc -> !^"Ptr"
+  | CI.ITP_Datatype (CI.ITP_sym tag) -> Sym.pp tag
+  | CI.ITP_List _bt2 -> !^"list " ^^ bt_to_itp _bt2
+  | CI.ITP_Unit -> !^"unsupported BT unit"
+  | CI.ITP_Membyte -> !^"unsupported BT membyte"
+  | CI.ITP_Real -> !^"unsupported BT real"
+  | CI.ITP_Alloc_id -> !^"unsupported BT alloc_id"
+  | CI.ITP_CType -> !^"unsupported BT ctype"
+  | CI.ITP_Tuple fld_bts ->
+    let enc_fld_bts = List.map bt_to_itp fld_bts in
+    tuple_itp_ty !^"" enc_fld_bts
+  | CI.ITP_Set _bt2 -> rets "unsupported BT set"
 
 
 let pp_let sym rhs_doc doc =
@@ -298,14 +298,14 @@ let pp_let sym rhs_doc doc =
 
 let pp_forall sym bt doc =
   let open Pp in
-  let coq_bt = bt_to_coq bt in
-  !^"∀" ^^^ parens (typ (Sym.pp sym) coq_bt) ^^ !^"," ^^ break 1 ^^ doc
+  let itp_bt = bt_to_itp bt in
+  !^"∀" ^^^ parens (typ (Sym.pp sym) itp_bt) ^^ !^"," ^^ break 1 ^^ doc
 
 
 let pp_iris_exists sym bt doc =
   let open Pp in
-  let coq_bt = bt_to_coq bt in
-  !^"∃" ^^^ parens (typ (Sym.pp sym) coq_bt) ^^ !^"," ^^ break 1 ^^ doc
+  let itp_bt = bt_to_itp bt in
+  !^"∃" ^^^ parens (typ (Sym.pp sym) itp_bt) ^^ !^"," ^^ break 1 ^^ doc
 
 
 let pp_each_int (nm : Sym.t) (forall : bool) =
@@ -316,28 +316,28 @@ let pp_each_int (nm : Sym.t) (forall : bool) =
 
 let norm_bv_op bt doc_f =
   match bt with
-  | CI.Coq_Bits (sign, sz) ->
+  | CI.ITP_Bits (sign, sz) ->
     (match sign with
-     | CI.Coq_Unsigned ->
+     | CI.ITP_Unsigned ->
        let minInt, maxInt = BT.bits_range (Unsigned, sz) in
        f_appM "CN_Lib.wrapI" [ enc_z minInt; enc_z maxInt; doc_f ]
-     | CI.Coq_Signed ->
+     | CI.ITP_Signed ->
        let minInt, maxInt = BT.bits_range (Signed, sz) in
        f_appM "CN_Lib.wrapI" [ enc_z minInt; enc_z maxInt; doc_f ])
   | _ -> doc_f
 
 
-let rec pat_to_coq (pat : CI.coq_pat) =
+let rec pat_to_itp (pat : CI.itp_pat) =
   match pat with
-  | Coq_pSym (Coq_sym sym) -> Sym.pp sym
-  | Coq_pWild -> rets "_"
-  | Coq_pConstructor (Coq_sym s, l) ->
-    parensM (build ([ Sym.pp s ] @ List.map pat_to_coq l))
+  | ITP_pSym (ITP_sym sym) -> Sym.pp sym
+  | ITP_pWild -> rets "_"
+  | ITP_pConstructor (ITP_sym s, l) ->
+    parensM (build ([ Sym.pp s ] @ List.map pat_to_itp l))
 
 
 (* is_clause is true when the translated term is a resource predicate clause,
     this is because resource predicate clauses use different connectives *)
-let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
+let term_to_itp (global : Global.t) (t : CI.itp_term) (is_clause : bool) =
   let open Pp in
   let rec f (global : Global.t) (iris_bool : bool) t =
     let aux t = f global iris_bool t in
@@ -347,62 +347,62 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
     let mk_star doc doc2 = doc ^^^ !^"∗" ^^^ doc2 in
     let mk_iris_and doc doc2 = doc ^^^ !^"∧" ^^^ doc2 in
     match t with
-    | CI.Coq_sym_term (CI.Coq_sym s) -> Sym.pp s
-    | Coq_const c ->
+    | CI.ITP_sym_term (CI.ITP_sym s) -> Sym.pp s
+    | ITP_const c ->
       (match c with
-       | Coq_bool b -> rets (if b then "true" else "false")
-       | Coq_bool_prop b -> f_appM "Is_true" [ rets (if b then "true" else "false") ]
-       | Coq_Z z -> enc_z z
-       | Coq_bits z -> parensM (rets (Z.to_string z)))
-    | Coq_unop (op, x, bt) ->
+       | ITP_bool b -> rets (if b then "true" else "false")
+       | ITP_bool_prop b -> f_appM "Is_true" [ rets (if b then "true" else "false") ]
+       | ITP_Z z -> enc_z z
+       | ITP_bits z -> parensM (rets (Z.to_string z)))
+    | ITP_unop (op, x, bt) ->
       norm_bv_op
         bt
         (match op with
-         | CI.Coq_neg -> f_appM "negb" [ aux x ]
-         | CI.Coq_neg_prop -> f_appM "~" [ aux x ]
-         | CI.Coq_BW_FFS_NoSMT -> f_appM "CN_Lib.find_first_set_z" [ aux x ]
-         | CI.Coq_BW_CTZ_NoSMT -> f_appM "CN_Lib.count_trailing_zeroes_z" [ aux x ])
-    | CI.Coq_binop (op, x, y, bt) ->
+         | CI.ITP_neg -> f_appM "negb" [ aux x ]
+         | CI.ITP_neg_prop -> f_appM "~" [ aux x ]
+         | CI.ITP_BW_FFS_NoSMT -> f_appM "CN_Lib.find_first_set_z" [ aux x ]
+         | CI.ITP_BW_CTZ_NoSMT -> f_appM "CN_Lib.count_trailing_zeroes_z" [ aux x ])
+    | CI.ITP_binop (op, x, y, bt) ->
       norm_bv_op
         bt
         (match op with
-         | CI.Coq_add -> abinop "+" x y
-         | CI.Coq_sub -> abinop "-" x y
-         | CI.Coq_mul -> abinop "*" x y
-         | CI.Coq_div -> abinop "/" x y
-         | CI.Coq_mod -> abinop "mod" x y
+         | CI.ITP_add -> abinop "+" x y
+         | CI.ITP_sub -> abinop "-" x y
+         | CI.ITP_mul -> abinop "*" x y
+         | CI.ITP_div -> abinop "/" x y
+         | CI.ITP_mod -> abinop "mod" x y
          (* todo: rem is definitely not right *)
-         | CI.Coq_rem -> abinop "mod" x y
-         | CI.Coq_lt -> abinop "<?" x y
-         | CI.Coq_lt_prop -> abinop "<" x y
-         | CI.Coq_le -> abinop "<=?" x y
-         | CI.Coq_le_prop -> abinop "<=" x y
-         | CI.Coq_exp -> abinop "^" x y
-         | CI.Coq_bwxor -> f_appM "Z.lxor" [ aux x; aux y ]
-         | CI.Coq_bwand -> f_appM "Z.land" [ aux x; aux y ]
-         | CI.Coq_bwor -> f_appM "Z.lor" [ aux x; aux y ]
-         | CI.Coq_eq -> parensM (build [ aux x; rets "=?"; aux y ])
-         | CI.Coq_eq_prop -> parensM (build [ aux x; rets "="; aux y ])
-         | CI.Coq_and -> abinop "&&" x y
-         | CI.Coq_and_prop -> abinop "∧" x y
-         | CI.Coq_or -> abinop "||" x y
-         | CI.Coq_or_prop -> abinop "∨" x y
-         | CI.Coq_impl -> abinop "implb" x y
-         | CI.Coq_impl_prop -> abinop "-∗" x y)
-    | CI.Coq_match (x, cases) ->
-      let br (pat, rhs) = build [ rets "|"; pat_to_coq pat; rets "=>"; aux rhs ] in
+         | CI.ITP_rem -> abinop "mod" x y
+         | CI.ITP_lt -> abinop "<?" x y
+         | CI.ITP_lt_prop -> abinop "<" x y
+         | CI.ITP_le -> abinop "<=?" x y
+         | CI.ITP_le_prop -> abinop "<=" x y
+         | CI.ITP_exp -> abinop "^" x y
+         | CI.ITP_bwxor -> f_appM "Z.lxor" [ aux x; aux y ]
+         | CI.ITP_bwand -> f_appM "Z.land" [ aux x; aux y ]
+         | CI.ITP_bwor -> f_appM "Z.lor" [ aux x; aux y ]
+         | CI.ITP_eq -> parensM (build [ aux x; rets "=?"; aux y ])
+         | CI.ITP_eq_prop -> parensM (build [ aux x; rets "="; aux y ])
+         | CI.ITP_and -> abinop "&&" x y
+         | CI.ITP_and_prop -> abinop "∧" x y
+         | CI.ITP_or -> abinop "||" x y
+         | CI.ITP_or_prop -> abinop "∨" x y
+         | CI.ITP_impl -> abinop "implb" x y
+         | CI.ITP_impl_prop -> abinop "-∗" x y)
+    | CI.ITP_match (x, cases) ->
+      let br (pat, rhs) = build [ rets "|"; pat_to_itp pat; rets "=>"; aux rhs ] in
       parensM
         (build
            ([ rets "match"; aux x; rets "with"; hardline ]
             @ List.map br cases
             @ [ rets "end" ]))
-    | CI.Coq_ite (sw, x, y) ->
+    | CI.ITP_ite (sw, x, y) ->
       parensM (build [ rets "if"; aux sw; rets "then"; aux x; rets "else"; aux y ])
-    | CI.Coq_eachI ((i1, (CI.Coq_sym s, _), i2), x) ->
+    | CI.ITP_eachI ((i1, (CI.ITP_sym s, _), i2), x) ->
       let enc =
         pp_forall
           s
-          CI.Coq_Integer
+          CI.ITP_Integer
           (binop
              "->"
              (binop
@@ -412,64 +412,64 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
              (aux x))
       in
       parens enc
-    | CI.Coq_mapset (m, x, y) -> f_appM "fun_upd" [ rets "Z.eqb"; aux m; aux x; aux y ]
-    | CI.Coq_mapget (m, x) ->
+    | CI.ITP_mapset (m, x, y) -> f_appM "fun_upd" [ rets "Z.eqb"; aux m; aux x; aux y ]
+    | CI.ITP_mapget (m, x) ->
       (match x with
        (* case for array member accesses *)
-       | CI.Coq_const (Coq_bits _) ->
+       | CI.ITP_const (ITP_bits _) ->
          parensM (build [ rets "nth"; aux x; aux m; rets "0" ])
        | _ -> parensM (build [ aux m; aux x ]))
-    | CI.Coq_recordmember (t, _, ix) -> gen_get_upd ix (aux t)
-    | CI.Coq_recordupdate ((t, _), x, ix) ->
+    | CI.ITP_recordmember (t, _, ix) -> gen_get_upd ix (aux t)
+    | CI.ITP_recordupdate ((t, _), x, ix) ->
       let op_nm = gen_get_upd ix (aux t) in
       parensM (build [ op_nm; aux x ])
-    | CI.Coq_record l ->
+    | CI.ITP_record l ->
       let xs = List.map aux l in
       parensM (flow (comma ^^ break 1) xs)
-    | CI.Coq_structmember (t, CI.Coq_id fieldnm, _) ->
+    | CI.ITP_structmember (t, CI.ITP_id fieldnm, _) ->
       aux t ^^ !^"." ^^ parens !^(Id.get_string fieldnm)
-    | CI.Coq_structupdate ((t, _), x, ix) ->
+    | CI.ITP_structupdate ((t, _), x, ix) ->
       let op_nm = gen_get_upd ix (aux t) in
       parensM (build [ op_nm; aux x ])
-    | CI.Coq_cast (_, x) -> aux x
-    | CI.Coq_apply (CI.Coq_sym name, args) ->
+    | CI.ITP_cast (_, x) -> aux x
+    | CI.ITP_apply (CI.ITP_sym name, args) ->
       parensM (build ([ Sym.pp name ] @ List.map aux args))
-    | CI.Coq_apply_prop (CI.Coq_sym name, args) ->
+    | CI.ITP_apply_prop (CI.ITP_sym name, args) ->
       let r = parensM (build ([ Sym.pp name ] @ List.map aux args)) in
       f_appM "Is_true" [ r ]
-    | CI.Coq_representable (CI.Coq_sym s, _, t) ->
+    | CI.ITP_representable (CI.ITP_sym s, _, t) ->
       let op_nm = "representable_" ^ Sym.pp_string s in
       parensM (build [ rets op_nm; aux t ])
-    | CI.Coq_constructor (CI.Coq_sym name, args) ->
+    | CI.ITP_constructor (CI.ITP_sym name, args) ->
       parensM (build ([ Sym.pp name ] @ List.map aux args))
-    | CI.Coq_nthlist (n, xs, d) ->
+    | CI.ITP_nthlist (n, xs, d) ->
       parensM (build [ rets "CN_Lib.nth_list_z"; aux n; aux xs; aux d ])
-    | CI.Coq_arraytolist (arr, i, len) ->
+    | CI.ITP_arraytolist (arr, i, len) ->
       parensM (build [ rets "CN_Lib.array_to_list"; aux arr; aux i; aux len ])
-    | CI.Coq_wrapI (z1, z2, t) -> f_appM "CN_Lib.wrapI" [ enc_z z1; enc_z z2; aux t ]
-    | CI.Coq_let (CI.Coq_sym nm, x, y) -> parensM (pp_let nm (aux x) (aux y))
-    | CI.Coq_arrayshift (base, ct, index) ->
+    | CI.ITP_wrapI (z1, z2, t) -> f_appM "CN_Lib.wrapI" [ enc_z z1; enc_z z2; aux t ]
+    | CI.ITP_let (CI.ITP_sym nm, x, y) -> parensM (pp_let nm (aux x) (aux y))
+    | CI.ITP_arrayshift (base, ct, index) ->
       f_appM "arrayshift" [ aux base; enc_z ct; aux index ]
-    | CI.Coq_forall (CI.Coq_sym sym, bt, t) -> pp_forall sym bt (aux t)
-    | CI.Coq_Define (CI.Coq_sym sym, x, y) -> map_split (pp_let sym (aux x)) (aux y)
-    | CI.Coq_Constraint_LRT (t1, t2) ->
+    | CI.ITP_forall (CI.ITP_sym sym, bt, t) -> pp_forall sym bt (aux t)
+    | CI.ITP_Define (CI.ITP_sym sym, x, y) -> map_split (pp_let sym (aux x)) (aux y)
+    | CI.ITP_Constraint_LRT (t1, t2) ->
       (match t1 with
        (* todo: is this right? *)
-       | CI.Coq_good _ -> mk_star (aux t1) (aux t2)
+       | CI.ITP_good _ -> mk_star (aux t1) (aux t2)
        | _ -> mk_iris_and (aux t1) (aux t2))
-    | CI.Coq_Constraint_LAT (t1, t2) ->
+    | CI.ITP_Constraint_LAT (t1, t2) ->
       if is_clause then
         mk_star (aux t1) (aux t2)
       else
         mk_wand (aux t1) (aux t2)
-    | CI.Coq_LRT_I ->
+    | CI.ITP_LRT_I ->
       if iris_bool then
         rets "emp"
       else
         iris_pure !^"Is_true true"
     (* this is the return value of a resource predicate*)
-    | CI.Coq_LAT_I t -> iris_pure (!^(ret_sym ^ " = ") ^^ aux t)
-    | CI.Coq_Owned_LAT (CI.Coq_sym s, bt, t, pointer, _) ->
+    | CI.ITP_LAT_I t -> iris_pure (!^(ret_sym ^ " = ") ^^ aux t)
+    | CI.ITP_Owned_LAT (CI.ITP_sym s, bt, t, pointer, _) ->
       let forall_owned op_nm =
         pp_forall
           s
@@ -483,42 +483,42 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
           (build [ rets op_nm; aux pointer; rets (Sym.pp_string s); g global t ])
       in
       (match bt with
-       | CI.Coq_Bits (_, _) ->
+       | CI.ITP_Bits (_, _) ->
          let op_nm = "Owned_int" in
          if is_clause then exists_owned op_nm else forall_owned op_nm
-       | CI.Coq_Loc ->
+       | CI.ITP_Loc ->
          let op_nm = "Owned_int" in
          if is_clause then exists_owned op_nm else forall_owned op_nm
-       | CI.Coq_Struct (CI.Coq_sym nm, _) ->
+       | CI.ITP_Struct (CI.ITP_sym nm, _) ->
          let op_nm = "Owned_" ^ Sym.pp_string nm in
          if is_clause then exists_owned op_nm else forall_owned op_nm
-       | CI.Coq_Map (_, _) ->
+       | CI.ITP_Map (_, _) ->
          let op_nm = "Owned_int" in
          if is_clause then exists_owned op_nm else forall_owned op_nm
-       | _ -> !^"Coq_Owned_LAT unsupported BT" ^^ bt_to_coq bt)
-    | CI.Coq_Block_LAT (CI.Coq_sym s, _, t, _) ->
+       | _ -> !^"ITP_Owned_LAT unsupported BT" ^^ bt_to_itp bt)
+    | CI.ITP_Block_LAT (CI.ITP_sym s, _, t, _) ->
       let op_nm = "block_" ^ Sym.pp_string s in
       parensM (build [ rets op_nm; g global t ])
-    | CI.Coq_Owned_LRT (CI.Coq_sym s, bt, t, pointer, _) ->
+    | CI.ITP_Owned_LRT (CI.ITP_sym s, bt, t, pointer, _) ->
       (match bt with
-       | CI.Coq_Bits (_, _) ->
+       | CI.ITP_Bits (_, _) ->
          let op_nm = "Owned_int" in
          pp_iris_exists
            s
            bt
            (build [ rets op_nm; aux pointer; rets (Sym.pp_string s); g global t ])
-       | CI.Coq_Struct (CI.Coq_sym nm, _) ->
+       | CI.ITP_Struct (CI.ITP_sym nm, _) ->
          let op_nm = "Owned_" ^ Sym.pp_string nm in
          pp_iris_exists
            s
            bt
            (build [ rets op_nm; aux pointer; rets (Sym.pp_string s); g global t ])
-       | _ -> rets "Coq_Owned_LRT unsupported BT")
-    | CI.Coq_Block_LRT (CI.Coq_sym s, _, t, _) ->
+       | _ -> rets "ITP_Owned_LRT unsupported BT")
+    | CI.ITP_Block_LRT (CI.ITP_sym s, _, t, _) ->
       let op_nm = "Block_" ^ Sym.pp_string s in
       parensM (build [ rets op_nm; g global t ])
-    | CI.Coq_good _ -> rets ""
-    | CI.Coq_PName_LAT (CI.Coq_sym nm, CI.Coq_sym pname, bt, t, iargs, ptr) ->
+    | CI.ITP_good _ -> rets ""
+    | CI.ITP_PName_LAT (CI.ITP_sym nm, CI.ITP_sym pname, bt, t, iargs, ptr) ->
       let args = List.map aux iargs in
       if is_clause then
         mk_star
@@ -531,16 +531,16 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
         mk_wand
           (pp_forall nm bt (build ((Sym.pp pname :: aux ptr :: args) @ [ Sym.pp nm ])))
           (aux t)
-    | CI.Coq_PName_LRT (CI.Coq_sym nm, CI.Coq_sym pname, bt, t, iargs, ptr) ->
+    | CI.ITP_PName_LRT (CI.ITP_sym nm, CI.ITP_sym pname, bt, t, iargs, ptr) ->
       let args = List.map aux iargs in
       mk_star
         (pp_iris_exists nm bt (build ((Sym.pp pname :: aux ptr :: args) @ [ Sym.pp nm ])))
         (aux t)
-    | CI.Coq_pure t -> (match t with CI.Coq_good _ -> rets "" | _ -> iris_pure (aux t))
-    | CI.Coq_Each_LAT (Coq_sym nm, Coq_sym _, _, ptr, _, perm, pred) ->
+    | CI.ITP_pure t -> (match t with CI.ITP_good _ -> rets "" | _ -> iris_pure (aux t))
+    | CI.ITP_Each_LAT (ITP_sym nm, ITP_sym _, _, ptr, _, perm, pred) ->
       (match perm with
-       | Coq_binop
-           (Coq_and_prop, Coq_binop (_, min_term, _, _), Coq_binop (_, _, max_term, _), _)
+       | ITP_binop
+           (ITP_and_prop, ITP_binop (_, min_term, _, _), ITP_binop (_, _, max_term, _), _)
          ->
          let min_doc a = parens (rets "Z.to_nat " ^^ a) in
          build
@@ -556,11 +556,11 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
              !^(Sym.pp_string nm);
              aux pred
            ]
-       | _ -> rets "unsupported Coq_Each_LAT perm")
-    | CI.Coq_Each_LRT (Coq_sym nm, Coq_sym _, _, ptr, _, perm, pred) ->
+       | _ -> rets "unsupported ITP_Each_LAT perm")
+    | CI.ITP_Each_LRT (ITP_sym nm, ITP_sym _, _, ptr, _, perm, pred) ->
       (match perm with
-       | Coq_binop
-           (Coq_and_prop, Coq_binop (_, min_term, _, _), Coq_binop (_, _, max_term, _), _)
+       | ITP_binop
+           (ITP_and_prop, ITP_binop (_, min_term, _, _), ITP_binop (_, _, max_term, _), _)
          ->
          let min_doc a = parens (rets "Z.to_nat " ^^ a) in
          build
@@ -576,8 +576,8 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
              !^(Sym.pp_string nm);
              aux pred
            ]
-       | _ -> rets "unsupported Coq_Each_LAT perm")
-    | CI.Coq_unsupported msg -> rets msg
+       | _ -> rets "unsupported ITP_Each_LAT perm")
+    | CI.ITP_unsupported msg -> rets msg
   (* turn on iris mode! *)
   and g global (t : CI.iris_term) = match t with CI.Iris_term t -> f global true t in
   if is_clause then
@@ -586,10 +586,10 @@ let term_to_coq (global : Global.t) (t : CI.coq_term) (is_clause : bool) =
     f global false t
 
 
-let convert_lemma_defs global (lemmas : CI.coq_lemma list) =
-  let lemma_ty (CI.Coq_lemma (CI.Coq_sym nm, tm)) =
+let convert_lemma_defs global (lemmas : CI.itp_lemma list) =
+  let lemma_ty (CI.ITP_lemma (CI.ITP_sym nm, tm)) =
     Pp.progress_simple "converting lemma type" (Sym.pp_string nm);
-    let rhs = term_to_coq global tm false in
+    let rhs = term_to_itp global tm false in
     defn (Sym.pp_string nm ^ "_type") [] (Some (Pp.string "iProp Σ")) rhs false
   in
   let tys = List.map lemma_ty lemmas in
@@ -597,13 +597,13 @@ let convert_lemma_defs global (lemmas : CI.coq_lemma list) =
 
 
 (* print datatypes *)
-let translate_datatypes (dtys : CI.coq_dt list list) =
+let translate_datatypes (dtys : CI.itp_dt list list) =
   let open Pp in
-  let cons_line dt_tag (CI.Coq_constr (CI.Coq_sym nm, params)) =
-    let argTs = List.map (fun bt -> bt_to_coq bt) params in
+  let cons_line dt_tag (CI.ITP_constr (CI.ITP_sym nm, params)) =
+    let argTs = List.map (fun bt -> bt_to_itp bt) params in
     !^"    | " ^^ Sym.pp nm ^^^ colon ^^^ flow !^" -> " (argTs @ [ Sym.pp dt_tag ])
   in
-  let dt_eqs (CI.Coq_dt (CI.Coq_sym nm, _, constr)) =
+  let dt_eqs (CI.ITP_dt (CI.ITP_sym nm, _, constr)) =
     let c_lines = List.map (cons_line nm) constr in
     !^"    " ^^ Sym.pp nm ^^^ colon ^^^ !^"Type :=" ^^ hardline ^^ flow hardline c_lines
   in
@@ -616,7 +616,7 @@ let translate_datatypes (dtys : CI.coq_dt list list) =
     ^^ !^"."
     ^^ hardline
   in
-  let rec f (dtys : CI.coq_dt list list) =
+  let rec f (dtys : CI.itp_dt list list) =
     match dtys with [] -> [] | x :: xs -> print_dt x :: f xs
   in
   f dtys
@@ -632,71 +632,71 @@ let scanl1 f ls = match ls with x :: xs -> scanl f x xs | [] -> []
 let make_pred_ty args ret_ty res_ty =
   let open Pp in
   (* add pointer arg *)
-  let arg_bts = CI.Coq_Loc :: List.map snd args in
-  let arg_types = List.map bt_to_coq arg_bts @ [ bt_to_coq ret_ty ] in
+  let arg_bts = CI.ITP_Loc :: List.map snd args in
+  let arg_types = List.map bt_to_itp arg_bts @ [ bt_to_itp ret_ty ] in
   List.fold_right (fun arg result -> infix 2 1 !^"->" arg result) arg_types !^res_ty
 
 
 (* print resource predicate definitions *)
-let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
+let translate_pred (gl : Global.t) (preds : CI.itp_resource_pred_group list) =
   let open Pp in
-  let unpack_clauses (clauses : CI.coq_clause list) =
-    let clause_to_coq (clause : CI.coq_clause) =
+  let unpack_clauses (clauses : CI.itp_clause list) =
+    let clause_to_itp (clause : CI.itp_clause) =
       match clause with
-      | CI.Coq_clause (guard, body) ->
+      | CI.ITP_clause (guard, body) ->
         (* assuming all guards are pure *)
         let guard_doc =
           match guard with
           | x :: xs ->
-            iris_pure (term_to_coq gl x false)
+            iris_pure (term_to_itp gl x false)
             ^^ intersperse
                  ""
                  ""
                  (List.map
-                    (fun y -> !^" ∧ " ^^ iris_pure (!^"~" ^^ term_to_coq gl y false))
+                    (fun y -> !^" ∧ " ^^ iris_pure (!^"~" ^^ term_to_itp gl y false))
                     xs)
           | [] -> rets "True"
         in
-        let body_doc = term_to_coq gl body true in
+        let body_doc = term_to_itp gl body true in
         parensM (build [ guard_doc; rets " ∧ "; body_doc ])
     in
     (* add all previous guards to the beginnig of each clause *)
-    let clause_concat (c1 : CI.coq_clause) (c2 : CI.coq_clause) =
+    let clause_concat (c1 : CI.itp_clause) (c2 : CI.itp_clause) =
       match c1 with
-      | CI.Coq_clause (guard, _) ->
+      | CI.ITP_clause (guard, _) ->
         (match c2 with
-         | CI.Coq_clause (guard2, body) -> CI.Coq_clause (guard2 @ guard, body))
+         | CI.ITP_clause (guard2, body) -> CI.ITP_clause (guard2 @ guard, body))
     in
-    List.map clause_to_coq (scanl1 clause_concat clauses)
+    List.map clause_to_itp (scanl1 clause_concat clauses)
   in
   let make_one_arg = function
-    | CI.Coq_sym id, bt -> parens (typ (Sym.pp id) (bt_to_coq bt))
+    | CI.ITP_sym id, bt -> parens (typ (Sym.pp id) (bt_to_itp bt))
   in
-  let unpack_sym (CI.Coq_sym sym) = sym in
-  let get_pred_name (pred : CI.coq_resource_pred) = unpack_sym pred.CI.name in
-  let make_formal_args (pred : CI.coq_resource_pred) =
+  let unpack_sym (CI.ITP_sym sym) = sym in
+  let get_pred_name (pred : CI.itp_resource_pred) = unpack_sym pred.CI.name in
+  let make_formal_args (pred : CI.itp_resource_pred) =
     let ptr = unpack_sym pred.CI.ptr in
-    let ptr_arg = parens (typ (Sym.pp ptr) (bt_to_coq CI.Coq_Loc)) in
-    let ret_arg = parens (typ !^ret_sym (bt_to_coq pred.CI.ret_bt)) in
+    let ptr_arg = parens (typ (Sym.pp ptr) (bt_to_itp CI.ITP_Loc)) in
+    let ret_arg = parens (typ !^ret_sym (bt_to_itp pred.CI.ret_bt)) in
     (ptr_arg :: List.map make_one_arg pred.CI.args) @ [ ret_arg ]
   in
-  let make_actual_args (pred : CI.coq_resource_pred) =
+  let make_actual_args (pred : CI.itp_resource_pred) =
     let ptr = unpack_sym pred.CI.ptr in
     let args = List.map (fun (arg, _) -> Sym.pp (unpack_sym arg)) pred.CI.args in
     (Sym.pp ptr :: args) @ [ !^ret_sym ]
   in
-  let make_args (group : CI.coq_resource_pred_group) (pred : CI.coq_resource_pred) =
-    let make_rec_arg (arg : CI.coq_resource_pred) =
+  let make_args (group : CI.itp_resource_pred_group) (pred : CI.itp_resource_pred) =
+    let make_rec_arg (arg : CI.itp_resource_pred) =
       let ty = make_pred_ty arg.args arg.ret_bt "iProp Σ" in
       parens (typ (Sym.pp (get_pred_name arg)) ty)
     in
     let rec_args = List.map make_rec_arg group in
     rec_args @ make_formal_args pred
   in
-  let get_body_name (pred : CI.coq_resource_pred) =
+  let get_body_name (pred : CI.itp_resource_pred) =
     Sym.pp_string (get_pred_name pred) ^ "_body"
   in
-  let unpack_body (group : CI.coq_resource_pred_group) (pred : CI.coq_resource_pred) =
+  let unpack_body (group : CI.itp_resource_pred_group) (pred : CI.itp_resource_pred) =
     defn
       (get_body_name pred)
       (make_args group pred)
@@ -704,7 +704,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       (intersperse " ∨ " "" (unpack_clauses pred.CI.clauses))
       false
   in
-  let get_constr_name (pred : CI.coq_resource_pred) =
+  let get_constr_name (pred : CI.itp_resource_pred) =
     "CN_GROUP_" ^ Sym.pp_string (get_pred_name pred)
   in
   let get_group_type_name index = "cn_predicate_group_" ^ string_of_int index in
@@ -712,7 +712,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     let constr_name = get_constr_name pred in
     typ (Pp.string constr_name) (make_pred_ty pred.args pred.ret_bt type_name)
   in
-  let make_group_type index (predicates : CI.coq_resource_pred_group) =
+  let make_group_type index (predicates : CI.itp_resource_pred_group) =
     let type_name = get_group_type_name index in
     let constrs = List.map (make_constr type_name) predicates in
     let group_type =
@@ -729,7 +729,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     group_type ^^ ofe_type
   in
   (* (λ p ν, rec (CN_GROUP_IsForest p ν)) *)
-  let make_closure (pred : CI.coq_resource_pred) =
+  let make_closure (pred : CI.itp_resource_pred) =
     let args = make_actual_args pred in
     let call = parensM @@ build @@ (!^(get_constr_name pred) :: args) in
     let binders = build args in
@@ -741,7 +741,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
         (λ p ν, (rec (CN_GROUP_IsForest p ν)))
         (λ p ν, (rec (CN_GROUP_IsTree p ν)))
         p ν *)
-  let make_case predicates (pred : CI.coq_resource_pred) =
+  let make_case predicates (pred : CI.itp_resource_pred) =
     let body_name = !^(get_body_name pred) in
     let args = make_actual_args pred in
     let closures = List.map make_closure predicates in
@@ -750,7 +750,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     infix 2 1 !^"=>" pattern body
   in
   let get_pre_fixpoint_name index = "cn_predicate_group_pre_" ^ string_of_int index in
-  let make_pre_fixpoint_body (predicates : CI.coq_resource_pred_group) =
+  let make_pre_fixpoint_body (predicates : CI.itp_resource_pred_group) =
     let cases =
       predicates
       |> List.map (make_case predicates)
@@ -759,7 +759,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     align @@ !^"match call with" ^^ nest 2 (hardline ^^ cases) ^^ hardline ^^ !^"end"
   in
-  let make_pre_fixpoint_definition index (predicates : CI.coq_resource_pred_group) =
+  let make_pre_fixpoint_definition index (predicates : CI.itp_resource_pred_group) =
     let group_ofe_name = get_group_type_name index ^ "O" in
     let rec_type = flow !^" -> " [ !^group_ofe_name; !^"iProp Σ" ] in
     let rec_arg = parens @@ typ !^"rec" rec_type in
@@ -771,7 +771,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       (make_pre_fixpoint_body predicates)
       false
   in
-  let make_monotonicity_instance index (predicates : CI.coq_resource_pred_group) =
+  let make_monotonicity_instance index (predicates : CI.itp_resource_pred_group) =
     let pre_fixpoint = get_pre_fixpoint_name index in
     let instance_name = get_group_type_name index ^ "_mono" in
     let instance =
@@ -804,12 +804,12 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     instance ^^ hardline ^^ proof ^^ hardline
   in
-  let make_pre_fixpoint index (predicates : CI.coq_resource_pred_group) =
+  let make_pre_fixpoint index (predicates : CI.itp_resource_pred_group) =
     let definition = make_pre_fixpoint_definition index predicates in
     let mono = make_monotonicity_instance index predicates in
     definition ^^ mono
   in
-  let make_fixpoint index (pred : CI.coq_resource_pred) =
+  let make_fixpoint index (pred : CI.itp_resource_pred) =
     let args = make_formal_args pred in
     let app = !^(get_constr_name pred) :: make_actual_args pred in
     let body =
@@ -818,30 +818,30 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     defn (Sym.pp_string (get_pred_name pred)) args (Some !^"iProp Σ") body false
   in
-  let make_fixpoints index (predicates : CI.coq_resource_pred_group) =
+  let make_fixpoints index (predicates : CI.itp_resource_pred_group) =
     let pre_fixpoint = make_pre_fixpoint index predicates in
     let fixpoints = List.map (make_fixpoint index) predicates in
     pre_fixpoint ^^ hardline ^^ flow hardline fixpoints
   in
   (* induction lemma *)
-  let get_pred_prop_name (pred : CI.coq_resource_pred) =
+  let get_pred_prop_name (pred : CI.itp_resource_pred) =
     "Φ_" ^ Sym.pp_string (get_pred_name pred)
   in
-  let make_induction_lemma_arg (pred : CI.coq_resource_pred) =
+  let make_induction_lemma_arg (pred : CI.itp_resource_pred) =
     let ty = make_pred_ty pred.args pred.ret_bt "iProp Σ" in
     let name = get_pred_prop_name pred in
     typ (Pp.string name) ty
   in
   let make_forall vars body =
-    let binders = List.map (fun (nm, bt) -> parens @@ typ nm (bt_to_coq bt)) vars in
+    let binders = List.map (fun (nm, bt) -> parens @@ typ nm (bt_to_itp bt)) vars in
     group @@ !^"∀" ^^^ build binders ^^ comma ^^ nest 2 (break 1 ^^ body)
   in
-  let get_pred_vars (pred : CI.coq_resource_pred) =
+  let get_pred_vars (pred : CI.itp_resource_pred) =
     let vars =
-      List.map (fun (CI.Coq_sym sym, bt) -> (Sym.pp sym, bt)) pred.args
+      List.map (fun (CI.ITP_sym sym, bt) -> (Sym.pp sym, bt)) pred.args
       @ [ (!^ret_sym, pred.ret_bt) ]
     in
-    (Sym.pp (unpack_sym pred.ptr), CI.Coq_Loc) :: vars
+    (Sym.pp (unpack_sym pred.ptr), CI.ITP_Loc) :: vars
   in
   let make_lemma proof_name args statement proof =
     let s =
@@ -861,8 +861,8 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     s ^^ proof
   in
-  let make_induction_lemma index (predicates : CI.coq_resource_pred_group) =
-    let make_assumption predicates (pred : CI.coq_resource_pred) =
+  let make_induction_lemma index (predicates : CI.itp_resource_pred_group) =
+    let make_assumption predicates (pred : CI.itp_resource_pred) =
       (* □ (∀ (p : Ptr) (ν : forest), IsForest_body Φ_IsForest Φ_IsTree p ν -∗ Φ_IsForest p ν) -∗ *)
       let vars = get_pred_vars pred in
       let extended_vars =
@@ -875,7 +875,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       let body = infix 2 1 !^"-∗" body1 body2 in
       !^"□" ^^^ parens @@ make_forall vars body
     in
-    let make_conc (pred : CI.coq_resource_pred) =
+    let make_conc (pred : CI.itp_resource_pred) =
       (* (∀ (p : Ptr) (ν : forest), IsForest p ν -∗ Φ_IsForest p ν) *)
       let vars = get_pred_vars pred in
       let body1 =
@@ -894,7 +894,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       let conclusion = flow and_sep (List.map parens concs) in
       separate (space ^^ !^"-∗" ^^ hardline) @@ assumptions @ [ conclusion ]
     in
-    let make_induction_lemma_proof index (predicates : CI.coq_resource_pred_group) =
+    let make_induction_lemma_proof index (predicates : CI.itp_resource_pred_group) =
       let name = !^(get_pre_fixpoint_name index) in
       let cases =
         List.map
@@ -957,8 +957,8 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
   in
   let make_unfold_lemma
         index
-        (predicates : CI.coq_resource_pred_group)
-        (pred : CI.coq_resource_pred)
+        (predicates : CI.itp_resource_pred_group)
+        (pred : CI.itp_resource_pred)
     =
     let proof_name = Sym.pp (get_pred_name pred) ^^ underscore ^^ !^"unfold" in
     let args = get_pred_vars pred in
@@ -985,11 +985,11 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     make_lemma
       proof_name
-      (List.map (fun (nm, bt) -> parens (typ nm (bt_to_coq bt))) args)
+      (List.map (fun (nm, bt) -> parens (typ nm (bt_to_itp bt))) args)
       statement
       proof
   in
-  let unpack_group index (predicates : CI.coq_resource_pred_group) =
+  let unpack_group index (predicates : CI.itp_resource_pred_group) =
     let group_type = make_group_type index predicates in
     let pred_defs = List.map (unpack_body predicates) predicates in
     let fixpoint = make_fixpoints index predicates in
@@ -1003,52 +1003,52 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
 
 let translate_uninterp_pred =
   let open Pp in
-  List.map (fun (CI.Coq_sym nm, _, args, ret_ty) ->
+  List.map (fun (CI.ITP_sym nm, _, args, ret_ty) ->
     let ty = make_pred_ty args ret_ty "iProp Σ" in
     (!^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline) ^^ hardline)
 
 
-(* translate functions to Coq *)
-let translate_fun (gl : Global.t) (funs : CI.coq_fun list list * CI.coq_fun list list) =
+(* translate functions to ITP *)
+let translate_fun (gl : Global.t) (funs : CI.itp_fun list list * CI.itp_fun list list) =
   let open Pp in
   let translate_one cf =
     match cf with
-    | CI.Coq_fun_def (CI.Coq_sym nm, logical_fun, args, _) ->
+    | CI.ITP_fun_def (CI.ITP_sym nm, logical_fun, args, _) ->
       (match logical_fun with
-       | CI.Coq_def body ->
-         let coq_body = term_to_coq gl body false in
-         let coq_args =
+       | CI.ITP_def body ->
+         let itp_body = term_to_itp gl body false in
+         let itp_args =
            List.map
-             (fun (CI.Coq_sym arg, bt) ->
-                let coq_bt = bt_to_coq bt in
-                Pp.parens (Pp.typ (Sym.pp arg) coq_bt))
+             (fun (CI.ITP_sym arg, bt) ->
+                let itp_bt = bt_to_itp bt in
+                Pp.parens (Pp.typ (Sym.pp arg) itp_bt))
              args
          in
-         defn (Sym.pp_string nm) coq_args None coq_body false
-       | CI.Coq_recdef body ->
-         let coq_body = term_to_coq gl body false in
-         let coq_args =
+         defn (Sym.pp_string nm) itp_args None itp_body false
+       | CI.ITP_recdef body ->
+         let itp_body = term_to_itp gl body false in
+         let itp_args =
            List.map
-             (fun (CI.Coq_sym arg, bt) ->
-                let coq_bt = bt_to_coq bt in
-                Pp.parens (Pp.typ (Sym.pp arg) coq_bt))
+             (fun (CI.ITP_sym arg, bt) ->
+                let itp_bt = bt_to_itp bt in
+                Pp.parens (Pp.typ (Sym.pp arg) itp_bt))
              args
          in
-         defn (Sym.pp_string nm) coq_args None coq_body true)
-    | CI.Coq_fun_uninterp (CI.Coq_sym nm, logical_fun, args, ret_typ) ->
+         defn (Sym.pp_string nm) itp_args None itp_body true)
+    | CI.ITP_fun_uninterp (CI.ITP_sym nm, logical_fun, args, ret_typ) ->
       (match logical_fun with
-       | CI.Coq_uninterp ->
-         let coq_arg_typs = List.map (fun (_, bt) -> bt_to_coq bt) args in
-         let coq_rt = bt_to_coq ret_typ in
+       | CI.ITP_uninterp ->
+         let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
+         let itp_rt = bt_to_itp ret_typ in
          let ty =
-           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) coq_arg_typs coq_rt
+           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) itp_arg_typs itp_rt
          in
          !^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline
-       | CI.Coq_uninterp_prop ->
-         let coq_arg_typs = List.map (fun (_, bt) -> bt_to_coq bt) args in
-         let coq_rt = !^"Prop" in
+       | CI.ITP_uninterp_prop ->
+         let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
+         let itp_rt = !^"Prop" in
          let ty =
-           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) coq_arg_typs coq_rt
+           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) itp_arg_typs itp_rt
          in
          !^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline)
   in
@@ -1134,9 +1134,9 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
     let filename, _kinds = parse_directions directions in
     let channel = open_out filename in
     Pp.print channel (header filename);
-    (* translate everything to coq AST*)
-    let (CI.Coq_gl (dtys, funs, preds, uninterp_preds, lemmas)) =
-      CC.cn_to_coq_ir global lemmata
+    (* translate everything to itp AST*)
+    let (CI.ITP_gl (dtys, funs, preds, uninterp_preds, lemmas)) =
+      CC.cn_to_itp_ir global lemmata
     in
     (* print datatypes *)
     let dtypes = translate_datatypes dtys in
@@ -1165,6 +1165,6 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
     Pp.print channel (lemmas_module [] translated_lemmas);
     Pp.print
       channel
-      (mod_spec (List.map (fun (CI.Coq_lemma (CI.Coq_sym nm, _)) -> nm) lemmas))
+      (mod_spec (List.map (fun (CI.ITP_lemma (CI.ITP_sym nm, _)) -> nm) lemmas))
   in
   Result.Ok f

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -1024,7 +1024,7 @@ let translate_fun (gl : Global.t) (funs : CI.itp_fun list list * CI.itp_fun list
              args
          in
          defn (Sym.pp_string nm) itp_args None itp_body true)
-    | CI.ITP_fun_uninterp (CI.ITP_sym nm, _, args, ret_typ) ->
+    | CI.ITP_fun_uninterp (CI.ITP_sym nm, args, ret_typ) ->
       let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
       let itp_rt = bt_to_itp ret_typ in
       let ty =

--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -350,15 +350,13 @@ let term_to_itp (global : Global.t) (t : CI.itp_term) (is_clause : bool) =
     | CI.ITP_sym_term (CI.ITP_sym s) -> Sym.pp s
     | ITP_const c ->
       (match c with
-       | ITP_bool b -> rets (if b then "true" else "false")
-       | ITP_bool_prop b -> f_appM "Is_true" [ rets (if b then "true" else "false") ]
+       | ITP_bool_prop b -> rets (if b then "true" else "false")
        | ITP_Z z -> enc_z z
        | ITP_bits z -> parensM (rets (Z.to_string z)))
     | ITP_unop (op, x, bt) ->
       norm_bv_op
         bt
         (match op with
-         | CI.ITP_neg -> f_appM "negb" [ aux x ]
          | CI.ITP_neg_prop -> f_appM "~" [ aux x ]
          | CI.ITP_BW_FFS_NoSMT -> f_appM "CN_Lib.find_first_set_z" [ aux x ]
          | CI.ITP_BW_CTZ_NoSMT -> f_appM "CN_Lib.count_trailing_zeroes_z" [ aux x ])
@@ -373,21 +371,15 @@ let term_to_itp (global : Global.t) (t : CI.itp_term) (is_clause : bool) =
          | CI.ITP_mod -> abinop "mod" x y
          (* todo: rem is definitely not right *)
          | CI.ITP_rem -> abinop "mod" x y
-         | CI.ITP_lt -> abinop "<?" x y
          | CI.ITP_lt_prop -> abinop "<" x y
-         | CI.ITP_le -> abinop "<=?" x y
          | CI.ITP_le_prop -> abinop "<=" x y
          | CI.ITP_exp -> abinop "^" x y
          | CI.ITP_bwxor -> f_appM "Z.lxor" [ aux x; aux y ]
          | CI.ITP_bwand -> f_appM "Z.land" [ aux x; aux y ]
          | CI.ITP_bwor -> f_appM "Z.lor" [ aux x; aux y ]
-         | CI.ITP_eq -> parensM (build [ aux x; rets "=?"; aux y ])
          | CI.ITP_eq_prop -> parensM (build [ aux x; rets "="; aux y ])
-         | CI.ITP_and -> abinop "&&" x y
          | CI.ITP_and_prop -> abinop "∧" x y
-         | CI.ITP_or -> abinop "||" x y
          | CI.ITP_or_prop -> abinop "∨" x y
-         | CI.ITP_impl -> abinop "implb" x y
          | CI.ITP_impl_prop -> abinop "-∗" x y)
     | CI.ITP_match (x, cases) ->
       let br (pat, rhs) = build [ rets "|"; pat_to_itp pat; rets "=>"; aux rhs ] in
@@ -432,11 +424,8 @@ let term_to_itp (global : Global.t) (t : CI.itp_term) (is_clause : bool) =
       let op_nm = gen_get_upd ix (aux t) in
       parensM (build [ op_nm; aux x ])
     | CI.ITP_cast (_, x) -> aux x
-    | CI.ITP_apply (CI.ITP_sym name, args) ->
-      parensM (build ([ Sym.pp name ] @ List.map aux args))
     | CI.ITP_apply_prop (CI.ITP_sym name, args) ->
-      let r = parensM (build ([ Sym.pp name ] @ List.map aux args)) in
-      f_appM "Is_true" [ r ]
+      parensM (build ([ Sym.pp name ] @ List.map aux args))
     | CI.ITP_representable (CI.ITP_sym s, _, t) ->
       let op_nm = "representable_" ^ Sym.pp_string s in
       parensM (build [ rets op_nm; aux t ])
@@ -466,7 +455,7 @@ let term_to_itp (global : Global.t) (t : CI.itp_term) (is_clause : bool) =
       if iris_bool then
         rets "emp"
       else
-        iris_pure !^"Is_true true"
+        iris_pure !^"true"
     (* this is the return value of a resource predicate*)
     | CI.ITP_LAT_I t -> iris_pure (!^(ret_sym ^ " = ") ^^ aux t)
     | CI.ITP_Owned_LAT (CI.ITP_sym s, bt, t, pointer, _) ->
@@ -1035,22 +1024,13 @@ let translate_fun (gl : Global.t) (funs : CI.itp_fun list list * CI.itp_fun list
              args
          in
          defn (Sym.pp_string nm) itp_args None itp_body true)
-    | CI.ITP_fun_uninterp (CI.ITP_sym nm, logical_fun, args, ret_typ) ->
-      (match logical_fun with
-       | CI.ITP_uninterp ->
-         let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
-         let itp_rt = bt_to_itp ret_typ in
-         let ty =
-           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) itp_arg_typs itp_rt
-         in
-         !^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline
-       | CI.ITP_uninterp_prop ->
-         let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
-         let itp_rt = !^"Prop" in
-         let ty =
-           List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) itp_arg_typs itp_rt
-         in
-         !^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline)
+    | CI.ITP_fun_uninterp (CI.ITP_sym nm, _, args, ret_typ) ->
+      let itp_arg_typs = List.map (fun (_, bt) -> bt_to_itp bt) args in
+      let itp_rt = bt_to_itp ret_typ in
+      let ty =
+        List.fold_right (fun at rt -> at ^^^ !^"->" ^^^ rt) itp_arg_typs itp_rt
+      in
+      !^"  Parameter" ^^^ typ (Sym.pp nm) ty ^^ !^"." ^^ hardline
   in
   let print clump =
     flow


### PR DESCRIPTION
These are some of the refactors discussed in meetings last week:
1. Remove the deprecated `fun_prop_ret` function and related machinery
2. Make everything live in prop, e.g. just print `true` rather than `Is_true true`.

I wasn't super sure about (2) but the Rocq output passes the (working) tests, so I guess it's fine?