### PR TITLE
[CN-Rocq] Hide resource predicate bodies

### DIFF
--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -861,6 +861,23 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
     in
     s ^^ proof
   in
+  let unfold_predicate_bodies predicates statement =
+    let body_names =
+      separate (comma ^^ space) (List.map (fun pred -> !^(get_body_name pred)) predicates)
+    in
+    !^"ltac:"
+    ^^ parens
+         (align
+            (!^"let T := constr:"
+             ^^ parens statement
+             ^^^ !^"in"
+             ^^ hardline
+             ^^ !^"let T' := eval unfold"
+             ^^^ body_names
+             ^^^ !^"in T in"
+             ^^ hardline
+             ^^ !^"exact T'"))
+  in
   let make_induction_lemma index (predicates : CI.coq_resource_pred_group) =
     let make_assumption predicates (pred : CI.coq_resource_pred) =
       (* □ (∀ (p : Ptr) (ν : forest), IsForest_body Φ_IsForest Φ_IsTree p ν -∗ Φ_IsForest p ν) -∗ *)
@@ -949,7 +966,9 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       ^^^ nest 2 (hardline ^^ flow hardline [ name; arg1; arg2; arg3 ])
     in
     let args = List.map (fun p -> p |> make_induction_lemma_arg |> parens) predicates in
-    let statement = make_induction_lemma_statement predicates in
+    let statement =
+      make_induction_lemma_statement predicates |> unfold_predicate_bodies predicates
+    in
     let proof = make_induction_lemma_proof index predicates in
     let names = List.map (fun p -> Sym.pp (get_pred_name p)) predicates in
     let proof_name = separate underscore names ^^ underscore ^^ !^"induction" in
@@ -974,7 +993,7 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
             :: List.map (fun p -> Sym.pp (get_pred_name p)) predicates)
         @ List.map fst args
       in
-      infix 2 1 !^"⊣⊢" body1 body2
+      infix 2 1 !^"⊣⊢" body1 body2 |> unfold_predicate_bodies [ pred ]
     in
     let proof =
       let rewrites = List.map (fun p -> !^"/" ^^ Sym.pp (get_pred_name p)) predicates in
@@ -989,13 +1008,20 @@ let translate_pred (gl : Global.t) (preds : CI.coq_resource_pred_group list) =
       statement
       proof
   in
+  let make_opaque (predicates : CI.coq_resource_pred_group) =
+    !^"Global Opaque"
+    ^^^ build (List.map (fun pred -> Sym.pp (get_pred_name pred)) predicates)
+    ^^ dot
+    ^^ hardline
+  in
   let unpack_group index (predicates : CI.coq_resource_pred_group) =
     let group_type = make_group_type index predicates in
     let pred_defs = List.map (unpack_body predicates) predicates in
     let fixpoint = make_fixpoints index predicates in
     let induction_lemma = make_induction_lemma index predicates in
     let unfold_lemmata = List.map (make_unfold_lemma index predicates) predicates in
-    (group_type, pred_defs @ (fixpoint :: induction_lemma :: unfold_lemmata))
+    let opaque = make_opaque predicates in
+    (group_type, pred_defs @ (fixpoint :: induction_lemma :: unfold_lemmata) @ [ opaque ])
   in
   let groups = List.mapi unpack_group preds in
   (List.map fst groups, List.concat_map snd groups)


### PR DESCRIPTION
Given a recursive resource predicate `predicate P(x) = { e }`, the fixpoint machinery in Rocq-Iris is currently implemented in three steps:

1. define an auxiliary predicate body Ψ = λP. λx. [e].  where [ ] is the translation from CN AST to Rocq-Iris expr
2. define a monotone function F P X = φ[Ψ, P, X] (more precisely, with some data structure plumbing for mutual recursions)
3. get a fixpoint P by `bi_least_fixpoint F`

This design is for simplicity of the generation code, in particular when dealing with mutually recursive predicates. However, the auxiliary body definitions were exposed in the generated induction and unfolding lemmas, forcing users to understand parts of the fixpoint encoding.

This PR hides these implementation details by "inlining the auxiliary predicate bodies" on definition, while keeping the generation code's simplicity.