### PR TITLE
[Fulminate] Clean up initialisation

### DIFF
--- a/lib/fulminate/cn_to_ail.ml
+++ b/lib/fulminate/cn_to_ail.ml
@@ -4533,7 +4533,7 @@ let get_loop_ownership_bs_and_ss () =
     create_binding loop_local_ownership_sym loop_ownership_struct_ptr_ctype
   in
   let loop_ownership_init_fn_call =
-    A.(AilEcall (mk_expr (AilEident (Sym.fresh "initialise_loop_ownership_state")), []))
+    A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_loop_ownership_state")), []))
   in
   let loop_ownership_decl = A.(AilSdeclaration [ (loop_local_ownership_sym, None) ]) in
   let loop_ownership_assign =

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -716,16 +716,16 @@ let generate_global_assignments
           @ global_map_stmts_ )
     in
     let global_unmapping_stmts_ = List.map OE.generate_c_local_ownership_exit globals in
-    let free_ghost_frame_stack_fn_str = "free_ghost_frame_stack" in
+    (* let free_ghost_frame_stack_fn_str = "free_ghost_frame_stack" in
     let free_ghost_frame_stack_decl =
       A.(
         AilSexpr
           (mk_expr
              (AilEcall (mk_expr (AilEident (Sym.fresh free_ghost_frame_stack_fn_str)), []))))
-    in
+    in *)
     let global_unmapping_str =
       generate_ail_stat_strs
-        ([], global_unmapping_stmts_ @ [ free_ghost_frame_stack_decl ])
+        ([], global_unmapping_stmts_ (* @ [ free_ghost_frame_stack_decl ] *))
     in
     [ (main_sym, (init_and_global_mapping_str, global_unmapping_str)) ]
 

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -703,6 +703,7 @@ let generate_global_assignments
     let assignments =
       OE.get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size ()
     in
