### PR TITLE
`derive_constraints` command

### DIFF
--- a/bin/verify.ml
+++ b/bin/verify.ml
@@ -39,7 +39,7 @@ let verify
       no_inherit_loc
       magic_comment_char_dollar
       allow_split_magic_comments
-      disable_resource_derived_constraints
+      disable_derived_lc1
       try_hard
       disable_unfold_multiclause_preds
       check_consistency (* integermode *)
@@ -70,7 +70,7 @@ let verify
   MakeTerm.use_vip := not dont_use_vip;
   Check.fail_fast := fail_fast;
   Diagnostics.diag_string := diag;
-  Resource.disable_resource_derived_constraints := disable_resource_derived_constraints;
+  Resource.disable_derived_lc1 := disable_derived_lc1;
   (* Set the prooflog flag based on --coq-proof-log *)
   Prooflog.set_enabled coq_proof_log;
   Typing.unfold_multiclause_preds := not disable_unfold_multiclause_preds;
@@ -217,8 +217,8 @@ module Flags = struct
       & info ~docs:s_verification [ "output-dir" ] ~docv:"DIR" ~doc)
 
 
-  let disable_resource_derived_constraints =
-    let doc = "disable resource-derived constraints" in
+  let disable_derived_lc1 =
+    let doc = "disable constraints derived from ownership of individual resources" in
     Arg.(
       value
       & flag
@@ -323,7 +323,7 @@ let verify_t : unit Term.t =
   $ Common.Flags.no_inherit_loc
   $ Common.Flags.magic_comment_char_dollar
   $ Common.Flags.allow_split_magic_comments
-  $ Flags.disable_resource_derived_constraints
+  $ Flags.disable_derived_lc1
   $ Flags.try_hard
   $ Flags.disable_unfold_multiclause_preds
   $ Flags.check_consistency

--- a/cn.opam
+++ b/cn.opam
@@ -29,7 +29,7 @@ depends: [
   "qcheck-ounit" {with-test}
 ]
 pin-depends: [
-  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#dccd7b4"]
+  ["cerberus-lib.dev" "git+https://github.com/rems-project/cerberus.git#b9aeedc"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/coq/Cn/ErrorCommon.v
+++ b/coq/Cn/ErrorCommon.v
@@ -25,5 +25,5 @@ Inductive call_situation : Type :=
   (* Corresponds to OCaml type situation *)
 Inductive situation : Type :=
   | Access : access -> situation
-  | Call : call_situation -> situation.
-
+  | Call : call_situation -> situation
+  | Derive_constraints : situation.

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -2190,8 +2190,7 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
       (* copying bits of code from elsewhere in check.ml *)
       match stmt with
       | Cnstatement.Pack_unpack (Unpack, Predicate pred) ->
-        let@ req = WellTyped.request loc (P pred) in
-        let pred = match req with Req.P pred -> pred | Req.Q _ -> assert false in
+        let req = Req.P pred in
         let@ pred, o =
           let@ found = RI.General.predicate_request_scan loc pred in
           match found with
@@ -2210,7 +2209,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
         do_unpack (pred, o)
       | Cnstatement.Pack_unpack (Unpack, PredicateName pn) ->
         let pn = match pn with Owned _ -> assert false | PName pn -> pn in
-        let@ _def = Global.get_resource_predicate_def loc pn in
         let@ found =
           let open Request in
           map_and_fold_resources
@@ -2273,9 +2271,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
       | To_from_bytes ((To | From), { name = PName _; _ }) ->
         fail (fun _ -> { loc; msg = Byte_conv_needs_owned })
       | To_from_bytes (To, { name = Owned (ct, init); pointer; _ }) ->
-        let ctxt = match init with Init -> `RW | Uninit -> `W in
-        let@ () = WellTyped.err_if_ct_void loc ctxt ct in
-        let@ pointer = WellTyped.check_term loc (BT.Loc ()) pointer in
         let@ _, O value =
           RI.Special.predicate_request
             loc
@@ -2301,9 +2296,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
            let@ constr = bytes_constraints loc To ~value ~byte_arr ct in
            add_c loc (LC.T constr))
       | To_from_bytes (From, { name = Owned (ct, init); pointer; _ }) ->
-        let ctxt = match init with Init -> `RW | Uninit -> `W in
-        let@ () = WellTyped.err_if_ct_void loc ctxt ct in
-        let@ pointer = WellTyped.check_term loc (BT.Loc ()) pointer in
         let q_sym = Sym.fresh "from_bytes" in
         let@ _, O byte_arr =
           RI.Special.qpredicate_request
@@ -2325,24 +2317,18 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
          | Init ->
            let@ constr = bytes_constraints loc From ~value ~byte_arr ct in
            add_c loc (LC.T constr))
-      | Have lc ->
-        let@ _lc = WellTyped.logical_constraint loc lc in
+      | Have _lc ->
         fail (fun _ ->
           { loc;
             msg = Generic !^"todo: 'have' not implemented yet" [@alert "-deprecated"]
           })
       | Instantiate (to_instantiate, it) ->
-        let@ filter =
+        let filter =
           match to_instantiate with
-          | I_Everything -> return (fun _ -> true)
-          | I_Function f ->
-            let@ _ = Global.get_logical_function_def loc f in
-            return (Terms.mentions_call f)
-          | I_Good ct ->
-            let@ () = WellTyped.check_ct loc ct in
-            return (Terms.mentions_good ct)
+          | I_Everything -> fun _ -> true
+          | I_Function f -> Terms.mentions_call f
+          | I_Good ct -> Terms.mentions_good ct
         in
-        let@ it = WellTyped.infer_term it in
         instantiate loc filter it
       | Split_case _ -> assert false
       | Extract (attrs, to_extract, it) ->
@@ -2354,20 +2340,13 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
           | E_Pred (CN_owned None) ->
             let msg = "'extract' requires a C-type annotation for 'Owned'" in
             fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] })
-          | E_Pred (CN_owned (Some ct)) ->
-            let@ () = WellTyped.check_ct loc ct in
-            return (Request.Owned (ct, Init))
+          | E_Pred (CN_owned (Some ct)) -> return (Request.Owned (ct, Init))
           | E_Pred (CN_block None) ->
             let msg = "'extract' requires a C-type annotation for 'Block'" in
             fail (fun _ -> { loc; msg = Generic !^msg [@alert "-deprecated"] })
-          | E_Pred (CN_block (Some ct)) ->
-            let@ () = WellTyped.check_ct loc ct in
-            return (Request.Owned (ct, Uninit))
-          | E_Pred (CN_named pn) ->
-            let@ _ = Global.get_resource_predicate_def loc pn in
-            return (Request.PName pn)
+          | E_Pred (CN_block (Some ct)) -> return (Request.Owned (ct, Uninit))
+          | E_Pred (CN_named pn) -> return (Request.PName pn)
         in
-        let@ it = WellTyped.infer_term it in
         let@ original_rs = all_resources loc in
         (* let verbose = List.exists (Id.is_str "verbose") attrs in *)
         let quiet = List.exists (Id.equal_string "quiet") attrs in
