### PR TITLE
[CN-Rocq] Fix incorrect ordering of struct printing

### DIFF
--- a/lib/lemmata.ml
+++ b/lib/lemmata.ml
@@ -596,6 +596,26 @@ let convert_lemma_defs global (lemmas : CI.coq_lemma list) =
   tys
 
 
+let generate_structs (struct_decls : Memory.struct_decls) =
+  let open Pp in
+  let get_struct_field (piece : Memory.struct_piece) =
+    match piece.member_or_padding with
+    | Some (id, ctype) ->
+      !^("  " ^ Id.get_string id ^ " : " ^ print_ctype ctype ^ "; ") ^^ hardline
+    | None -> rets ""
+  in
+  let unpack_struct_type (decl : Sym.t * Memory.struct_layout) =
+    let nm = !^(Sym.pp_string (fst decl)) in
+    !^"  Record "
+    ^^ nm
+    ^^ !^" : Type := { "
+    ^^ hardline
+    ^^ build (List.map get_struct_field (snd decl))
+    ^^ !^" }."
+  in
+  List.map unpack_struct_type (Sym.Map.bindings struct_decls)
+
+
 (* print datatypes *)
 let translate_datatypes (dtys : CI.coq_dt list list) =
   let open Pp in
@@ -1089,7 +1109,7 @@ let translate_fun (gl : Global.t) (funs : CI.coq_fun list list * CI.coq_fun list
 
 
 (* generate records and Owned_Structname predicates for all structs*)
-let translate_structs (struct_decls : Memory.struct_decls) =
+let translate_own_structs (struct_decls : Memory.struct_decls) =
   let open Pp in
   let piece_to_owned (piece : Memory.struct_piece) =
     let make_owned (nm : string) (id : Id.t) =
@@ -1125,23 +1145,9 @@ let translate_structs (struct_decls : Memory.struct_decls) =
     | x :: [] -> piece_to_owned x ^^ !^"."
     | x :: xs -> piece_to_owned x ^^ !^" ∗ " ^^ decl_to_pieces xs
   in
-  let get_struct_field (piece : Memory.struct_piece) =
-    match piece.member_or_padding with
-    | Some (id, ctype) ->
-      !^("  " ^ Id.get_string id ^ " : " ^ print_ctype ctype ^ "; ") ^^ hardline
-    | None -> rets ""
-  in
   let unpack_decls (decl : Sym.t * Memory.struct_layout) =
     let nm = !^(Sym.pp_string (fst decl)) in
-    !^"  Record "
-    ^^ nm
-    ^^ !^" : Type := { "
-    ^^ hardline
-    ^^ build (List.map get_struct_field (snd decl))
-    ^^ !^" }."
-    ^^ hardline
-    ^^ hardline
-    ^^ !^"  Definition "
+    !^"  Definition "
     ^^ !^"Owned_"
     ^^ nm
     ^^ !^" (l: Ptr) (v : "
@@ -1165,18 +1171,19 @@ let generate (global : Global.t) directions (lemmata : (Sym.t * (Loc.t * AT.lemm
       CC.cn_to_coq_ir global lemmata
     in
     (* print datatypes *)
+    let struct_defs = generate_structs global.struct_decls in
     let dtypes = translate_datatypes dtys in
     let structs =
       if global.struct_decls == Sym.Map.empty then
         [ Pp.string "(* no struct definitions required *)" ]
       else
-        translate_structs global.struct_decls
+        translate_own_structs global.struct_decls
     in
     let translated_funs = translate_fun global funs in
     let translated_uninterp_preds = translate_uninterp_pred uninterp_preds in
     let pred_group_tys, translated_preds = translate_pred global preds in
     (* print datatypes *)
-    Pp.print channel (types_spec (dtypes @ pred_group_tys));
+    Pp.print channel (types_spec (struct_defs @ dtypes @ pred_group_tys));
     (* print uninterpreted logical functions and resource predicates as parameters *)
     Pp.print channel (param_spec (fst translated_funs));
     (* print structs and function definitions *)

--- a/tests/rocq_lemmas/cases/basics/datatype.c
+++ b/tests/rocq_lemmas/cases/basics/datatype.c
@@ -1,0 +1,19 @@
+struct data {
+  int x;
+};
+
+/*@
+datatype data_option {
+  Data_none {},
+  Data_some { struct data value }
+}
+
+lemma data_option_trivial (datatype data_option x)
+  requires true;
+  ensures true;
+@*/
+
+int main(void)
+{
+  return 0;
+}

--- a/tests/rocq_lemmas/proofs/basics/Inst_Spec.v
+++ b/tests/rocq_lemmas/proofs/basics/Inst_Spec.v
@@ -1,0 +1,24 @@
+Require Import CN_Lemmas.Gen_Spec.
+Require CN_Lemmas.CN_Lib.
+Require Import CN_Lemmas.CN_Lib_Iris.
+Import CN_Lemmas.Gen_Spec.Types.
+From iris.proofmode Require Import proofmode.
+
+Module Inst.
+End Inst.
+
+Module InstOK: CN_Lemmas.Gen_Spec.Lemma_Spec(Inst).
+
+  Module L := CN_Lemmas.Gen_Spec.Lemma_Defs (Inst).
+
+  Section Proof.
+    Import L.
+    Context `{!heapGS_gen Σ}.
+    Local Notation "⊢ P" := (⊢@{iPropI Σ} P).
+    Lemma data_option_trivial : ⊢ data_option_trivial_type.
+    Proof.
+      iIntros (p).
+      done.
+    Qed.
+  End Proof.
+End InstOK.

--- a/tests/rocq_lemmas/proofs/basics/_CoqProject
+++ b/tests/rocq_lemmas/proofs/basics/_CoqProject
@@ -1,0 +1,6 @@
+-Q theories CN_Lemmas
+
+theories/CN_Lib.v
+theories/CN_Lib_Iris.v
+theories/Gen_Spec.v
+theories/Inst_Spec.v

--- a/tests/rocq_lemmas/proofs/list_segment/Inst_Spec.v
+++ b/tests/rocq_lemmas/proofs/list_segment/Inst_Spec.v
@@ -2,7 +2,8 @@ Require Import ZArith Bool.
 Require Import CN_Lemmas.Gen_Spec CN_Lemmas.CN_Lib_Iris.
 From iris.proofmode Require Import proofmode.
 
-Import CN_Lemmas.Gen_Spec.Types.
+Module Types := CN_Lemmas.Gen_Spec.Types.
+Import Types.
 
 Module Inst.
 End Inst.
@@ -42,7 +43,7 @@ Module InstOK : CN_Lemmas.Gen_Spec.Lemma_Spec (Inst).
         iDestruct "Hnodes" as (node) "[Hnode Htail]".
         iDestruct "Htail" as (tail) "[IH _]".
         iDestruct ("IH" with "Hsuffix'") as (whole_tail) "Htail".
-        iExists (Cons (Preds.D.value node) whole_tail).
+        iExists (Cons (Types.value node) whole_tail).
         iApply List_unfold.
         iRight.
         iSplit; first done.

--- a/tests/run-cn-lemmas.sh
+++ b/tests/run-cn-lemmas.sh
@@ -79,6 +79,7 @@ arrays_inductive|arrays/inductive|array_lemma.c
 arrays_testing|arrays/testing|array_lemma.c
 pop_queue|queue|pop.c
 struct_test|struct_test|test.c
+basics|basics|datatype.c
 EOF
 
 if ! run_and_report fixpoint run_fixpoint_test; then


### PR DESCRIPTION
The translation for the following program was broken.

```c
struct data {
  int x;
};

/*@
datatype data_option {
  Data_none {},
  Data_some { struct data value }
}
lemma data_option_trivial (datatype data_option x)
  requires true;
  ensures true;
@*/

int main(void)
{
  return 0;
}
```

This is because the rocq code for `struct data` is generated after the code for `data_option` is generated.