+    (* TODO: Add Ail generation for new Fulminate init function *)
     let init_and_global_mapping_str =
       generate_ail_stat_strs
         ( [],

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -680,13 +680,10 @@ let generate_global_assignments
   let exec_c_locs_mode =
     if experimental_ownership_stack_mode then false else exec_c_locs_mode
   in
-  let gen_ail_const_from_flag flag =
-    A.(
-      AilEconst (ConstantInteger (IConstant (Z.of_int (Bool.to_int flag), Decimal, None))))
-  in
   let gen_ail_const_from_int i =
     A.(AilEconst (ConstantInteger (IConstant (Z.of_int i, Decimal, None))))
   in
+  let gen_ail_const_from_flag flag = gen_ail_const_from_int (Bool.to_int flag) in
   match get_main sigm with
   | [] -> []
   | (main_sym, _) :: _ ->

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -680,19 +680,9 @@ let generate_global_assignments
   let exec_c_locs_mode =
     if experimental_ownership_stack_mode then false else exec_c_locs_mode
   in
-  let generate_flag_init_stat (flag, str) =
-    let gen_ail_const_from_flag flag =
-      A.(
-        AilEconst
-          (ConstantInteger (IConstant (Z.of_int (Bool.to_int flag), Decimal, None))))
-    in
-    let ownership_stack_mode_init_expr_ =
-      A.(
-        AilEcall
-          ( mk_expr (AilEident (Sym.fresh ("initialise_" ^ str))),
-            [ mk_expr (gen_ail_const_from_flag flag) ] ))
-    in
-    A.AilSexpr (mk_expr ownership_stack_mode_init_expr_)
+  let gen_ail_const_from_flag flag =
+    A.(
+      AilEconst (ConstantInteger (IConstant (Z.of_int (Bool.to_int flag), Decimal, None))))
   in
   match get_main sigm with
   | [] -> []
@@ -700,35 +690,39 @@ let generate_global_assignments
     let globals = Cn_to_ail.extract_global_variables cabs_tunit prog5 in
     let global_map_fcalls = List.map OE.generate_c_local_ownership_entry_fcall globals in
     let global_map_stmts_ = List.map (fun e -> A.AilSexpr e) global_map_fcalls in
+    (* TODO: Add to Fulminate init function as parameters *)
     let assignments =
       OE.get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size ()
     in
-    (* TODO: Add Ail generation for new Fulminate init function *)
-    let init_and_global_mapping_str =
-      generate_ail_stat_strs
-        ( [],
-          assignments
-          @ List.map
-              generate_flag_init_stat
-              [ (exec_c_locs_mode, "exec_c_locs_mode");
-                (correct_missing_ownership_mode, "correct_missing_ownership");
-                (experimental_ownership_stack_mode, "ownership_stack_mode")
-              ]
-          @ global_map_stmts_ )
+    let struct_tag = Sym.fresh "fulm_init_flags" in
+    let member_pairs =
+      [ ("with_ghost_args", true);
+        ("exec_c_locs_mode", exec_c_locs_mode);
+        ("correct_missing_ownership", correct_missing_ownership_mode);
+        ("ownership_stack_mode", experimental_ownership_stack_mode)
+      ]
     in
+    let struct_member_pairs =
+      List.map
+        (fun (str, flag) ->
+           ( Id.make Cerb_location.unknown str,
+             Some (mk_expr (gen_ail_const_from_flag flag)) ))
+        member_pairs
+    in
+    let struct_initialiser = A.AilEstruct (struct_tag, struct_member_pairs) in
+    let fulm_init_fcall_ident = A.(AilEident (Sym.fresh "fulminate_init")) in
+    let fulm_init_fcall =
+      mk_expr
+        A.(
+          AilEcall (mk_expr fulm_init_fcall_ident, List.map mk_expr [ struct_initialiser ]))
+    in
+    let init_str =
+      generate_ail_stat_strs ([], assignments @ [ A.(AilSexpr fulm_init_fcall) ])
+    in
+    let global_mapping_str = generate_ail_stat_strs ([], global_map_stmts_) in
     let global_unmapping_stmts_ = List.map OE.generate_c_local_ownership_exit globals in
-    (* let free_ghost_frame_stack_fn_str = "free_ghost_frame_stack" in
-    let free_ghost_frame_stack_decl =
-      A.(
-        AilSexpr
-          (mk_expr
-             (AilEcall (mk_expr (AilEident (Sym.fresh free_ghost_frame_stack_fn_str)), []))))
-    in *)
-    let global_unmapping_str =
-      generate_ail_stat_strs
-        ([], global_unmapping_stmts_ (* @ [ free_ghost_frame_stack_decl ] *))
-    in
-    [ (main_sym, (init_and_global_mapping_str, global_unmapping_str)) ]
+    let global_unmapping_str = generate_ail_stat_strs ([], global_unmapping_stmts_) in
+    [ (main_sym, (init_str @ global_mapping_str, global_unmapping_str)) ]
 
 
 (* Needed for handling typedef definitions *)

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -684,41 +684,61 @@ let generate_global_assignments
     A.(
       AilEconst (ConstantInteger (IConstant (Z.of_int (Bool.to_int flag), Decimal, None))))
   in
+  let gen_ail_const_from_int i =
+    A.(AilEconst (ConstantInteger (IConstant (Z.of_int i, Decimal, None))))
+  in
   match get_main sigm with
   | [] -> []
   | (main_sym, _) :: _ ->
     let globals = Cn_to_ail.extract_global_variables cabs_tunit prog5 in
     let global_map_fcalls = List.map OE.generate_c_local_ownership_entry_fcall globals in
     let global_map_stmts_ = List.map (fun e -> A.AilSexpr e) global_map_fcalls in
-    (* TODO: Add to Fulminate init function as parameters *)
-    let assignments =
-      OE.get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size ()
-    in
-    let struct_tag = Sym.fresh "fulm_init_flags" in
-    let member_pairs =
+    let flags_struct_tag = Sym.fresh "fulm_init_flags" in
+    let flags_member_pairs =
       [ ("with_ghost_args", true);
         ("exec_c_locs_mode", exec_c_locs_mode);
         ("correct_missing_ownership", correct_missing_ownership_mode);
         ("ownership_stack_mode", experimental_ownership_stack_mode)
       ]
     in
-    let struct_member_pairs =
+    let flags_struct_member_pairs =
       List.map
         (fun (str, flag) ->
            ( Id.make Cerb_location.unknown str,
              Some (mk_expr (gen_ail_const_from_flag flag)) ))
-        member_pairs
+        flags_member_pairs
     in
-    let struct_initialiser = A.AilEstruct (struct_tag, struct_member_pairs) in
+    let flags_struct_initialiser =
+      A.AilEstruct (flags_struct_tag, flags_struct_member_pairs)
+    in
+    let config_struct_tag = Sym.fresh "fulm_init_config" in
+    let config_member_pairs =
+      [ ("max_bump_blocks", Option.value max_bump_blocks ~default:0);
+        ("bump_block_size", Option.value bump_block_size ~default:0)
+      ]
+    in
+    let config_struct_member_pairs =
+      List.map
+        (fun (str, i) ->
+           (Id.make Cerb_location.unknown str, Some (mk_expr (gen_ail_const_from_int i))))
+        config_member_pairs
+    in
+    let config_flags_member =
+      (Id.make Cerb_location.unknown "flags", Some (mk_expr flags_struct_initialiser))
+    in
+    let config_struct_initialiser =
+      A.(
+        AilEstruct
+          (config_struct_tag, config_struct_member_pairs @ [ config_flags_member ]))
+    in
     let fulm_init_fcall_ident = A.(AilEident (Sym.fresh "fulminate_init")) in
     let fulm_init_fcall =
       mk_expr
         A.(
-          AilEcall (mk_expr fulm_init_fcall_ident, List.map mk_expr [ struct_initialiser ]))
+          AilEcall
+            (mk_expr fulm_init_fcall_ident, List.map mk_expr [ config_struct_initialiser ]))
     in
-    let init_str =
-      generate_ail_stat_strs ([], assignments @ [ A.(AilSexpr fulm_init_fcall) ])
-    in
+    let init_str = generate_ail_stat_strs ([], [ A.(AilSexpr fulm_init_fcall) ]) in
     let global_mapping_str = generate_ail_stat_strs ([], global_map_stmts_) in
     let global_unmapping_stmts_ = List.map OE.generate_c_local_ownership_exit globals in
     let global_unmapping_str = generate_ail_stat_strs ([], global_unmapping_stmts_) in

--- a/lib/fulminate/internal.ml
+++ b/lib/fulminate/internal.ml
@@ -666,6 +666,64 @@ let has_main (sigm : CF.GenTypes.genTypeCategory CF.AilSyntax.sigma) =
   List.non_empty (get_main sigm)
 
 