@@ -2380,16 +2359,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
         return ()
       | Unfold (f, args) ->
         let@ def = Global.get_logical_function_def loc f in
-        let has_args, expect_args = (List.length args, List.length def.args) in
-        let@ () =
-          WellTyped.ensure_same_argument_number loc `Other has_args ~expect:expect_args
-        in
-        let@ args =
-          ListM.map2M
-            (fun has_arg (_, def_arg_bt) -> WellTyped.check_term loc def_arg_bt has_arg)
-            args
-            def.args
-        in
         (match Definition.Function.unroll_once def args with
          | None ->
            let msg =
@@ -2409,7 +2378,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
              let@ () = bind_logical_return loc prefix lrt in
              return ())
       | Assert lc ->
-        let@ lc = WellTyped.logical_constraint loc lc in
         let@ provable = provable loc in
         (match provable lc with
          | `True -> return ()
@@ -2426,7 +2394,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
              }))
       | Inline _nms -> return ()
       | Print it ->
-        let@ it = WellTyped.infer_term it in
         let@ simp_ctxt = simp_ctxt () in
         let it = Simplify.Terms.simp simp_ctxt it in
         print stdout (item "printed" (T.pp it));
@@ -2443,7 +2410,6 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
         (match cn_statement with
          | Cnstatement.Split_case lc ->
            Pp.debug 5 (lazy (Pp.headline "checking split_case"));
-           let@ lc = WellTyped.logical_constraint loc lc in
            let@ it =
              match lc with
              | T it -> return it

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -2226,6 +2226,50 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
       | Cnstatement.Pack_unpack (Pack, _pt) ->
         warn loc !^"Explicit pack unsupported.";
         return ()
+      | Cnstatement.Derive_constraints preds ->
+        let preds, pred_names =
+          List.partition_map
+            (function
+              | Cnstatement.Predicate pred -> Left pred
+              | Cnstatement.PredicateName pn -> Right pn)
+            preds
+        in
+        let@ pred_rs =
+          ListM.mapM
+            (fun pred ->
+               let@ found = RI.General.predicate_request_scan loc pred in
+               match found with
+               | Some (pred, o) -> return (Request.P pred, o)
+               | None ->
+                 let@ model = model () in
+                 fail (fun ctxt ->
+                   let requests =
+                     [ RequestChain.{ resource = P pred; loc = Some loc; reason = None } ]
+                   in
+                   let msg =
+                     Missing_resource
+                       { requests; situation = Derive_constraints; ctxt; model }
+                   in
+                   { loc; msg }))
+            preds
+        in
+        let@ pred_name_rs =
+          ListM.fold_leftM
+            (fun acc pn ->
+               map_and_fold_resources
+                 loc
+                 (fun (re, o) acc ->
+                    match re with
+                    | P p when Request.equal_name p.name pn -> (Deleted, (re, o) :: acc)
+                    | P _ -> (Unchanged, acc)
+                    | Q _ -> (Unchanged, acc))
+                 acc)
+            []
+            pred_names
+        in
+        let rs = pred_rs @ pred_name_rs in
+        let@ () = add_rs loc rs in
+        add_cs loc (List.map (fun t -> LC.T t) (Resource.derived_lc2 rs))
       | To_from_bytes ((To | From), { name = PName _; _ }) ->
         fail (fun _ -> { loc; msg = Byte_conv_needs_owned })
       | To_from_bytes (To, { name = Owned (ct, init); pointer; _ }) ->
@@ -2393,6 +2437,9 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
       | [] -> k (unit_ loc)
       | cn_prog :: cn_progs ->
         let@ loc, cn_statement = cn_prog_sub_let Cnstatement.subst cn_prog in
+        (* The individual statement-well-formedness checks above can be omitted
+           if we do the following here. *)
+        let@ cn_statement = WellTyped.check_cn_statement loc cn_statement in
         (match cn_statement with
          | Cnstatement.Split_case lc ->
            Pp.debug 5 (lazy (Pp.headline "checking split_case"));

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -2235,20 +2235,10 @@ let rec check_expr labels (e : BT.t Mu.expr) (k : T.t -> unit m) : unit m =
         let@ pred_rs =
           ListM.mapM
             (fun pred ->
-               let@ found = RI.General.predicate_request_scan loc pred in
-               match found with
-               | Some (pred, o) -> return (Request.P pred, o)
-               | None ->
-                 let@ model = model () in
-                 fail (fun ctxt ->
-                   let requests =
-                     [ RequestChain.{ resource = P pred; loc = Some loc; reason = None } ]
-                   in
-                   let msg =
-                     Missing_resource
-                       { requests; situation = Derive_constraints; ctxt; model }
-                   in
-                   { loc; msg }))
+               let@ pred, o =
+                 RI.Special.predicate_request loc Derive_constraints (pred, None)
+               in
+               return (Request.P pred, o))
             preds
         in
         let@ pred_name_rs =

--- a/lib/cnstatement.ml
+++ b/lib/cnstatement.ml
@@ -17,6 +17,7 @@ type predicate_or_predicate_name =
 
 type statement =
   | Pack_unpack of CF.Cn.pack_unpack * predicate_or_predicate_name
+  | Derive_constraints of predicate_or_predicate_name list
   | To_from_bytes of CF.Cn.to_from * Request.Predicate.t
   | Have of LogicalConstraints.t
   | Instantiate of (Sym.t, Sctypes.t) CF.Cn.cn_to_instantiate * T.t
@@ -36,6 +37,9 @@ let subst_predicate_or_predicate_name substitution = function
 let rec subst substitution = function
   | Pack_unpack (pack_unpack, pt) ->
     Pack_unpack (pack_unpack, subst_predicate_or_predicate_name substitution pt)
+  | Derive_constraints preds ->
+    let preds = List.map (subst_predicate_or_predicate_name substitution) preds in
+    Derive_constraints preds
   | To_from_bytes (to_from, pt) ->
     To_from_bytes (to_from, Req.Predicate.subst substitution pt)
   | Have lc -> Have (LC.subst substitution lc)
@@ -76,6 +80,9 @@ let free_vars_predicate_or_predicate_name = function
 
 let free_vars = function
   | Pack_unpack (_pack_unpack, pt) -> free_vars_predicate_or_predicate_name pt
+  | Derive_constraints preds ->
+    let fvarss = List.map free_vars_predicate_or_predicate_name preds in
+    List.fold_left Sym.Set.union Sym.Set.empty fvarss
   | To_from_bytes (_to_from, pt) -> T.free_vars_list (pt.pointer :: pt.iargs)
   | Have lc -> LC.free_vars lc
   | Instantiate (_o_s, it) ->
@@ -132,6 +139,9 @@ let dtree =
     Dnode (pp_ctor "Pack", [ dtree_of_predicate_or_predicate_name pred ])
   | Pack_unpack (Unpack, pred) ->
     Dnode (pp_ctor "Unpack", [ dtree_of_predicate_or_predicate_name pred ])
+  | Derive_constraints preds ->
+    Dnode
+      (pp_ctor "DeriveConstraints", List.map dtree_of_predicate_or_predicate_name preds)
   | To_from_bytes (To, pred) ->
     Dnode (pp_ctor "To_bytes", [ Request.Predicate.dtree pred ])
   | To_from_bytes (From, pred) ->

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -1182,21 +1182,22 @@ module C_vars = struct
     let@ pname, ptr_expr, iargs, oargs_ty = cn_res_info ~pred_loc env_with_q res args in
     let here = Locations.other __LOC__ in
     let@ ptr_base, step = split_pointer_linear_step pred_loc (q, bt', here) ptr_expr in
+    let pointer = Terms.Surface.proj ptr_base in
     let m_oargs_ty = SBT.make_map_bt bt' oargs_ty in
     let pt =
       ( Req.Q
           { name = pname;
             q = (q, SBT.proj bt');
             q_loc = here;
-            pointer = Terms.Surface.proj ptr_base;
+            pointer;
             step;
             permission = Terms.Surface.proj guard_expr;
             iargs = List.map Terms.Surface.proj iargs
           },
         m_oargs_ty )
     in
-    let info = (here, Some "owned-value-representable") in
     let pointee_constrs =
+      let info = (here, Some "owned-value-representable") in
       let qt = MT.sym_ (q, SBT.proj bt', here) in
       match pname with
       | Owned (ct, Init) ->
@@ -1215,7 +1216,13 @@ module C_vars = struct
           ]
       | _ -> []
     in
-    return (pt, [], pointee_constrs)
+    (* let has_alloc_id_constr = *)
+    (*   let info = (here, Some "iterated-resource-pointer-has-alloc-id") in *)
+    (*   match pname with *)
+    (*   | Owned _ -> [ (LC.T (MT.hasAllocId_ pointer here), info) ] *)
+    (*   | _ -> [] *)
+    (* in *)
+    return (pt, [], pointee_constrs (* @ has_alloc_id_constr *))
 
 
   let cn_let_resource env (sym, the_res) =
@@ -1273,6 +1280,51 @@ module C_vars = struct
       in
       let stmt = Pack_unpack (pack_unpack, PredicateName name) in
       return stmt
+    | CN_derive_constraints pred_iargs ->
+      let@ preds =
+        ListM.mapM
+          (fun (pred, maybe_args) ->
+             match maybe_args with
+             | Some args ->
+               let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
+               let@ name, pointer, iargs, _oargs_ty =
+                 cn_res_info ~pred_loc:loc env pred args
+               in
+               let pred =
+                 Predicate
+                   { name;
+                     pointer = Terms.Surface.proj pointer;
+                     iargs = List.map Terms.Surface.proj iargs
+                   }
+               in
+               return pred
+             | None ->
+               let@ name =
+                 match pred with
+                 | Cn.CN_owned (Some ct) ->
+                   return (Request.Owned (Sctypes.of_ctype_unsafe loc ct, Init))
+                 | Cn.CN_block (Some ct) ->
+                   return (Request.Owned (Sctypes.of_ctype_unsafe loc ct, Uninit))
+                 | Cn.CN_owned None ->
+                   fail
+                     { loc;
+                       msg =
+                         Generic !^"Cannot use `derive_constrs` for RW without C-type"
+                         [@alert "-deprecated"]
+                     }
+                 | Cn.CN_block None ->
+                   fail
+                     { loc;
+                       msg =
+                         Generic !^"Cannot use `derive_constrs` for W without C-type"
+                         [@alert "-deprecated"]
+                     }
+                 | Cn.CN_named name -> return (Request.PName name)
+               in
+               return (PredicateName name))
+          pred_iargs
+      in
+      return (Derive_constraints preds)
     | CN_to_from_bytes (to_from, pred, args) ->
       let@ args = ListM.mapM (cn_expr Sym.Set.empty env) args in
       let@ name, pointer, iargs, _oargs_ty = cn_res_info ~pred_loc:loc env pred args in

--- a/lib/error_common.ml
+++ b/lib/error_common.ml
@@ -18,3 +18,4 @@ type situation =
   | Access of access
   | Call of call_situation
   | Unpacking
+  | Derive_constraints

--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -4058,6 +4058,7 @@ let cn_to_ail_cnstatement
   let default_res_for_dest = empty_for_dest d in
   match cnstatement with
   | Cnstatement.Pack_unpack (_pack_unpack, _pt) -> (default_res_for_dest, true)
+  | Derive_constraints _preds -> (default_res_for_dest, true)
   | To_from_bytes (_to_from, _res) -> (default_res_for_dest, true)
   | Have _lc -> failwith "TODO Have"
   | Instantiate (_to_instantiate, _it) -> (default_res_for_dest, true)

--- a/lib/fulminate/records.ml
+++ b/lib/fulminate/records.ml
@@ -66,8 +66,8 @@ let add_records_to_map_from_lc = function
 let add_records_to_map_from_cn_statement = function
   | Cnstatement.Assert lc -> add_records_to_map_from_lc lc
   (* All other CN statements are (currently) no-ops at runtime *)
-  | Pack_unpack _ | To_from_bytes _ | Have _ | Instantiate _ | Split_case _ | Extract _
-  | Unfold _ | Apply _ | Inline _ | Print _ ->
+  | Pack_unpack _ | Derive_constraints _ | To_from_bytes _ | Have _ | Instantiate _
+  | Split_case _ | Extract _ | Unfold _ | Apply _ | Inline _ | Print _ ->
     ()
 
 

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -1735,6 +1735,15 @@ let pp_cnprogs_extract (ids, extract, term) =
 let pp_cnprog_statement = function
   | Cnstatement.Pack_unpack (pu, Predicate pred) ->
     pp_constructor "CNProgs.Pack_unpack" [ pp_pack_unpack pu; pp_request_ppredicate pred ]
+  | Cnstatement.Derive_constraints preds ->
+    let preds =
+      List.map
+        (function
+          | Cnstatement.Predicate pred -> pp_request_ppredicate pred
+          | Cnstatement.PredicateName _pn -> failwith "todo")
+        preds
+    in
+    pp_constructor "CNProgs.Derive_constraints" preds
   | Cnstatement.Pack_unpack (_pu, PredicateName _) -> failwith "todo"
   | To_from_bytes (tf, pred) ->
     pp_constructor "CNProgs.To_from_bytes" [ pp_to_from tf; pp_request_ppredicate pred ]
@@ -1785,6 +1794,16 @@ let rec pp_cn_statement ppfa ppfty (CF.Cn.CN_statement (loc, stmt)) =
                  pp_list (pp_cn_expr ppfa ppfty) exprs
                ]
            ]
+       | CN_derive_constraints preds_iargs ->
+         pp_constructor2
+           "CN_derive_constraints"
+           (List.map
+              (fun (pred, iargs) ->
+                 pp_tuple
+                   [ pp_cn_pred ppfa ppfty pred;
+                     pp_option (pp_list (pp_cn_expr ppfa ppfty)) iargs
+                   ])
+              preds_iargs)
        | CN_to_from_bytes (tf, pred, exprs) ->
          pp_constructor2
            "CN_to_from_bytes"
@@ -2070,6 +2089,7 @@ let pp_situation (s : Error_common.situation) =
   | Error_common.Access a -> pp_constructor "ErrorCommon.Access" [ pp_access a ]
   | Error_common.Call c -> pp_constructor "ErrorCommon.Call" [ pp_call_situation c ]
   | Error_common.Unpacking -> failwith "todo: pp_situation Unpacking"
+  | Error_common.Derive_constraints -> failwith "todo: pp_situation Derive_constraints"
 
 
 let pp_init = function

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2089,7 +2089,7 @@ let pp_situation (s : Error_common.situation) =
   | Error_common.Access a -> pp_constructor "ErrorCommon.Access" [ pp_access a ]
   | Error_common.Call c -> pp_constructor "ErrorCommon.Call" [ pp_call_situation c ]
   | Error_common.Unpacking -> failwith "todo: pp_situation Unpacking"
-  | Error_common.Derive_constraints -> failwith "todo: pp_situation Derive_constraints"
+  | Error_common.Derive_constraints -> pp_constructor "ErrorCommon.Derive_constraints"
 
 
 let pp_init = function

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -2089,7 +2089,7 @@ let pp_situation (s : Error_common.situation) =
   | Error_common.Access a -> pp_constructor "ErrorCommon.Access" [ pp_access a ]
   | Error_common.Call c -> pp_constructor "ErrorCommon.Call" [ pp_call_situation c ]
   | Error_common.Unpacking -> failwith "todo: pp_situation Unpacking"
-  | Error_common.Derive_constraints -> pp_constructor "ErrorCommon.Derive_constraints"
+  | Error_common.Derive_constraints -> pp_constructor "ErrorCommon.Derive_constraints" []
 
 
 let pp_init = function

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -22,8 +22,11 @@ let subst substitution ((r, O oargs) : t) =
 
 let free_vars (r, O oargs) = Sym.Set.union (Req.free_vars r) (T.free_vars oargs)
 
+let disable_derived_lc1 = ref false
+
 (* assumption: the resource is owned *)
 let derived_lc1 ((resource : Req.t), O output) =
+  if !disable_derived_lc1 then [] else
   let here = Locations.other __LOC__ in
   match resource with
   | P { name = Owned (ct, _); pointer; iargs = _ } ->
@@ -50,23 +53,23 @@ let derived_lc1 ((resource : Req.t), O output) =
 
 (* assumption: both resources are owned at the same *)
 (* todo, depending on how much we need *)
-let derived_lc2 ((resource : Req.t), _) ((resource' : Req.t), _) =
-  match (resource, resource') with
-  | ( P { name = Owned (ct1, _); pointer = p1; iargs = _ },
-      P { name = Owned (ct2, _); pointer = p2; iargs = _ } ) ->
-    let here = Locations.other __LOC__ in
-    let addr1 = MT.addr_ p1 here in
-    let addr2 = MT.addr_ p2 here in
-    let up1 = MT.upper_bound addr1 ct1 here in
-    let up2 = MT.upper_bound addr2 ct2 here in
-    [ MT.(or2_ (le_ (up2, addr1) here, le_ (up1, addr2) here) here) ]
-  | _ -> []
 
 
-let disable_resource_derived_constraints = ref false
-
-let pointer_facts ~new_resource ~old_resources =
-  if !disable_resource_derived_constraints then
-    []
-  else
-    derived_lc1 new_resource @ List.concat_map (derived_lc2 new_resource) old_resources
+let derived_lc2 = 
+  let derived ((resource : Req.t), _) ((resource' : Req.t), _) =
+    match (resource, resource') with
+    | ( P { name = Owned (ct1, _); pointer = p1; iargs = _ },
+	P { name = Owned (ct2, _); pointer = p2; iargs = _ } ) ->
+      let here = Locations.other __LOC__ in
+      let addr1 = MT.addr_ p1 here in
+      let addr2 = MT.addr_ p2 here in
+      let up1 = MT.upper_bound addr1 ct1 here in
+      let up2 = MT.upper_bound addr2 ct2 here in
+      [ MT.(or2_ (le_ (up2, addr1) here, le_ (up1, addr2) here) here) ]
+    | _ -> []
+  in
+  let rec aux acc = function
+    | [] -> acc
+    | r :: rs -> aux (List.concat_map (derived r) rs @ acc) rs
+  in
+  fun rs -> aux [] rs

--- a/lib/resource.ml
+++ b/lib/resource.ml
@@ -26,40 +26,41 @@ let disable_derived_lc1 = ref false
 
 (* assumption: the resource is owned *)
 let derived_lc1 ((resource : Req.t), O output) =
-  if !disable_derived_lc1 then [] else
-  let here = Locations.other __LOC__ in
-  match resource with
-  | P { name = Owned (ct, _); pointer; iargs = _ } ->
-    let addr = MT.addr_ pointer here in
-    let upper = MT.upper_bound addr ct here in
-    let alloc_bounds =
-      if !MT.use_vip then
-        let module H = Alloc.History in
-        let H.{ base; size } = H.(split (lookup_ptr pointer here) here) in
-        [ MT.(le_ (base, addr) here); MT.(le_ (upper, add_ (base, size) here) here) ]
-      else
-        []
-    in
-    [ MT.hasAllocId_ pointer here; MT.(le_ (addr, upper) here) ] @ alloc_bounds
-  | P { name; pointer; iargs = [] }
-    when !MT.use_vip && Req.(equal_name name Predicate.alloc) ->
-    let module H = Alloc.History in
-    let lookup = H.lookup_ptr pointer here in
-    let H.{ base; size } = H.split lookup here in
-    [ MT.(eq_ (lookup, output) here); MT.(le_ (base, add_ (base, size) here) here) ]
-  | Q { name = Owned _; pointer; _ } -> [ MT.hasAllocId_ pointer here ]
-  | P { name = PName _; pointer = _; iargs = _ } | Q { name = PName _; _ } -> []
+  if !disable_derived_lc1 then
+    []
+  else (
+    let here = Locations.other __LOC__ in
+    match resource with
+    | P { name = Owned (ct, _); pointer; iargs = _ } ->
+      let addr = MT.addr_ pointer here in
+      let upper = MT.upper_bound addr ct here in
+      let alloc_bounds =
+        if !MT.use_vip then
+          let module H = Alloc.History in
+          let H.{ base; size } = H.(split (lookup_ptr pointer here) here) in
+          [ MT.(le_ (base, addr) here); MT.(le_ (upper, add_ (base, size) here) here) ]
+        else
+          []
+      in
+      [ MT.hasAllocId_ pointer here; MT.(le_ (addr, upper) here) ] @ alloc_bounds
+    | P { name; pointer; iargs = [] }
+      when !MT.use_vip && Req.(equal_name name Predicate.alloc) ->
+      let module H = Alloc.History in
+      let lookup = H.lookup_ptr pointer here in
+      let H.{ base; size } = H.split lookup here in
+      [ MT.(eq_ (lookup, output) here); MT.(le_ (base, add_ (base, size) here) here) ]
+    | Q { name = Owned _; pointer; _ } -> [ MT.hasAllocId_ pointer here ]
+    | P { name = PName _; pointer = _; iargs = _ } | Q { name = PName _; _ } -> [])
 
 
 (* assumption: both resources are owned at the same *)
 (* todo, depending on how much we need *)
 
-
-let derived_lc2 = 
+let derived_lc2 =
   let derived ((resource : Req.t), _) ((resource' : Req.t), _) =
     match (resource, resource') with
     | ( P { name = Owned (ct1, _); pointer = p1; iargs = _ },
-	P { name = Owned (ct2, _); pointer = p2; iargs = _ } ) ->
+        P { name = Owned (ct2, _); pointer = p2; iargs = _ } ) ->
       let here = Locations.other __LOC__ in
       let addr1 = MT.addr_ p1 here in
       let addr2 = MT.addr_ p2 here in

--- a/lib/resource.mli
+++ b/lib/resource.mli
@@ -18,10 +18,8 @@ val subst : [ `Rename of Sym.t | `Term of Terms.Normal.t ] Subst.t -> t -> t
 
 val free_vars : t -> Sym.Set.t
 
+val disable_derived_lc1 : bool ref
+
 val derived_lc1 : t -> Terms.Normal.t list
 
-val derived_lc2 : t -> t -> Terms.Normal.t list
-
-val disable_resource_derived_constraints : bool ref
-
-val pointer_facts : new_resource:t -> old_resources:t list -> Terms.Normal.t list
+val derived_lc2 : t list -> Terms.Normal.t list

--- a/lib/typeErrors.ml
+++ b/lib/typeErrors.ml
@@ -25,6 +25,7 @@ let checking_situation = function
   | Access _ -> !^"checking access"
   | Call s -> call_situation s
   | Unpacking -> !^"unpacking"
+  | Derive_constraints -> !^"deriving resource constraints"
 
 
 let for_access = function
@@ -55,6 +56,7 @@ let for_situation = function
         | LAdefault -> !^"for default case"
         | LAactual_label -> !^"for jumping to label")
      | Subtyping -> !^"for returning")
+  | Derive_constraints -> !^"for deriving resource constraints"
 
 
 module RequestChain = struct

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -402,6 +402,7 @@ let set_movable_indices ixs : unit m = modify (fun s -> { s with movable_indices
 
 let add_c_internal lc =
   let@ s = get_typing_context () in
+  if LC.Set.mem lc s.constraints then return () else
   let@ solver = get_solver () in
   let@ simp_ctxt = simp_ctxt () in
   let lc = Simplify.LogicalConstraints.simp simp_ctxt lc in
@@ -418,10 +419,7 @@ let add_r_internal ?(derive_constraints = true) loc (r, Res.O oargs) =
   let r = Simplify.Request.simp simp_ctxt r in
   let oargs = Simplify.Terms.simp simp_ctxt oargs in
   let pointer_facts =
-    if derive_constraints then
-      Res.pointer_facts ~new_resource:(r, Res.O oargs) ~old_resources:(Context.get_rs s)
-    else
-      []
+    if derive_constraints then Res.derived_lc1 (r, Res.O oargs) else []
   in
   let@ () = set_typing_context (Context.add_r loc (r, O oargs) s) in
   iterM (fun x -> add_c_internal (LC.T x)) pointer_facts

--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -402,15 +402,17 @@ let set_movable_indices ixs : unit m = modify (fun s -> { s with movable_indices
 
 let add_c_internal lc =
   let@ s = get_typing_context () in
-  if LC.Set.mem lc s.constraints then return () else
-  let@ solver = get_solver () in
-  let@ simp_ctxt = simp_ctxt () in
-  let lc = Simplify.LogicalConstraints.simp simp_ctxt lc in
-  let s = Context.add_c lc s in
-  let () = Solver.assume solver lc in
-  let@ _ = add_sym_eqs (List.filter_map LC.is_sym_lhs_equality [ lc ]) in
-  let@ () = set_typing_context s in
-  return ()
+  if LC.Set.mem lc s.constraints then
+    return ()
+  else
+    let@ solver = get_solver () in
+    let@ simp_ctxt = simp_ctxt () in
+    let lc = Simplify.LogicalConstraints.simp simp_ctxt lc in
+    let s = Context.add_c lc s in
+    let () = Solver.assume solver lc in
+    let@ _ = add_sym_eqs (List.filter_map LC.is_sym_lhs_equality [ lc ]) in
+    let@ () = set_typing_context s in
+    return ()
 
 
 let add_r_internal ?(derive_constraints = true) loc (r, Res.O oargs) =

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2226,7 +2226,7 @@ module BaseTyping = struct
     | _ -> assert false
 
 
-  let check_cn_statement loc stmt =
+  let check_cn_statement ?(warn=true) loc stmt =
     let open Cnstatement in
     Pp.debug 22 (lazy (Pp.item __FUNCTION__ (CF.Pp_ast.pp_doc_tree (dtree stmt))));
     match stmt with
@@ -2322,7 +2322,7 @@ module BaseTyping = struct
         | E_Everything -> return ()
       in
       let@ it = WT.infer it in
-      warn_when_not_quantifier_bt "focus" (T.get_loc it) (T.get_bt it) (T.pp it);
+      (if warn then warn_when_not_quantifier_bt "focus" (T.get_loc it) (T.get_bt it) (T.pp it));
       return (Extract (attrs, to_extract, it))
     | Unfold (f, its) ->
       let@ def = get_logical_function_def loc f in
@@ -3092,7 +3092,10 @@ module Lift (M : ErrorReader) : WellTyped_intf.S with type 'a t := 'a M.t = stru
 
   let check_expr x y z = lift3 check_expr x y z
 
-  let check_cn_statement x y = lift2 check_cn_statement x y
+  let check_cn_statement ?(warn=false) y z = 
+    let ( let@ ) = M.bind in
+    let@ context = M.get_context () in
+    M.lift (Result.map fst (check_cn_statement ~warn y z context))
 
   let function_type = lift3 function_type
 

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2264,9 +2264,36 @@ module BaseTyping = struct
         | PName n -> get_resource_predicate_def loc n
       in
       return (Pack_unpack (pack_unpack, PredicateName pn))
+    | Derive_constraints preds ->
+      let@ preds =
+        ListM.mapM
+          (function
+            | Predicate pred ->
+              let@ p_pred = WReq.welltyped loc (P pred) in
+              let[@warning "-8"] (Req.P pred) = p_pred in
+              return (Predicate pred)
+            | PredicateName pn ->
+              let@ () =
+                match pn with
+                | Owned (ct, _) -> WCT.is_ct loc ct
+                | PName pn ->
+                  let@ _def = get_resource_predicate_def loc pn in
+                  return ()
+              in
+              return (PredicateName pn))
+          preds
+      in
+      return (Derive_constraints preds)
     | To_from_bytes (to_from, pt) ->
       let@ pt = WReq.welltyped loc (P pt) in
       let[@warning "-8"] (Req.P pt) = pt in
+      let@ () =
+        match pt.name with
+        | Owned (ct, init) ->
+          let ctxt = match init with Init -> `RW | Uninit -> `W in
+          err_if_ct_void loc ctxt ct
+        | PName _ -> return ()
+      in
       return (To_from_bytes (to_from, pt))
     | Have lc ->
       let@ lc = WLC.welltyped loc lc in
@@ -2984,6 +3011,8 @@ let infer_expr = BaseTyping.infer_expr
 
 let check_expr = BaseTyping.check_expr
 
+let check_cn_statement = BaseTyping.check_cn_statement
+
 let function_type = WFT.welltyped
 
 let logical_constraint = WLC.welltyped
@@ -3062,6 +3091,8 @@ module Lift (M : ErrorReader) : WellTyped_intf.S with type 'a t := 'a M.t = stru
   let infer_expr x y = lift2 infer_expr x y
 
   let check_expr x y z = lift3 check_expr x y z
+
+  let check_cn_statement x y = lift2 check_cn_statement x y
 
   let function_type = lift3 function_type
 

--- a/lib/wellTyped.ml
+++ b/lib/wellTyped.ml
@@ -2226,7 +2226,7 @@ module BaseTyping = struct
     | _ -> assert false
 
 
-  let check_cn_statement ?(warn=true) loc stmt =
+  let check_cn_statement ?(warn = true) loc stmt =
     let open Cnstatement in
     Pp.debug 22 (lazy (Pp.item __FUNCTION__ (CF.Pp_ast.pp_doc_tree (dtree stmt))));
     match stmt with
@@ -2322,7 +2322,8 @@ module BaseTyping = struct
         | E_Everything -> return ()
       in
       let@ it = WT.infer it in
-      (if warn then warn_when_not_quantifier_bt "focus" (T.get_loc it) (T.get_bt it) (T.pp it));
+      if warn then
+        warn_when_not_quantifier_bt "focus" (T.get_loc it) (T.get_bt it) (T.pp it);
       return (Extract (attrs, to_extract, it))
     | Unfold (f, its) ->
       let@ def = get_logical_function_def loc f in
@@ -3092,10 +3093,11 @@ module Lift (M : ErrorReader) : WellTyped_intf.S with type 'a t := 'a M.t = stru
 
   let check_expr x y z = lift3 check_expr x y z
 
-  let check_cn_statement ?(warn=false) y z = 
+  let check_cn_statement ?(warn = false) y z =
     let ( let@ ) = M.bind in
     let@ context = M.get_context () in
     M.lift (Result.map fst (check_cn_statement ~warn y z context))
+
 
   let function_type = lift3 function_type
 

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -55,6 +55,8 @@ module type S = sig
     'TY Mucore.expr ->
     BaseTypes.t Mucore.expr t
 
+  val check_cn_statement : Locations.t -> Cnstatement.statement -> Cnstatement.statement t
+
   val procedure
     :  Locations.t ->
     'TY1 Mucore.args_and_body ->

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -55,7 +55,11 @@ module type S = sig
     'TY Mucore.expr ->
     BaseTypes.t Mucore.expr t
 
-  val check_cn_statement : ?warn:bool -> Locations.t -> Cnstatement.statement -> Cnstatement.statement t
+  val check_cn_statement
+    :  ?warn:bool ->
+    Locations.t ->
+    Cnstatement.statement ->
+    Cnstatement.statement t
 
   val procedure
     :  Locations.t ->

--- a/lib/wellTyped_intf.ml
+++ b/lib/wellTyped_intf.ml
@@ -55,7 +55,7 @@ module type S = sig
     'TY Mucore.expr ->
     BaseTypes.t Mucore.expr t
 
-  val check_cn_statement : Locations.t -> Cnstatement.statement -> Cnstatement.statement t
+  val check_cn_statement : ?warn:bool -> Locations.t -> Cnstatement.statement -> Cnstatement.statement t
 
   val procedure
     :  Locations.t ->

--- a/tests/cn/bad_ordering.error.c.verify
+++ b/tests/cn/bad_ordering.error.c.verify
@@ -1,3 +1,4 @@
+return code: 1
 [1mtests/cn/bad_ordering.error.c:4:5:[0m [1;31merror:[0m [1munexpected token after ';' and before 'requires'
 Please add error message for state 1709 to parsers/c/c_parser_error.messages[0m
     requires x < MAXi32(); @*/

--- a/tests/cn/bad_ordering.error.c.verify
+++ b/tests/cn/bad_ordering.error.c.verify
@@ -1,5 +1,4 @@
-return code: 1
-tests/cn/bad_ordering.error.c:4:5: error: unexpected token after ';' and before 'requires'
-Please add error message for state 1702 to parsers/c/c_parser_error.messages
+[1mtests/cn/bad_ordering.error.c:4:5:[0m [1;31merror:[0m [1munexpected token after ';' and before 'requires'
+Please add error message for state 1709 to parsers/c/c_parser_error.messages[0m
     requires x < MAXi32(); @*/
     ^~~~~~~~ 

--- a/tests/cn/bad_ordering.error.c.verify
+++ b/tests/cn/bad_ordering.error.c.verify
@@ -1,5 +1,5 @@
 return code: 1
-[1mtests/cn/bad_ordering.error.c:4:5:[0m [1;31merror:[0m [1munexpected token after ';' and before 'requires'
-Please add error message for state 1709 to parsers/c/c_parser_error.messages[0m
+tests/cn/bad_ordering.error.c:4:5: error: unexpected token after ';' and before 'requires'
+Please add error message for state 1709 to parsers/c/c_parser_error.messages
     requires x < MAXi32(); @*/
     ^~~~~~~~ 

--- a/tests/cn/disj_nonnull.c
+++ b/tests/cn/disj_nonnull.c
@@ -4,6 +4,7 @@ int y = 2;
 void globals()
 /*@ accesses x; accesses y; @*/
 {
+  /*@ derive_constraints(Owned<int>(&x), Owned<int>(&y)); @*/
 
   /*@ assert((u64) &x != (u64) &y); @*/
 
@@ -22,6 +23,8 @@ int main()
 {
     int p = 1;
     int q = 2;
+
+  /*@ derive_constraints(Owned<int>(&p), Owned<int>(&q)); @*/
 
   /*@ assert((u64) &p != (u64) &q); @*/
 

--- a/tests/cn/disj_nonnull.c
+++ b/tests/cn/disj_nonnull.c
@@ -4,7 +4,7 @@ int y = 2;
 void globals()
 /*@ accesses x; accesses y; @*/
 {
-  /*@ derive_constraints(Owned<int>(&x), Owned<int>(&y)); @*/
+  /*@ derive_constraints(RW<int>(&x), RW<int>(&y)); @*/
 
   /*@ assert((u64) &x != (u64) &y); @*/
 
@@ -24,7 +24,7 @@ int main()
     int p = 1;
     int q = 2;
 
-  /*@ derive_constraints(Owned<int>(&p), Owned<int>(&q)); @*/
+  /*@ derive_constraints(RW<int>(&p), RW<int>(&q)); @*/
 
   /*@ assert((u64) &p != (u64) &q); @*/
 

--- a/tests/cn/ghost_bad_ordering.error.c.verify
+++ b/tests/cn/ghost_bad_ordering.error.c.verify
@@ -1,8 +1,7 @@
-return code: 1
 tests/cn/ghost_bad_ordering.error.c:5:5: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
     cn_ghost i32 n; true;
     ^~~~~~~~ 
-tests/cn/ghost_bad_ordering.error.c:5:5: error: unexpected token after ';' and before 'cn_ghost'
-Please add error message for state 1702 to parsers/c/c_parser_error.messages
+[1mtests/cn/ghost_bad_ordering.error.c:5:5:[0m [1;31merror:[0m [1munexpected token after ';' and before 'cn_ghost'
+Please add error message for state 1709 to parsers/c/c_parser_error.messages[0m
     cn_ghost i32 n; true;
     ^~~~~~~~ 

--- a/tests/cn/ghost_bad_ordering.error.c.verify
+++ b/tests/cn/ghost_bad_ordering.error.c.verify
@@ -1,7 +1,8 @@
+return code: 1
 tests/cn/ghost_bad_ordering.error.c:5:5: warning: experimental keyword 'cn_ghost' (use of experimental features is discouraged)
     cn_ghost i32 n; true;
     ^~~~~~~~ 
-[1mtests/cn/ghost_bad_ordering.error.c:5:5:[0m [1;31merror:[0m [1munexpected token after ';' and before 'cn_ghost'
-Please add error message for state 1709 to parsers/c/c_parser_error.messages[0m
+tests/cn/ghost_bad_ordering.error.c:5:5: error: unexpected token after ';' and before 'cn_ghost'
+Please add error message for state 1709 to parsers/c/c_parser_error.messages
     cn_ghost i32 n; true;
     ^~~~~~~~ 

--- a/tests/cn/has_alloc_id_ptr_neq.c
+++ b/tests/cn/has_alloc_id_ptr_neq.c
@@ -15,5 +15,6 @@ int main()
 {
     int x = 0;
     int y = 1;
+    /*@ derive_constraints(Owned<int>(&x), Owned<int>(&y)); @*/
     f(&x, &y);
 }

--- a/tests/cn/has_alloc_id_ptr_neq.c
+++ b/tests/cn/has_alloc_id_ptr_neq.c
@@ -15,6 +15,6 @@ int main()
 {
     int x = 0;
     int y = 1;
-    /*@ derive_constraints(Owned<int>(&x), Owned<int>(&y)); @*/
+    /*@ derive_constraints(RW<int>(&x), RW<int>(&y)); @*/
     f(&x, &y);
 }

--- a/tests/cn/list_literal_type.error.c.verify
+++ b/tests/cn/list_literal_type.error.c.verify
@@ -1,5 +1,4 @@
-return code: 2
 tests/cn/list_literal_type.error.c:3:15: error: unexpected token after 'list' and before '<'
-Please add error message for state 1862 to parsers/c/c_parser_error.messages
+Please add error message for state 1869 to parsers/c/c_parser_error.messages
 function (list<integer>) nonempty_list() {
               ^ 

--- a/tests/cn/list_literal_type.error.c.verify
+++ b/tests/cn/list_literal_type.error.c.verify
@@ -1,3 +1,4 @@
+return code: 2
 tests/cn/list_literal_type.error.c:3:15: error: unexpected token after 'list' and before '<'
 Please add error message for state 1869 to parsers/c/c_parser_error.messages
 function (list<integer>) nonempty_list() {

--- a/tests/cn/spec_after_curly_brace.error.c.verify
+++ b/tests/cn/spec_after_curly_brace.error.c.verify
@@ -1,3 +1,4 @@
+return code: 1
 [1mtests/cn/spec_after_curly_brace.error.c:3:3:[0m [1;31merror:[0m [1munexpected token before 'ensures'
 You're inside a function - so I'm expecting a CN statement.
 Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print', 'apply', 'derive_constraints'.[0m

--- a/tests/cn/spec_after_curly_brace.error.c.verify
+++ b/tests/cn/spec_after_curly_brace.error.c.verify
@@ -1,6 +1,6 @@
 return code: 1
-[1mtests/cn/spec_after_curly_brace.error.c:3:3:[0m [1;31merror:[0m [1munexpected token before 'ensures'
+tests/cn/spec_after_curly_brace.error.c:3:3: error: unexpected token before 'ensures'
 You're inside a function - so I'm expecting a CN statement.
-Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print', 'apply', 'derive_constraints'.[0m
+Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print', 'apply', 'derive_constraints'.
   ensures return == 0i32; @*/
   ^~~~~~~ 

--- a/tests/cn/spec_after_curly_brace.error.c.verify
+++ b/tests/cn/spec_after_curly_brace.error.c.verify
@@ -1,6 +1,5 @@
-return code: 1
-tests/cn/spec_after_curly_brace.error.c:3:3: error: unexpected token before 'ensures'
+[1mtests/cn/spec_after_curly_brace.error.c:3:3:[0m [1;31merror:[0m [1munexpected token before 'ensures'
 You're inside a function - so I'm expecting a CN statement.
-Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print', 'apply'.
+Hint: these start with 'extract', 'instantiate', 'split_case', 'assert', 'print', 'apply', 'derive_constraints'.[0m
   ensures return == 0i32; @*/
   ^~~~~~~ 

--- a/tests/cn_vip_testsuite/no_annot.json
+++ b/tests/cn_vip_testsuite/no_annot.json
@@ -1,6 +1,6 @@
 {
     "name": "no_annot",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "--solver-type=cvc5", "--output-dir=/tmp"],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "--solver-type=z3", "--output-dir=/tmp"],
     "filter": "^(.*\\.c)$",
     "timeout": 75
 }

--- a/tests/cn_vip_testsuite/non_det_false.json
+++ b/tests/cn_vip_testsuite/non_det_false.json
@@ -1,6 +1,6 @@
 {
     "name": "non_det_false",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_FALSE", "--solver-type=cvc5", "--output-dir=/tmp"],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_FALSE", "--solver-type=z3", "--output-dir=/tmp"],
     "filter": "^(.*\\.nondet.c)$",
     "timeout": 35
 }

--- a/tests/cn_vip_testsuite/non_det_true.json
+++ b/tests/cn_vip_testsuite/non_det_true.json
@@ -1,6 +1,6 @@
 {
     "name": "non_det_true",
-    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_TRUE", "--solver-type=cvc5", "--output-dir=/tmp"],
+    "args": ["verify", "-DVIP", "-DNO_ROUND_TRIP", "-DNON_DET_TRUE", "--solver-type=z3", "--output-dir=/tmp"],
     "filter": "^(.*\\.nondet\\.c)$",
     "timeout": 35
 }

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c
@@ -13,6 +13,7 @@ int main()
   int *q = &y;
   uintptr_t i = (uintptr_t)p;
   uintptr_t j = (uintptr_t)q;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:17:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:22:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:29:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:30:5: error: Missing resource for writing
     *r=11;  // is this free of UB?
     ~~^~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:17:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_1.annot.c:22:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c
@@ -13,6 +13,7 @@ int main()
   int *q = &y;
   uintptr_t i = (uintptr_t)p;
   uintptr_t j = (uintptr_t)q;
+  /*@ derive_constraints (RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c.no_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:17:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:20:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_2.pass.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c
@@ -13,6 +13,7 @@ int main()
   int *q = &y;
   uintptr_t i = (uintptr_t)p;
   uintptr_t j = (uintptr_t)q;
+  /*@ derive_constraints (RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:17:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:22:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:29:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:30:5: error: Missing resource for writing
     *r=11;  // CN VIP UB if ¬ANNOT
     ~~^~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c.with_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:16:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:17:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:21:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:22:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:30:7: error: `&copy_alloc_id((u64)&&x[1'u64], value)[(u64)(0'i32 - 1'i32)]` out of bounds
+tests/cn_vip_testsuite/pointer_from_int_disambiguation_3.error.c:31:7: error: `&copy_alloc_id((u64)&&x[1'u64], value)[(u64)(0'i32 - 1'i32)]` out of bounds
     r=r-1;  // CN VIP UB if  ANNOT
       ~^~ 
 (UB missing short message): UB_CERB004_unspecified__pointer_add

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c
@@ -18,6 +18,7 @@ int main() {
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:22:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:28:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:29:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:22:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_xy.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c
@@ -18,6 +18,7 @@ int main() {
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:22:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:28:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:29:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:21:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:22:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:25:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_auto_yx.annot.c:26:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c
@@ -20,6 +20,7 @@ int main()
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:30:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:31:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_xy.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c
@@ -20,6 +20,7 @@ int main()
   int *p = (int *)(ux + offset);
 #endif
   int *q = &y;
+  /*@ derive_constraints (RW<int*>(&p), RW<int*>(&q)); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/
   /*CN_VIP*//*@ apply byte_array_init_8(&p, &q, sizeof<int*>); @*/

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:30:5: error: Missing resource for writing
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:31:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:23:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:27:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/pointer_offset_from_int_subtraction_global_yx.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c
+++ b/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c
@@ -6,6 +6,7 @@ int main() {
   int y=2, x=1;
   int *p = &x + 1;
   int *q = &y;
+  /*@ derive_constraints (RW<int*>(&p), RW<int*>(&q)); @*/
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:10:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:11:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:14:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:15:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:17:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_auto_yx.error.c:18:5: error: Missing resource for writing
     *p = 11;  // CN VIP UB
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c
+++ b/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c
@@ -8,6 +8,7 @@ int main()
 {
   int *p = &x + 1;
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   //CN_VIP printf("Addresses: p=%p q=%p\n",(void*)p,(void*)q);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
   /*CN_VIP*//*@ to_bytes RW<int*>(&q); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_global_yx.error.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:12:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:13:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:16:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:17:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:19:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_global_yx.error.c:20:5: error: Missing resource for writing
     *p = 11;  // CN_VIP UB
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c
@@ -20,6 +20,7 @@ int main() {
   int *p = (int *)ux; // does this have undefined behaviour?
 #endif
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   //CN_VIP printf("Addresses: &x=%p p=%p &y=%"PRIxPTR\
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:26:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:30:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:32:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:33:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:26:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_auto_yx.annot.c:30:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c
@@ -20,6 +20,7 @@ int main()
   int *p = (int *)ux; // does this have undefined behaviour?
 #endif
   int *q = &y;
+  /*@ derive_constraints(RW<int*>(&p), RW<int*>(&q)); @*/
   //CN_VIP printf("Addresses: &x=%p p=%p &y=%"PRIxPTR\
          "\n",(void*)&x,(void*)p,(unsigned long)uy);
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:26:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:30:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:32:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:33:5: error: Missing resource for writing
     *p = 11; // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(value)

--- a/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:26:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<int*>(&p); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_basic_using_uintptr_t_global_yx.annot.c:30:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<int*>(&p); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c
@@ -20,6 +20,7 @@ int main()
 #else
   int *q = (int *)i4;
 #endif
+  /*@ derive_constraints(RW<uintptr_t>(&i1), RW<uintptr_t>(&i4)); @*/
   //CN_VIP printf("Addresses: p=%p\n",(void*)p);
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i4); @*/

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.no_annot
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.no_annot
@@ -1,12 +1,12 @@
 return code: 1
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- fail
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:31:5: error: Missing resource for writing
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:32:5: error: Missing resource for writing
     *q = 11;  // CN VIP UB (no annot)
     ~~~^~~~ 
 Resource needed: W<signed int>(intToPtr)

--- a/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.with_annot
+++ b/tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c.with_annot
@@ -1,8 +1,8 @@
 return code: 0
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:24:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:25:17: warning: experimental keyword 'to_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ to_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~ 
-tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:28:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
+tests/cn_vip_testsuite/provenance_lost_escape_1.annot.c:29:17: warning: experimental keyword 'from_bytes' (use of experimental features is discouraged)
   /*CN_VIP*//*@ from_bytes RW<uintptr_t>(&i1); @*/
                 ^~~~~~~~~~ 
 [1/1]: main -- pass

--- a/tests/cn_vip_testsuite/with_annot.json
+++ b/tests/cn_vip_testsuite/with_annot.json
@@ -2,5 +2,5 @@
     "name": "with_annot",
     "args": ["verify", "-DVIP", "-DANNOT", "-DNO_ROUND_TRIP", "--solver-type=cvc5", "--output-dir=/tmp"],
     "filter": "^((pointer_from_int_disambiguation_3\\.error\\.c)|(.*\\.annot\\.c))$",
-    "timeout": 55
+    "timeout": 60
 }

--- a/tests/cn_vip_testsuite/with_annot.json
+++ b/tests/cn_vip_testsuite/with_annot.json
@@ -1,6 +1,6 @@
 {
     "name": "with_annot",
-    "args": ["verify", "-DVIP", "-DANNOT", "-DNO_ROUND_TRIP", "--solver-type=cvc5", "--output-dir=/tmp"],
+    "args": ["verify", "-DVIP", "-DANNOT", "-DNO_ROUND_TRIP", "--solver-type=z3", "--output-dir=/tmp"],
     "filter": "^((pointer_from_int_disambiguation_3\\.error\\.c)|(.*\\.annot\\.c))$",
     "timeout": 60
 }


### PR DESCRIPTION
add CN command for deriving disjointness constraints from resource
ownership (but not for other derived constraints, which remain
automatic)