### PR TITLE
[CN-Rocq] Add list segment test case

### DIFF
--- a/tests/rocq_lemmas/cases/list_segment/list_seg.c
+++ b/tests/rocq_lemmas/cases/list_segment/list_seg.c
@@ -1,0 +1,39 @@
+struct list {
+  int value;
+  struct list *next;
+};
+
+/*@
+datatype list_cn {
+  Nil {},
+  Cons {i32 head, datatype list_cn tail}
+}
+
+predicate [rec] (datatype list_cn) ListSeg(pointer p, pointer q) {
+  if (ptr_eq(p, q)) {
+    return Nil {};
+  } else {
+    assert (!is_null(p));
+    take node = RW<struct list>(p);
+    take tail = ListSeg(node.next, q);
+    return Cons {head: node.value, tail: tail};
+  }
+}
+
+predicate [rec] (datatype list_cn) List(pointer p) {
+  if (is_null(p)) {
+    return Nil {};
+  } else {
+    take node = RW<struct list>(p);
+    take tail = List(node.next);
+    return Cons {head: node.value, tail: tail};
+  }
+}
+
+lemma ListSeg_List(pointer p, pointer q)
+  requires
+    take segment = ListSeg(p, q);
+    take suffix = List(q);
+  ensures
+    take whole = List(p);
+@*/

--- a/tests/rocq_lemmas/proofs/list_segment/Inst_Spec.v
+++ b/tests/rocq_lemmas/proofs/list_segment/Inst_Spec.v
@@ -1,0 +1,63 @@
+Require Import ZArith Bool.
+Require Import CN_Lemmas.Gen_Spec CN_Lemmas.CN_Lib_Iris.
+From iris.proofmode Require Import proofmode.
+
+Import CN_Lemmas.Gen_Spec.Types.
+
+Module Inst.
+End Inst.
+
+Module InstOK : CN_Lemmas.Gen_Spec.Lemma_Spec (Inst).
+  Module L := CN_Lemmas.Gen_Spec.Lemma_Defs (Inst).
+  Module Preds := L.R.
+  Import Preds L.
+  Open Scope Z.
+
+  Section Proof.
+  Context `{!heapGS_gen Σ}.
+
+  Local Notation "⊢ P" := (⊢@{iPropI Σ} P).
+
+  Lemma ListSeg_List : ⊢ ListSeg_List_type.
+  Proof.
+    iIntros (p q segment) "Hsegment".
+    iIntros (suffix) "Hsuffix".
+    iPoseProof
+      (ListSeg_induction
+         (fun p q _ => ∀ suffix, List q suffix -∗ ∃ whole, List p whole)%I
+         with "[]") as "#Hind".
+    { iIntros "!>" (p' q' segment') "Hbody".
+      iIntros (suffix') "Hsuffix'".
+      iDestruct "Hbody" as "[Hnil | Hcons]".
+      - iDestruct "Hnil" as "[%Hpq _]".
+        unfold Preds.D.ptr_eq in Hpq.
+        apply Is_true_eq_true in Hpq.
+        apply Z.eqb_eq in Hpq.
+        subst q'.
+        iExists suffix'.
+        iFrame.
+      - iDestruct "Hcons" as "[_ Hcons]".
+        iDestruct "Hcons" as "[_ Hcons]".
+        iDestruct "Hcons" as "[%Hp_nonnull Hnodes]".
+        iDestruct "Hnodes" as (node) "[Hnode Htail]".
+        iDestruct "Htail" as (tail) "[IH _]".
+        iDestruct ("IH" with "Hsuffix'") as (whole_tail) "Htail".
+        iExists (Cons (Preds.D.value node) whole_tail).
+        iApply List_unfold.
+        iRight.
+        iSplit; first done.
+        iSplit; first done.
+        iExists node.
+        iSplitL "Hnode"; first iExact "Hnode".
+        iExists whole_tail.
+        iFrame.
+        done. }
+    iSpecialize ("Hind" $! p q segment).
+    iSpecialize ("Hind" with "Hsegment").
+    iDestruct ("Hind" $! suffix with "Hsuffix") as (whole) "Hwhole".
+    iExists whole.
+    iFrame.
+  Qed.
+
+  End Proof.
+End InstOK.

--- a/tests/rocq_lemmas/proofs/list_segment/_CoqProject
+++ b/tests/rocq_lemmas/proofs/list_segment/_CoqProject
@@ -1,0 +1,6 @@
+-Q theories CN_Lemmas
+
+theories/CN_Lib.v
+theories/CN_Lib_Iris.v
+theories/Gen_Spec.v
+theories/Inst_Spec.v

--- a/tests/run-cn-lemmas.sh
+++ b/tests/run-cn-lemmas.sh
@@ -73,6 +73,7 @@ while IFS='|' read -r case_name source_dir input_file; do
   fi
 done <<'EOF'
 list_rev|list|rev.c
+list_segment|list_segment|list_seg.c
 array_combine|arrays/combine|array_lemma.c
 arrays_inductive|arrays/inductive|array_lemma.c
 arrays_testing|arrays/testing|array_lemma.c


### PR DESCRIPTION
This is the first test case that uses the fixpoint machinery for resource predicates.
The lemma is the standard list segment entailment, `List(q) * ListSeg(p, q) => List(p)`, which is stated in CN as follows:

```
lemma ListSeg_List(pointer p, pointer q)
  requires
    take segment = ListSeg(p, q);
    take suffix = List(q);
  ensures
    take whole = List(p);
```

I used Codex for generating the proof of the lemma in Rocq