+let get_global_init_stats
+      ?max_bump_blocks
+      ?bump_block_size
+      ?(exec_c_locs_mode = false)
+      ?(correct_missing_ownership_mode = false)
+      ?(experimental_ownership_stack_mode = false)
+      ()
+  =
+  let gen_ail_const_from_int i =
+    A.(AilEconst (ConstantInteger (IConstant (Z.of_int i, Decimal, None))))
+  in
+  let gen_ail_const_from_flag flag = gen_ail_const_from_int (Bool.to_int flag) in
+  let flags_struct_tag = Sym.fresh "fulm_init_flags" in
+  let flags_member_pairs =
+    [ ("with_ghost_args", true);
+      ("exec_c_locs_mode", exec_c_locs_mode);
+      ("correct_missing_ownership", correct_missing_ownership_mode);
+      ("ownership_stack_mode", experimental_ownership_stack_mode)
+    ]
+  in
+  let flags_struct_member_pairs =
+    List.map
+      (fun (str, flag) ->
+         (Id.make Cerb_location.unknown str, Some (mk_expr (gen_ail_const_from_flag flag))))
+      flags_member_pairs
+  in
+  let flags_struct_initialiser =
+    A.AilEstruct (flags_struct_tag, flags_struct_member_pairs)
+  in
+  let config_struct_tag = Sym.fresh "fulm_init_config" in
+  let config_member_pairs =
+    [ ("max_bump_blocks", Option.value max_bump_blocks ~default:0);
+      ("bump_block_size", Option.value bump_block_size ~default:0)
+    ]
+  in
+  let config_struct_member_pairs =
+    List.map
+      (fun (str, i) ->
+         (Id.make Cerb_location.unknown str, Some (mk_expr (gen_ail_const_from_int i))))
+      config_member_pairs
+  in
+  let config_flags_member =
+    (Id.make Cerb_location.unknown "flags", Some (mk_expr flags_struct_initialiser))
+  in
+  let config_struct_initialiser =
+    A.(
+      AilEstruct (config_struct_tag, config_struct_member_pairs @ [ config_flags_member ]))
+  in
+  let fulm_init_fcall_ident = A.(AilEident (Sym.fresh "fulminate_init")) in
+  let fulm_init_fcall =
+    mk_expr
+      A.(
+        AilEcall
+          (mk_expr fulm_init_fcall_ident, List.map mk_expr [ config_struct_initialiser ]))
+  in
+  A.(AilSexpr fulm_init_fcall)
+
+
 let generate_global_assignments
       ?(exec_c_locs_mode = false)
       ?(correct_missing_ownership_mode = false)
@@ -680,62 +738,22 @@ let generate_global_assignments
   let exec_c_locs_mode =
     if experimental_ownership_stack_mode then false else exec_c_locs_mode
   in
-  let gen_ail_const_from_int i =
-    A.(AilEconst (ConstantInteger (IConstant (Z.of_int i, Decimal, None))))
-  in
-  let gen_ail_const_from_flag flag = gen_ail_const_from_int (Bool.to_int flag) in
   match get_main sigm with
   | [] -> []
   | (main_sym, _) :: _ ->
     let globals = Cn_to_ail.extract_global_variables cabs_tunit prog5 in
     let global_map_fcalls = List.map OE.generate_c_local_ownership_entry_fcall globals in
     let global_map_stmts_ = List.map (fun e -> A.AilSexpr e) global_map_fcalls in
-    let flags_struct_tag = Sym.fresh "fulm_init_flags" in
-    let flags_member_pairs =
-      [ ("with_ghost_args", true);
-        ("exec_c_locs_mode", exec_c_locs_mode);
-        ("correct_missing_ownership", correct_missing_ownership_mode);
-        ("ownership_stack_mode", experimental_ownership_stack_mode)
-      ]
-    in
-    let flags_struct_member_pairs =
-      List.map
-        (fun (str, flag) ->
-           ( Id.make Cerb_location.unknown str,
-             Some (mk_expr (gen_ail_const_from_flag flag)) ))
-        flags_member_pairs
-    in
-    let flags_struct_initialiser =
-      A.AilEstruct (flags_struct_tag, flags_struct_member_pairs)
-    in
-    let config_struct_tag = Sym.fresh "fulm_init_config" in
-    let config_member_pairs =
-      [ ("max_bump_blocks", Option.value max_bump_blocks ~default:0);
-        ("bump_block_size", Option.value bump_block_size ~default:0)
-      ]
-    in
-    let config_struct_member_pairs =
-      List.map
-        (fun (str, i) ->
-           (Id.make Cerb_location.unknown str, Some (mk_expr (gen_ail_const_from_int i))))
-        config_member_pairs
-    in
-    let config_flags_member =
-      (Id.make Cerb_location.unknown "flags", Some (mk_expr flags_struct_initialiser))
-    in
-    let config_struct_initialiser =
-      A.(
-        AilEstruct
-          (config_struct_tag, config_struct_member_pairs @ [ config_flags_member ]))
-    in
-    let fulm_init_fcall_ident = A.(AilEident (Sym.fresh "fulminate_init")) in
     let fulm_init_fcall =
-      mk_expr
-        A.(
-          AilEcall
-            (mk_expr fulm_init_fcall_ident, List.map mk_expr [ config_struct_initialiser ]))
+      get_global_init_stats
+        ?max_bump_blocks
+        ?bump_block_size
+        ~exec_c_locs_mode
+        ~correct_missing_ownership_mode
+        ~experimental_ownership_stack_mode
+        ()
     in
-    let init_str = generate_ail_stat_strs ([], [ A.(AilSexpr fulm_init_fcall) ]) in
+    let init_str = generate_ail_stat_strs ([], [ fulm_init_fcall ]) in
     let global_mapping_str = generate_ail_stat_strs ([], global_map_stmts_) in
     let global_unmapping_stmts_ = List.map OE.generate_c_local_ownership_exit globals in
     let global_unmapping_str = generate_ail_stat_strs ([], global_unmapping_stmts_) in

--- a/lib/fulminate/internal.mli
+++ b/lib/fulminate/internal.mli
@@ -96,6 +96,15 @@ val generate_conversion_and_equality_functions
 
 val has_main : GenTypes.genTypeCategory AilSyntax.sigma -> bool
 
+val get_global_init_stats
+  :  ?max_bump_blocks:int ->
+  ?bump_block_size:int ->
+  ?exec_c_locs_mode:bool ->
+  ?correct_missing_ownership_mode:bool ->
+  ?experimental_ownership_stack_mode:bool ->
+  unit ->
+  GenTypes.genTypeCategory AilSyntax.statement_
+
 val generate_global_assignments
   :  ?exec_c_locs_mode:bool ->
   ?correct_missing_ownership_mode:bool ->

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -61,24 +61,8 @@ let get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size () =
     ]
     |> List.filter_map Fun.id
   in
-  let cn_ghost_state_init_fcall =
-    mk_expr
-      A.(
-        AilEcall (mk_expr (AilEident (Sym.fresh "initialise_ownership_ghost_state")), []))
-  in
-  let cn_ghost_stack_depth_init_fcall =
-    mk_expr
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh "initialise_ghost_stack_depth")), []))
-  in
-  let fcalls = [ cn_ghost_state_init_fcall; cn_ghost_stack_depth_init_fcall ] in
-  let fcalls =
-    let cn_initialise_ghost_frame_stack_fcall =
-      mk_expr
-        A.(AilEcall (mk_expr (AilEident (Sym.fresh "initialise_ghost_frame_stack")), []))
-    in
-    fcalls @ [ cn_initialise_ghost_frame_stack_fcall ]
-  in
-  List.map (fun e -> A.(AilSexpr e)) (bump_config_calls @ fcalls)
+  (* TODO: Add to new fulminate_init function parameters *)
+  List.map (fun e -> A.(AilSexpr e)) bump_config_calls
 
 
 let generate_c_local_cn_addr_var sym =

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -45,39 +45,6 @@ let c_remove_ownership_fn_sym = Sym.fresh "c_remove_from_ghost_state"
    let c_declare_init_and_map_local_sym = Sym.fresh "c_declare_init_and_map_local"
 *)
 
-let get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size () =
-  let bump_config_calls =
-    let make_bump_config_call fn_name n =
-      mk_expr
-        A.(
-          AilEcall
-            ( mk_expr (AilEident (Sym.fresh fn_name)),
-              [ mk_expr
-                  (AilEconst (ConstantInteger (IConstant (Z.of_int n, Decimal, None))))
-              ] ))
-    in
-    [ Option.map (make_bump_config_call "cn_bump_set_max_blocks") max_bump_blocks;
-      Option.map (make_bump_config_call "cn_bump_set_block_size") bump_block_size
-    ]
-    |> List.filter_map Fun.id
-  in
-  let cn_ghost_state_init_fcall =
-    mk_expr
-      A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ownership_ghost_state")), []))
-  in
-  let cn_ghost_stack_depth_init_fcall =
-    mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ghost_stack_depth")), []))
-  in
-  let fcalls = [ cn_ghost_state_init_fcall; cn_ghost_stack_depth_init_fcall ] in
-  let fcalls =
-    let cn_initialise_ghost_frame_stack_fcall =
-      mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ghost_frame_stack")), []))
-    in
-    fcalls @ [ cn_initialise_ghost_frame_stack_fcall ]
-  in
-  List.map (fun e -> A.(AilSexpr e)) (bump_config_calls @ fcalls)
-
-
 let generate_c_local_cn_addr_var sym =
   (* Hardcoding parts of cn_to_ail_base_type to prevent circular dependency between
       this module and Cn_internal_to_ail, which includes Ownership already. *)

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -61,7 +61,6 @@ let get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size () =
     ]
     |> List.filter_map Fun.id
   in
-  (* TODO: Add to new fulminate_init function parameters *)
   List.map (fun e -> A.(AilSexpr e)) bump_config_calls
 
 

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -45,25 +45,6 @@ let c_remove_ownership_fn_sym = Sym.fresh "c_remove_from_ghost_state"
    let c_declare_init_and_map_local_sym = Sym.fresh "c_declare_init_and_map_local"
 *)
 
-let get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size () =
-  let bump_config_calls =
-    let make_bump_config_call fn_name n =
-      mk_expr
-        A.(
-          AilEcall
-            ( mk_expr (AilEident (Sym.fresh fn_name)),
-              [ mk_expr
-                  (AilEconst (ConstantInteger (IConstant (Z.of_int n, Decimal, None))))
-              ] ))
-    in
-    [ Option.map (make_bump_config_call "cn_bump_set_max_blocks") max_bump_blocks;
-      Option.map (make_bump_config_call "cn_bump_set_block_size") bump_block_size
-    ]
-    |> List.filter_map Fun.id
-  in
-  List.map (fun e -> A.(AilSexpr e)) bump_config_calls
-
-
 let generate_c_local_cn_addr_var sym =
   (* Hardcoding parts of cn_to_ail_base_type to prevent circular dependency between
       this module and Cn_internal_to_ail, which includes Ownership already. *)

--- a/lib/fulminate/ownership.ml
+++ b/lib/fulminate/ownership.ml
@@ -45,6 +45,39 @@ let c_remove_ownership_fn_sym = Sym.fresh "c_remove_from_ghost_state"
    let c_declare_init_and_map_local_sym = Sym.fresh "c_declare_init_and_map_local"
 *)
 
+let get_ownership_global_init_stats ?max_bump_blocks ?bump_block_size () =
+  let bump_config_calls =
+    let make_bump_config_call fn_name n =
+      mk_expr
+        A.(
+          AilEcall
+            ( mk_expr (AilEident (Sym.fresh fn_name)),
+              [ mk_expr
+                  (AilEconst (ConstantInteger (IConstant (Z.of_int n, Decimal, None))))
+              ] ))
+    in
+    [ Option.map (make_bump_config_call "cn_bump_set_max_blocks") max_bump_blocks;
+      Option.map (make_bump_config_call "cn_bump_set_block_size") bump_block_size
+    ]
+    |> List.filter_map Fun.id
+  in
+  let cn_ghost_state_init_fcall =
+    mk_expr
+      A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ownership_ghost_state")), []))
+  in
+  let cn_ghost_stack_depth_init_fcall =
+    mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ghost_stack_depth")), []))
+  in
+  let fcalls = [ cn_ghost_state_init_fcall; cn_ghost_stack_depth_init_fcall ] in
+  let fcalls =
+    let cn_initialise_ghost_frame_stack_fcall =
+      mk_expr A.(AilEcall (mk_expr (AilEident (Sym.fresh "init_ghost_frame_stack")), []))
+    in
+    fcalls @ [ cn_initialise_ghost_frame_stack_fcall ]
+  in
+  List.map (fun e -> A.(AilSexpr e)) (bump_config_calls @ fcalls)
+
+
 let generate_c_local_cn_addr_var sym =
   (* Hardcoding parts of cn_to_ail_base_type to prevent circular dependency between
       this module and Cn_internal_to_ail, which includes Ownership already. *)

--- a/lib/fulminate/ownership.mli
+++ b/lib/fulminate/ownership.mli
@@ -27,6 +27,12 @@ val cn_loop_put_back_ownership_sym : Sym.t
 
 val cn_loop_leak_check_sym : Sym.t
 
+val get_ownership_global_init_stats
+  :  ?max_bump_blocks:int ->
+  ?bump_block_size:int ->
+  unit ->
+  GenTypes.genTypeCategory AilSyntax.statement_ list
+
 val generate_c_local_ownership_entry_fcall
   :  AilSyntax.ail_identifier * Ctype.ctype ->
   GenTypes.genTypeCategory AilSyntax.expression

--- a/lib/fulminate/ownership.mli
+++ b/lib/fulminate/ownership.mli
@@ -27,12 +27,6 @@ val cn_loop_put_back_ownership_sym : Sym.t
 
 val cn_loop_leak_check_sym : Sym.t
 
-val get_ownership_global_init_stats
-  :  ?max_bump_blocks:int ->
-  ?bump_block_size:int ->
-  unit ->
-  GenTypes.genTypeCategory AilSyntax.statement_ list
-
 val generate_c_local_ownership_entry_fcall
   :  AilSyntax.ail_identifier * Ctype.ctype ->
   GenTypes.genTypeCategory AilSyntax.expression

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -194,7 +194,14 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
   ^^ string "int main"
   ^^ parens (string "int argc, char* argv[]")
   ^^ break 1
-  ^^ braces (nest 2 (hardline ^^ sequence) ^^ hardline)
+  ^^ braces
+       (nest
+          2
+          (hardline
+           ^^
+           let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
+           separate_map hardline SUtils.stmt_to_doc init_ghost ^^ hardline ^^ sequence)
+        ^^ hardline)
 
 
 let rec gen_sequence

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -199,8 +199,12 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
           2
           (hardline
            ^^
-           let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-           separate_map hardline SUtils.stmt_to_doc init_ghost ^^ hardline ^^ sequence)
+           let fulm_init =
+             Fulminate.Internal.get_global_init_stats ()
+             (* ghost arg init enabled *)
+           in
+           separate_map hardline SUtils.stmt_to_doc [ fulm_init ] ^^ hardline ^^ sequence
+          )
         ^^ hardline)
 
 

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -201,7 +201,7 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
            ^^
            let fulm_init =
              Fulminate.Internal.get_global_init_stats ()
-             (* ghost arg init enabled *)
+             (* ghost args enabled *)
            in
            separate_map hardline SUtils.stmt_to_doc [ fulm_init ] ^^ hardline ^^ sequence
           )

--- a/lib/seqTests/seqTests.ml
+++ b/lib/seqTests/seqTests.ml
@@ -194,14 +194,7 @@ let create_test_file (sequence : Pp.document) (fun_decls : Pp.document) : Pp.doc
   ^^ string "int main"
   ^^ parens (string "int argc, char* argv[]")
   ^^ break 1
-  ^^ braces
-       (nest
-          2
-          (hardline
-           ^^
-           let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-           separate_map hardline SUtils.stmt_to_doc init_ghost ^^ hardline ^^ sequence)
-        ^^ hardline)
+  ^^ braces (nest 2 (hardline ^^ sequence) ^^ hardline)
 
 
 let rec gen_sequence

--- a/lib/seqTests/utils.ml
+++ b/lib/seqTests/utils.ml
@@ -204,10 +204,6 @@ let create_intermediate_test_file
          (nest
             2
             (hardline
-             ^^
-             let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-             separate_map hardline stmt_to_doc init_ghost
-             ^^ hardline
              ^^ string "set_cn_failure_cb(&seq_failure_cb);"
              ^^ hardline
              ^^ sequence

--- a/lib/seqTests/utils.ml
+++ b/lib/seqTests/utils.ml
@@ -204,6 +204,10 @@ let create_intermediate_test_file
          (nest
             2
             (hardline
+             ^^
+             let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
+             separate_map hardline stmt_to_doc init_ghost
+             ^^ hardline
              ^^ string "set_cn_failure_cb(&seq_failure_cb);"
              ^^ hardline
              ^^ sequence

--- a/lib/seqTests/utils.ml
+++ b/lib/seqTests/utils.ml
@@ -205,8 +205,11 @@ let create_intermediate_test_file
             2
             (hardline
              ^^
-             let init_ghost = Fulminate.Ownership.get_ownership_global_init_stats () in
-             separate_map hardline stmt_to_doc init_ghost
+             let fulm_init =
+               Fulminate.Internal.get_global_init_stats ()
+               (* ghost arg init enabled *)
+             in
+             separate_map hardline stmt_to_doc [ fulm_init ]
              ^^ hardline
              ^^ string "set_cn_failure_cb(&seq_failure_cb);"
              ^^ hardline

--- a/lib/seqTests/utils.ml
+++ b/lib/seqTests/utils.ml
@@ -207,7 +207,7 @@ let create_intermediate_test_file
              ^^
              let fulm_init =
                Fulminate.Internal.get_global_init_stats ()
-               (* ghost arg init enabled *)
+               (* ghost args enabled *)
              in
              separate_map hardline stmt_to_doc [ fulm_init ]
              ^^ hardline

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -38,10 +38,18 @@ enum region_owned {
   FULL_WILDCARD,
 };
 
-/* Error handlers */
-void fulminate_destroy(void);
-void fulminate_init(void);
+struct fulm_init_flags {
+  _Bool exec_c_locs_mode;
+  _Bool correct_missing_ownership;
+  _Bool ownership_stack_mode;
+};
 
+void fulminate_destroy(_Bool with_ghost_args);
+void fulminate_init(_Bool with_ghost_args, struct fulm_init_flags flags);
+void fulminate_pbt_destroy(void);
+void fulminate_pbt_init(void);
+
+/* Error handlers */
 enum cn_logging_level {
   CN_LOGGING_NONE = 0,
   CN_LOGGING_ERROR = 1,
@@ -76,11 +84,9 @@ struct cn_error_message_info {
   struct cn_error_message_info* child;
 };
 
-void initialise_error_msg_info_(
-    const char* function_name, char* file_name, int line_number);
+void init_error_msg_info_(const char* function_name, char* file_name, int line_number);
 
-#define initialise_error_msg_info()                                                      \
-  initialise_error_msg_info_(__func__, __FILE__, __LINE__)
+#define init_error_msg_info() init_error_msg_info_(__func__, __FILE__, __LINE__)
 
 void reset_error_msg_info(void);
 void free_error_msg_info(void);
@@ -152,18 +158,18 @@ typedef struct cn_alloc_id {
 
 typedef hash_table cn_map;
 
-void initialise_ownership_ghost_state(void);
+void init_ownership_ghost_state(void);
 void free_ownership_ghost_state(void);
-void initialise_ghost_stack_depth(void);
-void initialise_exec_c_locs_mode(bool flag);
-void initialise_correct_missing_ownership(bool flag);
-void initialise_ownership_stack_mode(bool flag);
+void init_ghost_stack_depth(void);
+void init_exec_c_locs_mode(bool flag);
+void init_correct_missing_ownership(bool flag);
+void init_ownership_stack_mode(bool flag);
 signed long get_cn_stack_depth(void);
 void ghost_stack_depth_incr(void);
 void ghost_stack_depth_decr(void);
 void cn_postcondition_leak_check(void);
 
-struct loop_ownership* initialise_loop_ownership_state(void);
+struct loop_ownership* init_loop_ownership_state(void);
 void cn_loop_leak_check(void);
 void cn_loop_put_back_ownership(struct loop_ownership* loop_ownership);
 
@@ -593,7 +599,7 @@ enum region_owned c_ownership_check(char* access_kind,
     enum spec_mode spec_mode);
 
 /* Ghost arguments */
-void initialise_ghost_frame_stack(void);
+void init_ghost_frame_stack(void);
 void push_ghost_frame(int tag, int size);
 void add_arg_to_ghost_frame(int i, void* ptr_to_ghost_arg);
 void* load_arg_from_ghost_frame(int i);

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -45,8 +45,14 @@ struct fulm_init_flags {
   _Bool ownership_stack_mode;
 };
 
+struct fulm_init_config {
+  size_t max_bump_blocks;
+  size_t bump_block_size;
+  struct fulm_init_flags flags;
+};
+
 void fulminate_destroy(_Bool with_ghost_args);
-void fulminate_init(struct fulm_init_flags flags);
+void fulminate_init(struct fulm_init_config flags);
 void fulminate_pbt_destroy(void);
 void fulminate_pbt_init(void);
 

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -39,10 +39,10 @@ enum region_owned {
 };
 
 struct fulm_init_flags {
-  _Bool with_ghost_args;
-  _Bool exec_c_locs_mode;
-  _Bool correct_missing_ownership;
-  _Bool ownership_stack_mode;
+  bool with_ghost_args;
+  bool exec_c_locs_mode;
+  bool correct_missing_ownership;
+  bool ownership_stack_mode;
 };
 
 struct fulm_init_config {
@@ -51,7 +51,7 @@ struct fulm_init_config {
   struct fulm_init_flags flags;
 };
 
-void fulminate_destroy(_Bool with_ghost_args);
+void fulminate_destroy(bool with_ghost_args);
 void fulminate_init(struct fulm_init_config flags);
 void fulminate_pbt_destroy(void);
 void fulminate_pbt_init(void);

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -53,8 +53,6 @@ struct fulm_init_config {
 
 void fulminate_destroy(bool with_ghost_args);
 void fulminate_init(struct fulm_init_config flags);
-void fulminate_pbt_destroy(void);
-void fulminate_pbt_init(void);
 
 /* Error handlers */
 enum cn_logging_level {

--- a/runtime/libcn/include/cn-executable/utils.h
+++ b/runtime/libcn/include/cn-executable/utils.h
@@ -39,13 +39,14 @@ enum region_owned {
 };
 
 struct fulm_init_flags {
+  _Bool with_ghost_args;
   _Bool exec_c_locs_mode;
   _Bool correct_missing_ownership;
   _Bool ownership_stack_mode;
 };
 
 void fulminate_destroy(_Bool with_ghost_args);
-void fulminate_init(_Bool with_ghost_args, struct fulm_init_flags flags);
+void fulminate_init(struct fulm_init_flags flags);
 void fulminate_pbt_destroy(void);
 void fulminate_pbt_init(void);
 

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -333,8 +333,8 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
 
 int cn_test_main(int argc, char* argv[]);
 
-void fulminate_destroy(void);
-void fulminate_init(void);
+void fulminate_pbt_destroy(void);
+void fulminate_pbt_init(void);
 void bennet_destroy(void);
 void bennet_init(void);
 void cn_smt_destroy(void);
@@ -344,9 +344,9 @@ void cn_smt_init(void);
   std_set_default_alloc();                                                               \
   cn_smt_destroy();                                                                      \
   bennet_destroy();                                                                      \
-  fulminate_destroy();                                                                   \
+  fulminate_pbt_destroy();                                                               \
   cn_test_free_all();                                                                    \
-  fulminate_init();                                                                      \
+  fulminate_pbt_init();                                                                  \
   bennet_init();                                                                         \
   cn_smt_init();
 

--- a/runtime/libcn/include/cn-testing/test.h
+++ b/runtime/libcn/include/cn-testing/test.h
@@ -333,8 +333,8 @@ size_t bennet_compute_size(enum bennet_sizing_strategy strategy,
 
 int cn_test_main(int argc, char* argv[]);
 
-void fulminate_pbt_destroy(void);
-void fulminate_pbt_init(void);
+void fulminate_destroy(bool with_ghost_args);
+void fulminate_init(struct fulm_init_config config);
 void bennet_destroy(void);
 void bennet_init(void);
 void cn_smt_destroy(void);
@@ -344,9 +344,16 @@ void cn_smt_init(void);
   std_set_default_alloc();                                                               \
   cn_smt_destroy();                                                                      \
   bennet_destroy();                                                                      \
-  fulminate_pbt_destroy();                                                               \
+  fulminate_destroy(0);                                                                  \
   cn_test_free_all();                                                                    \
-  fulminate_pbt_init();                                                                  \
+  fulminate_init((struct fulm_init_config){                                              \
+      .max_bump_blocks = 0,                                                              \
+      .bump_block_size = 0,                                                              \
+      .flags = (struct fulm_init_flags){.with_ghost_args = 0,                            \
+          .exec_c_locs_mode = 0,                                                         \
+          .correct_missing_ownership = 0,                                                \
+          .ownership_stack_mode = 0},                                                    \
+  });                                                                                    \
   bennet_init();                                                                         \
   cn_smt_init();
 

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -2,6 +2,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <signal.h>  // for SIGABRT
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,10 +34,13 @@ static allocator bump_alloc = (allocator){
 
 static _Bool fulminate_initialized = false;
 
-void fulminate_destroy(void) {
+void fulminate_destroy(_Bool with_ghost_args) {
   if (!fulminate_initialized) {
     return;  // Already destroyed or never initialized
   }
+
+  if (with_ghost_args)
+    free_ghost_frame_stack();
 
   cn_bump_free_all();
   free_ownership_ghost_state();
@@ -45,16 +49,37 @@ void fulminate_destroy(void) {
   fulminate_initialized = false;
 }
 
-void fulminate_init(void) {
+void fulminate_pbt_destroy(void) {
+  fulminate_destroy(0);
+}
+
+void fulminate_init_global_ghost_state(_Bool with_ghost_args) {
+  init_ownership_ghost_state();
+  init_ghost_stack_depth();
+  if (with_ghost_args)
+    init_ghost_frame_stack();
+}
+
+void fulminate_init_flags(struct fulm_init_flags flags) {
+  init_exec_c_locs_mode(flags.exec_c_locs_mode);
+  init_correct_missing_ownership(flags.correct_missing_ownership);
+  init_ownership_stack_mode(flags.ownership_stack_mode);
+}
+
+void fulminate_init(_Bool with_ghost_args, struct fulm_init_flags flags) {
   assert(!fulminate_initialized && "Fulminate already initialized - destroy first");
 
-  initialise_ownership_ghost_state();
-  initialise_ghost_stack_depth();
-  initialise_exec_c_locs_mode(0);
-  initialise_correct_missing_ownership(0);
-  initialise_ownership_stack_mode(0);
+  fulminate_init_global_ghost_state(with_ghost_args);
+  fulminate_init_flags(flags);
 
   fulminate_initialized = true;
+}
+
+void fulminate_pbt_init(void) {
+  fulminate_init(0,
+      (struct fulm_init_flags){.exec_c_locs_mode = 0,
+          .correct_missing_ownership = 0,
+          .ownership_stack_mode = 0});
 }
 
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;
@@ -244,7 +269,7 @@ cn_map* map_create(void) {
   return ht_create(&bump_alloc);
 }
 
-void initialise_ownership_ghost_state(void) {
+void init_ownership_ghost_state(void) {
   nr_owned_predicates = 0;
   cn_ownership_global_ghost_state =
       rmap_create(2, fulm_default_alloc.malloc, fulm_default_alloc.free);
@@ -255,19 +280,19 @@ void free_ownership_ghost_state(void) {
   rmap_free(cn_ownership_global_ghost_state);
 }
 
-void initialise_ghost_stack_depth(void) {
+void init_ghost_stack_depth(void) {
   cn_stack_depth = 0;
 }
 
-void initialise_exec_c_locs_mode(_Bool flag) {
+void init_exec_c_locs_mode(_Bool flag) {
   exec_c_locs_mode = flag;
 }
 
-void initialise_correct_missing_ownership(_Bool flag) {
+void init_correct_missing_ownership(_Bool flag) {
   correct_missing_ownership = flag;
 }
 
-void initialise_ownership_stack_mode(_Bool flag) {
+void init_ownership_stack_mode(_Bool flag) {
   ownership_stack_mode = flag;
 }
 
@@ -329,7 +354,7 @@ struct loop_ownership {
 
 // No destructors: expects to be dropped by the bump allocator _in a timely
 // manner_.
-struct loop_ownership* initialise_loop_ownership_state(void) {
+struct loop_ownership* init_loop_ownership_state(void) {
   struct loop_ownership* loop_ownership =
       bump_alloc.malloc(sizeof(struct loop_ownership));
   assert(loop_ownership);
@@ -785,8 +810,7 @@ void update_error_message_info_(
       function_name, file_name, line_number, cn_source_loc, global_error_msg_info);
 }
 
-void initialise_error_msg_info_(
-    const char* function_name, char* file_name, int line_number) {
+void init_error_msg_info_(const char* function_name, char* file_name, int line_number) {
   // cn_printf(CN_LOGGING_INFO, "Initialising error message info\n");
   global_error_msg_info =
       make_error_message_info_entry(function_name, file_name, line_number, 0, NULL);
@@ -924,7 +948,7 @@ struct ghost_frame_stack {
 
 static struct ghost_frame_stack* ghost_frame_stack_top;
 
-void initialise_ghost_frame_stack(void) {
+void init_ghost_frame_stack(void) {
   ghost_frame_stack_top = NULL;
 }
 

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -49,10 +49,6 @@ void fulminate_destroy(_Bool with_ghost_args) {
   fulminate_initialized = false;
 }
 
-void fulminate_pbt_destroy(void) {
-  fulminate_destroy(0);
-}
-
 void fulminate_init_bump_alloc(size_t max_bump_blocks, size_t bump_block_size) {
   // Either argument being 0 means it wasn't set -- nothing to do
   if (max_bump_blocks)
@@ -82,17 +78,6 @@ void fulminate_init(struct fulm_init_config config) {
   fulminate_init_global_flags(config.flags);
 
   fulminate_initialized = true;
-}
-
-void fulminate_pbt_init(void) {
-  fulminate_init((struct fulm_init_config){
-      .max_bump_blocks = 0,
-      .bump_block_size = 0,
-      .flags = (struct fulm_init_flags){.with_ghost_args = 0,
-          .exec_c_locs_mode = 0,
-          .correct_missing_ownership = 0,
-          .ownership_stack_mode = 0},
-  });
 }
 
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -60,26 +60,26 @@ void fulminate_init_global_ghost_state(_Bool with_ghost_args) {
     init_ghost_frame_stack();
 }
 
-void fulminate_init_flags(struct fulm_init_flags flags) {
+void fulminate_init_global_flags(struct fulm_init_flags flags) {
   init_exec_c_locs_mode(flags.exec_c_locs_mode);
   init_correct_missing_ownership(flags.correct_missing_ownership);
   init_ownership_stack_mode(flags.ownership_stack_mode);
 }
 
-void fulminate_init(_Bool with_ghost_args, struct fulm_init_flags flags) {
+void fulminate_init(struct fulm_init_flags flags) {
   assert(!fulminate_initialized && "Fulminate already initialized - destroy first");
 
-  fulminate_init_global_ghost_state(with_ghost_args);
-  fulminate_init_flags(flags);
+  fulminate_init_global_ghost_state(flags.with_ghost_args);
+  fulminate_init_global_flags(flags);
 
   fulminate_initialized = true;
 }
 
 void fulminate_pbt_init(void) {
-  fulminate_init(0,
-      (struct fulm_init_flags){.exec_c_locs_mode = 0,
-          .correct_missing_ownership = 0,
-          .ownership_stack_mode = 0});
+  fulminate_init((struct fulm_init_flags){.with_ghost_args = 0,
+      .exec_c_locs_mode = 0,
+      .correct_missing_ownership = 0,
+      .ownership_stack_mode = 0});
 }
 
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;

--- a/runtime/libcn/src/cn-executable/utils.c
+++ b/runtime/libcn/src/cn-executable/utils.c
@@ -53,6 +53,14 @@ void fulminate_pbt_destroy(void) {
   fulminate_destroy(0);
 }
 
+void fulminate_init_bump_alloc(size_t max_bump_blocks, size_t bump_block_size) {
+  // Either argument being 0 means it wasn't set -- nothing to do
+  if (max_bump_blocks)
+    cn_bump_set_max_blocks(max_bump_blocks);
+  if (bump_block_size)
+    cn_bump_set_block_size(bump_block_size);
+}
+
 void fulminate_init_global_ghost_state(_Bool with_ghost_args) {
   init_ownership_ghost_state();
   init_ghost_stack_depth();
@@ -66,20 +74,25 @@ void fulminate_init_global_flags(struct fulm_init_flags flags) {
   init_ownership_stack_mode(flags.ownership_stack_mode);
 }
 
-void fulminate_init(struct fulm_init_flags flags) {
+void fulminate_init(struct fulm_init_config config) {
   assert(!fulminate_initialized && "Fulminate already initialized - destroy first");
 
-  fulminate_init_global_ghost_state(flags.with_ghost_args);
-  fulminate_init_global_flags(flags);
+  fulminate_init_bump_alloc(config.max_bump_blocks, config.bump_block_size);
+  fulminate_init_global_ghost_state(config.flags.with_ghost_args);
+  fulminate_init_global_flags(config.flags);
 
   fulminate_initialized = true;
 }
 
 void fulminate_pbt_init(void) {
-  fulminate_init((struct fulm_init_flags){.with_ghost_args = 0,
-      .exec_c_locs_mode = 0,
-      .correct_missing_ownership = 0,
-      .ownership_stack_mode = 0});
+  fulminate_init((struct fulm_init_config){
+      .max_bump_blocks = 0,
+      .bump_block_size = 0,
+      .flags = (struct fulm_init_flags){.with_ghost_args = 0,
+          .exec_c_locs_mode = 0,
+          .correct_missing_ownership = 0,
+          .ownership_stack_mode = 0},
+  });
 }
 
 static enum cn_logging_level logging_level = CN_LOGGING_INFO;


### PR DESCRIPTION
Clean up Fulminate's initialisation of global state, which is usually injected to run on entry to `main`. Making it a single function call makes it easier to pluck out of `main` and into some different entry-point, which might be especially useful for running on multiple compilation units.